### PR TITLE
changed Elemental Evil designation location

### DIFF
--- a/Spells/EE Spells V2.0.xml
+++ b/Spells/EE Spells V2.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spells version="5">
    <spell>
-      <name>Abi-Dalzim's Horrid Wilting</name>
+      <name>Abi-Dalzim's Horrid Wilting (EE)</name>
       <level>8</level>
       <school>N</school>
       <ritual />
@@ -9,13 +9,13 @@
       <range>150 feet</range>
       <components>V, S, M (a bit of sponge)</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Sorcerer, Wizard</classes>
       <text>You draw the moisture from every creature in a 30-foot cube centered on a point you choose within range. Each creature in that area must make a Constitution saving throw. Constructs and undead aren't affected, and plants and water elementals make this saving throw with disadvantage. A creature takes 10d8 necrotic damage on a failed save, or half as much damage on a successful one.</text>
       <text />
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Absorb Elements</name>
+      <name>Absorb Elements (EE)</name>
       <level>1</level>
       <school>A</school>
       <ritual />
@@ -23,7 +23,7 @@
       <range>Self</range>
       <components>S</components>
       <duration>1 round</duration>
-      <classes>Druid (EE), Ranger (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Druid, Ranger, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>The spell captures some of the incoming energy, lessening its effect on you and storing it for your next melee attack. You have resistance to the triggering damage type until the start of your next turn. Also, the first time you hit with a melee attack on your next turn, the target takes an extra 1d6 damage of the triggering type, and the spell ends.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each slot level above 1st.</text>
@@ -31,7 +31,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Aganazzar's Scorcher</name>
+      <name>Aganazzar's Scorcher (EE)</name>
       <level>2</level>
       <school>EV</school>
       <ritual />
@@ -39,7 +39,7 @@
       <range>30 feet</range>
       <components>V, S, M (a red dragon's scale)</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>A line of roaring flame 30 feet long and 5 feet wide emanates from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 3d8 fire damage on a failed save, or half as much damage on a successful one.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</text>
@@ -47,7 +47,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Beast Bond</name>
+      <name>Beast Bond (EE)</name>
       <level>1</level>
       <school>D</school>
       <ritual />
@@ -55,13 +55,13 @@
       <range>Touch</range>
       <components>V, S, M (a bit of fur wrapped in a cloth)</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid (EE), Ranger (EE)</classes>
+      <classes>Druid, Ranger</classes>
       <text>You establish a telepathic link with one beast you touch that is friendly to you or charmed by you. The spell fails if the beast's Intelligence is 4 or higher. Until the spell ends, the link is active while you and the beast are within line of sight of each other. Through the link, the beast can understand your telepathic messages to it, and it can telepathically communicate simple emotions and concepts back to you. While the link is active, the beast gains advantage on attack rolls against any creature within 5 feet of you that you can see.</text>
       <text />
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Bones of the Earth</name>
+      <name>Bones of the Earth (EE)</name>
       <level>6</level>
       <school>T</school>
       <ritual />
@@ -69,7 +69,7 @@
       <range>120 feet</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Druid (EE)</classes>
+      <classes>Druid</classes>
       <text>You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius. The rubble lasts until cleared.</text>
       <text />
       <text>If a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.</text>
@@ -79,7 +79,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Catapult</name>
+      <name>Catapult (EE)</name>
       <level>1</level>
       <school>T</school>
       <ritual />
@@ -87,7 +87,7 @@
       <range>150 feet</range>
       <components>S</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Sorcerer, Wizard</classes>
       <text>Choose one object weighing 1 to 5 pounds within range that isn't being worn or carried. The object flies in a straight line up to 90 feet in a direction you choose before falling to the ground, stopping early if it impacts against a solid surface. If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. In either case, both the object and the creature or solid surface take 3d8 bludgeoning damage.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the maximum weight of objects that you can target with this spell increases by 5 pounds, and the damage</text>
@@ -95,7 +95,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Control Flames</name>
+      <name>Control Flames (EE)</name>
       <level>0</level>
       <school>T</school>
       <ritual />
@@ -103,7 +103,7 @@
       <range>60 feet</range>
       <components>S</components>
       <duration>Instantaneous or 1 hour (see below)</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>You choose nonmagical flame that you can see within range and that fits within a 5-foot cube. You affect it in one of the following ways:</text>
       <text />
       <text>You instantaneously expand the flame 5 feet in one direction, provided that wood or other fuel is present in the new location.</text>
@@ -119,7 +119,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Control Winds</name>
+      <name>Control Winds (EE)</name>
       <level>5</level>
       <school>T</school>
       <ritual />
@@ -127,7 +127,7 @@
       <range>300 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 hour</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>You take control of the air in a 100-foot cube that you can see within range. Choose one of the following effects when you cast the spell. The effect lasts for the spell's duration, unless you use your action on a later turn to switch to a different effect. You can also use your action to temporarily halt the effect or to restart one you've halted.</text>
       <text />
       <text>Gusts. A wind picks up within the cube, continually blowing in a horizontal direction that you choose. You choose the intensity of the wind: calm, moderate, or strong. If the wind is moderate or strong, ranged weapon attacks that pass through it or that are made against targets within the cube have disadvantage on their attack rolls. If the wind is strong, any creature moving against the wind must spend 1 extra foot of movement for each foot moved.</text>
@@ -139,7 +139,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Create Bonfire</name>
+      <name>Create Bonfire (EE)</name>
       <level>0</level>
       <school>C</school>
       <ritual />
@@ -147,7 +147,7 @@
       <range>60 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
       <text>You create a bonfire on ground that you can see within range. Until the spells ends, the bonfire fills a 5-foot cube. Any creature in the bonfire's space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage. A creature must also make the saving throw when it enters the bonfire's space for the first time on a turn or ends its turn there.</text>
       <text />
       <text>The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</text>
@@ -155,7 +155,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Dust Devil</name>
+      <name>Dust Devil (EE)</name>
       <level>2</level>
       <school>C</school>
       <ritual />
@@ -163,7 +163,7 @@
       <range>60 feet</range>
       <components>V, S, M (a pinch of dust)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>Choose an unoccupied 5-foot cube of air that you can see within range. An elemental force that resembles a dust devil appears in the cube and lasts for the spell's duration.</text>
       <text />
       <text>Any creature that ends its turn within 5 feet of the dust devil must make a Strength saving throw. On a failed save, the creature takes 1d8 bludgeoning damage and is pushed 10 feet away. On a successful save, the creature takes half as much damage and isn't pushed.</text>
@@ -175,7 +175,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Earth Tremor</name>
+      <name>Earth Tremor (EE)</name>
       <level>1</level>
       <school>EV</school>
       <ritual />
@@ -183,7 +183,7 @@
       <range>Self (10-foot radius)</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Bard (EE), Druid (EE), Sorcerer (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Bard, Druid, Sorcerer, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>You cause a tremor in the ground in a 10-foot radius. Each creature other than you in that area must make a Dexterity saving throw. On a failed save, a creature takes 1d6 bludgeoning damage and is knocked prone. If the ground in that area is loose earth or stone, it becomes difficult terrain until cleared.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</text>
@@ -191,7 +191,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Earthbind</name>
+      <name>Earthbind (EE)</name>
       <level>2</level>
       <school>T</school>
       <ritual />
@@ -199,13 +199,13 @@
       <range>300 feet</range>
       <components>V</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
       <text>Choose one creature you can see within range. Yellow strips of magical energy loop around the creature. The target must succeed on a Strength saving throw or its flying speed (if any) is reduced to 0 feet for the spell's duration. An airborne creature affected by this spell descends at 60 feet per round until it reaches the ground or the spell ends.</text>
       <text />
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Elemental Bane</name>
+      <name>Elemental Bane (EE)</name>
       <level>4</level>
       <school>T</school>
       <ritual />
@@ -213,7 +213,7 @@
       <range>90 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE), Warlock (EE), Wizard (EE)</classes>
+      <classes>Druid, Warlock, Wizard</classes>
       <text>Choose one creature you can see within range, and choose one of the following damage types: acid, cold, fire, lightning, or thunder. The target must succeed on a Constitution saving throw or be affected by the spell for its duration. The first time each turn the affected target takes damage of the chosen type, the target takes an extra 2d6 damage of that type. Moreover, the target loses any resistance to that damage type until the spell ends.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them.</text>
@@ -221,7 +221,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Erupting Earth</name>
+      <name>Erupting Earth (EE)</name>
       <level>3</level>
       <school>T</school>
       <ritual />
@@ -229,7 +229,7 @@
       <range>120 feet</range>
       <components>V, S, M (a piece of obsidian)</components>
       <duration>Instantaneous</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>Choose a point you can see on the ground within range. A fountain of churned earth and stone erupts in a 20-foot cube centered on that point. Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared away. Each 5-foot-square portion of the area requires at least 1 minute to clear by hand.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d12 for each slot level above 2nd.</text>
@@ -237,7 +237,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Flame Arrows</name>
+      <name>Flame Arrows (EE)</name>
       <level>3</level>
       <school>T</school>
       <ritual />
@@ -245,7 +245,7 @@
       <range>Touch</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 hour</duration>
-      <classes>Druid (EE), Ranger (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Ranger, Sorcerer, Wizard</classes>
       <text>You touch a quiver containing arrows or bolts. When a target is hit by a ranged weapon attack using a piece of ammunition drawn from the quiver, the target takes an extra 1d6 fire damage. The spell's magic ends on the piece of ammunition when it hits or misses, and the spell ends when twelve pieces of ammunition have been drawn from the quiver.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 4th level or higher, the number of pieces of ammunition you can affect with this spell increases by two for each slot level above 3rd.</text>
@@ -253,7 +253,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Frostbite</name>
+      <name>Frostbite (EE)</name>
       <level>0</level>
       <school>EV</school>
       <ritual />
@@ -261,7 +261,7 @@
       <range>60 feet</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Druid, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>You cause numbing frost to form on one creature that you can see within range. The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn.</text>
       <text />
       <text>The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
@@ -269,7 +269,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Gust</name>
+      <name>Gust (EE)</name>
       <level>0</level>
       <school>T</school>
       <ritual />
@@ -277,7 +277,7 @@
       <range>30 feet</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>You seize the air and compel it to create one of the following effects at a point you can see within range:</text>
       <text />
       <text>*One Medium or smaller creature that you choose must succeed on a Strength saving throw or be pushed up to 5 feet away from you.</text>
@@ -289,7 +289,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Ice Knife</name>
+      <name>Ice Knife (EE)</name>
       <level>1</level>
       <school>C</school>
       <ritual />
@@ -297,7 +297,7 @@
       <range>60 feet</range>
       <components>S, M (a drop of water or piece of ice)</components>
       <duration>Instantaneous</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of the point where the ice exploded must succeed on a Dexterity saving throw or take 2d6 cold damage.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the cold damage increases by 1d6 for each slot level above 1st.</text>
@@ -305,7 +305,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Immolation</name>
+      <name>Immolation (EE)</name>
       <level>5</level>
       <school>EV</school>
       <ritual />
@@ -313,7 +313,7 @@
       <range>90 feet</range>
       <components>V</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Sorcerer, Wizard</classes>
       <text>Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 7d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell's duration. The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. At the end of each of its turns, the target repeats the saving throw. It takes 3d6 fire damage on a failed save, and the spell ends on a successful one. These magical flames can't be extinguished through nonmagical means.</text>
       <text />
       <text>If damage from this spell reduces a target to 0 hit points, the target is turned to ash.</text>
@@ -321,7 +321,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Investiture of Flame</name>
+      <name>Investiture of Flame (EE)</name>
       <level>6</level>
       <school>T</school>
       <ritual />
@@ -329,7 +329,7 @@
       <range>Self</range>
       <components>V, S</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
       <text>Flames race across your body, shedding bright light in a 30-foot radius and dim light for an additional 30 feet for the spell's duration. The flames don't harm you. Until the spell ends, you gain the following benefits:</text>
       <text />
       <text>*You are immune to fire damage and have resistance to cold damage.</text>
@@ -341,7 +341,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Investiture of Ice</name>
+      <name>Investiture of Ice (EE)</name>
       <level>6</level>
       <school>T</school>
       <ritual />
@@ -349,7 +349,7 @@
       <range>Self</range>
       <components>V, S</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
       <text>Until the spell ends, ice rimes your body, and you gain the following benefits:</text>
       <text />
       <text>*You are immune to cold damage and have resistance to fire damage.</text>
@@ -363,7 +363,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Investiture of Stone</name>
+      <name>Investiture of Stone (EE)</name>
       <level>6</level>
       <school>T</school>
       <ritual />
@@ -371,7 +371,7 @@
       <range>Self</range>
       <components>V, S</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
       <text>Until the spell ends, bits of rock spread across your body, and you gain the following benefits:</text>
       <text />
       <text>*You have resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons.</text>
@@ -383,7 +383,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Investiture of Wind</name>
+      <name>Investiture of Wind (EE)</name>
       <level>6</level>
       <school>T</school>
       <ritual />
@@ -391,7 +391,7 @@
       <range>Self</range>
       <components>V, S</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
       <text>Until the spell ends, wind whirls around you, and you gain the following benefits:</text>
       <text />
       <text>*Ranged weapon attacks made against you have disadvantage on the attack roll.</text>
@@ -403,7 +403,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Maelstrom</name>
+      <name>Maelstrom (EE)</name>
       <level>5</level>
       <school>EV</school>
       <ritual />
@@ -411,13 +411,13 @@
       <range>120 feet</range>
       <components>V, S, M (paper or leaf in the shape of a funnel)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE)</classes>
+      <classes>Druid</classes>
       <text>A mass of 5-foot-deep water appears and swirls in a 30-foot radius centered on a point you can see within range. The point must be on ground or in a body of water. Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center.</text>
       <text />
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Magic Stone</name>
+      <name>Magic Stone (EE)</name>
       <level>0</level>
       <school>T</school>
       <ritual />
@@ -425,7 +425,7 @@
       <range>Touch</range>
       <components>V, S</components>
       <duration>1 minute</duration>
-      <classes>Druid (EE), Warlock (EE)</classes>
+      <classes>Druid, Warlock</classes>
       <text>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker's, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</text>
       <text />
       <text>If you cast this spell again, the spell ends early on any pebbles still affected by it.</text>
@@ -433,7 +433,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Maximilian's Earthen Grasp</name>
+      <name>Maximilian's Earthen Grasp (EE)</name>
       <level>2</level>
       <school>T</school>
       <ritual />
@@ -441,7 +441,7 @@
       <range>30 feet</range>
       <components>V, S, M (a miniature hand sculpted from clay)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Sorcerer, Wizard</classes>
       <text>You choose a 5-foot-square unoccupied space on the ground that you can see within range. A Medium hand made from compacted soil rises there and reaches for one creature you can see within 5 feet of it. The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell's duration.</text>
       <text />
       <text>As an action, you can cause the hand to crush the restrained target, who must make a Strength saving throw. It takes 2d6 bludgeoning damage on a failed save, or half as much damage on a successful one.</text>
@@ -453,7 +453,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Melf's Minute Meteors</name>
+      <name>Melf's Minute Meteors (EE)</name>
       <level>3</level>
       <school>EV</school>
       <ritual />
@@ -461,7 +461,7 @@
       <range>Self</range>
       <components>V, S, M (niter, sulfur, and pine tar formed into a bead)</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Sorcerer (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>You create six tiny meteors in your space. They float in the air and orbit you for the spell's duration. When you cast the spell-and as a bonus action on each of your turns thereafter-you can expend one or two of the meteors, sending them streaking toward a point or points you choose within 120 feet of you. Once a meteor reaches its destination or impacts against a solid surface, the meteor explodes. Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 4th level or higher, the number of meteors created increases by two for each slot level above 3rd.</text>
@@ -469,7 +469,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Mold Earth</name>
+      <name>Mold Earth (EE)</name>
       <level>0</level>
       <school>T</school>
       <ritual />
@@ -477,7 +477,7 @@
       <range>30 feet</range>
       <components>S</components>
       <duration>Instantaneous or 1 hour (see below)</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>You choose a portion of dirt or stone that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways:</text>
       <text />
       <text>*If you target an area of loose earth, you can instantaneously excavate it, move it along the ground, and deposit it up to 5 feet away. This movement doesn't have enough force to cause damage.</text>
@@ -491,7 +491,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Primordial Ward</name>
+      <name>Primordial Ward (EE)</name>
       <level>6</level>
       <school>A</school>
       <ritual />
@@ -499,7 +499,7 @@
       <range>Self</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE)</classes>
+      <classes>Druid</classes>
       <text>You have resistance to acid, cold, fire, lightning, and thunder damage for the spell's duration.</text>
       <text />
       <text>When you take damage of one of those types, you can use your reaction to gain immunity to that type of damage, including against the triggering damage. If you do so, the resistances end, and you have the immunity until the end of your next turn, at which time the spell ends.</text>
@@ -507,7 +507,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Pyrotechnics</name>
+      <name>Pyrotechnics (EE)</name>
       <level>2</level>
       <school>T</school>
       <ritual />
@@ -515,7 +515,7 @@
       <range>60 feet</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Bard (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Bard, Sorcerer, Wizard</classes>
       <text>Choose an area of flame that you can see and that can fit within a 5-foot cube within range. You can extinguish the fire in that area, and you create either fireworks or smoke.</text>
       <text />
       <text>Fireworks. The target explodes with a dazzling display of colors. Each creature within 10 feet of the target must succeed on a Constitution saving throw or become blinded until the end of your next turn.</text>
@@ -525,7 +525,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Shape Water</name>
+      <name>Shape Water (EE)</name>
       <level>0</level>
       <school>T</school>
       <ritual />
@@ -533,7 +533,7 @@
       <range>30 feet</range>
       <components>S</components>
       <duration>Instantaneous or 1 hour (see below)</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>You choose an area of water that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways:</text>
       <text />
       <text>*You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn't have enough force to cause damage.</text>
@@ -549,7 +549,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Skywrite</name>
+      <name>Skywrite (EE)</name>
       <level>2</level>
       <school>T</school>
       <ritual>YES</ritual>
@@ -557,13 +557,13 @@
       <range>Sight</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 hour</duration>
-      <classes>Bard (EE), Druid (EE), Wizard (EE)</classes>
+      <classes>Bard, Druid, Wizard</classes>
       <text>You cause up to ten words to form in a part of the sky you can see. The words appear to be made of cloud and remain in place for the spell's duration. The words dissipate when the spell ends. A strong wind can disperse the clouds and end the spell early.</text>
       <text />
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Snilloc's Snowball Swarm</name>
+      <name>Snilloc's Snowball Swarm (EE)</name>
       <level>2</level>
       <school>EV</school>
       <ritual />
@@ -571,7 +571,7 @@
       <range>90 feet</range>
       <components>V, S, M (a piece of ice or a small white rock chip)</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>A flurry of magic snowballs erupts from a point you choose within range. Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.</text>
@@ -579,7 +579,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Storm Sphere</name>
+      <name>Storm Sphere (EE)</name>
       <level>4</level>
       <school>EV</school>
       <ritual />
@@ -587,7 +587,7 @@
       <range>150 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Sorcerer (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell's duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere's space is difficult terrain.</text>
       <text />
       <text>Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</text>
@@ -599,7 +599,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Thunderclap</name>
+      <name>Thunderclap (EE)</name>
       <level>0</level>
       <school>EV</school>
       <ritual />
@@ -607,7 +607,7 @@
       <range>Self (5-foot radius)</range>
       <components>S</components>
       <duration>Instantaneous</duration>
-      <classes>Bard (EE), Druid (EE), Sorcerer (EE), Warlock (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Bard, Druid, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>You create a burst of thunderous sound, which can be heard 100 feet away. Each creature other than you within 5 feet of you must make a Constitution saving throw. On a failed save, the creature takes 1d6 thunder damage.</text>
       <text />
       <text>The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
@@ -615,7 +615,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Tidal Wave</name>
+      <name>Tidal Wave (EE)</name>
       <level>3</level>
       <school>C</school>
       <ritual />
@@ -623,13 +623,13 @@
       <range>120 feet</range>
       <components>V, S, M (a drop of water)</components>
       <duration>Instantaneous</duration>
-      <classes>Druid (EE), Wizard (EE)</classes>
+      <classes>Druid, Wizard</classes>
       <text>You conjure up a wave of water that crashes down on an area within range. The area can be up to 30 feet long, up to 10 feet wide, and up to 10 feet tall. Each creature in that area must make a Dexterity saving throw. On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone. On a success, a creature takes half as much damage and isn't knocked prone. The water then spreads out across the ground in all directions, extinguishing unprotected flames in its area and within 30 feet of it.</text>
       <text />
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Transmute Rock</name>
+      <name>Transmute Rock (EE)</name>
       <level>5</level>
       <school>T</school>
       <ritual />
@@ -637,7 +637,7 @@
       <range>120 feet</range>
       <components>V, S, M (clay and water)</components>
       <duration>Instantaneous</duration>
-      <classes>Druid (EE), Wizard (EE)</classes>
+      <classes>Druid, Wizard</classes>
       <text>You choose an area of stone or mud that you can see that fits within a 40-foot cube and that is within range, and choose one of the following effects.</text>
       <text />
       <text>Transmute Rock to Mud. Nonmagical rock of any sort in the area becomes an equal volume of thick and flowing mud that remains for the spell's duration.</text>
@@ -651,7 +651,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Vitriolic Sphere</name>
+      <name>Vitriolic Sphere (EE)</name>
       <level>4</level>
       <school>EV</school>
       <ritual />
@@ -659,7 +659,7 @@
       <range>150 feet</range>
       <components>V, S, M (a drop of giant slug bile)</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>You point at a place within range, and a glowing 1-foot ball of emerald acid streaks there and explodes in a 20-foot radius. Each creature in that area must make a Dexterity saving throw. On a failed save, a creature takes 10d4 acid damage and 5d4 acid damage at the end of its next turn. On a successful save, a creature takes half the initial damage and no damage at the end of its next turn.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 5th level or higher, the initial damage increases by 2d4 for each slot level above 4th.</text>
@@ -667,7 +667,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Wall of Sand</name>
+      <name>Wall of Sand (EE)</name>
       <level>3</level>
       <school>EV</school>
       <ritual />
@@ -675,13 +675,13 @@
       <range>90 feet</range>
       <components>V, S, M (a handful of sand)</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>You conjure up a wall of swirling sand on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 10 feet thick, and it vanishes when the spell ends. It blocks line of sight but not movement. A creature is blinded while in the wall's space and must spend 3 feet of movement for every 1 foot it moves there.</text>
       <text />
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Wall of Water</name>
+      <name>Wall of Water (EE)</name>
       <level>3</level>
       <school>EV</school>
       <ritual />
@@ -689,7 +689,7 @@
       <range>60 feet</range>
       <components>V, S, M (a drop of water)</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE), Fighter (Eldritch Knight) EE</classes>
+      <classes>Druid, Sorcerer, Wizard, Fighter (Eldritch Knight) EE</classes>
       <text>You conjure up a wall of water on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 1 foot thick, or you can make a ringed wall up to 20 feet in diameter, 20 feet high, and 1 foot thick. The wall vanishes when the spell ends. The wall's space is difficult terrain.</text>
       <text />
       <text>Any ranged weapon attack that enters the wall's space has disadvantage on the attack roll, and fire damage is halved if the fire effect passes through the wall to reach its target. Spells that deal cold damage that pass through the wall cause the area of the wall they pass through to freeze solid (at least a 5-foot square section is frozen). Each 5-foot-square frozen section has AC 5 and 15 hit points. Reducing a frozen section to 0 hit points destroys it. When a section is destroyed, the wall's water doesn't fill it.</text>
@@ -697,7 +697,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Warding Wind</name>
+      <name>Warding Wind (EE)</name>
       <level>2</level>
       <school>EV</school>
       <ritual />
@@ -705,7 +705,7 @@
       <range>Self</range>
       <components>V</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Bard (EE), Druid (EE), Sorcerer (EE)</classes>
+      <classes>Bard, Druid, Sorcerer</classes>
       <text>A strong wind (20 miles per hour) blows around you in a 10-foot radius and moves with you, remaining centered on you. The wind lasts for the spell's duration.</text>
       <text />
       <text>The wind has the following effects:</text>
@@ -723,7 +723,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Watery Sphere</name>
+      <name>Watery Sphere (EE)</name>
       <level>4</level>
       <school>C</school>
       <ritual />
@@ -731,7 +731,7 @@
       <range>90 feet</range>
       <components>V, S, M (a droplet of water)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE), Sorcerer (EE), Wizard (EE)</classes>
+      <classes>Druid, Sorcerer, Wizard</classes>
       <text>You conjure up a sphere of water with a 10-foot radius on a point you can see within range. The sphere can hover in the air, but no more than 10 feet off the ground. The sphere remains for the spell's duration.</text>
       <text />
       <text>Any creature in the sphere's space must make a Strength saving throw. On a successful save, a creature is ejected from that space to the nearest unoccupied space outside it. A Huge or larger creature succeeds on the saving throw automatically. On a failed save, a creature is restrained by the sphere and is engulfed by the water. At the end of each of its turns, a restrained target can repeat the saving throw.</text>
@@ -745,7 +745,7 @@
       <text>This spell can be found in the Elemental Evil Player's Companion</text>
    </spell>
    <spell>
-      <name>Whirlwind</name>
+      <name>Whirlwind (EE)</name>
       <level>7</level>
       <school>EV</school>
       <ritual />
@@ -753,7 +753,7 @@
       <range>300 feet</range>
       <components>V, M (a piece of straw)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (EE), Wizard (EE)</classes>
+      <classes>Druid, Wizard</classes>
       <text>A whirlwind howls down to a point on the ground you specify. The whirlwind is a 10-foot-radius, 30-foot-high cylinder centered on that point. Until the spell ends, you can use your action to move the whirlwind up to 30 feet in any direction along the ground. The whirlwind sucks up any Medium or smaller objects that aren't secured to anything and that aren't worn or carried by anyone.</text>
       <text />
       <text>A creature must make a Dexterity saving throw the first time on a turn that it enters the whirlwind or that the whirlwind enters its space, including when the whirlwind first appears. A creature takes 10d6 bludgeoning damage on a failed save, or half as much damage on a successful one. In addition, a Large or smaller creature that fails the save must succeed on a Strength saving throw or become restrained in the whirlwind until the spell ends. When a creature starts its turn restrained by the whirlwind, the creature is pulled 5 feet higher inside it, unless the creature is at the top. A restrained creature moves with the whirlwind and falls when the spell ends, unless the creature has some means to stay aloft.</text>


### PR DESCRIPTION
removed (EE) from the classes to minimize classes listed in Compendium-Spellbook
added (EE) to the spell names to keep the distinction between PHB and non-PHB spells clear
