### PR TITLE
added R:(Arcane Trickster), updated F:(Eldritch Knight)

### DIFF
--- a/Spells/PHB Spells V3.0.xml
+++ b/Spells/PHB Spells V3.0.xml
@@ -9,7 +9,7 @@
       <range>60 feet</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>You hurl a bubble of acid. Choose one creature within range, or choose two creatures within range that are within 5 feet of each other. A target must succeed on a Dexterity saving throw or take 1d6 acid damage.</text>
       <text />
       <text>This spells damage increases by 1d6 when you reach 5th Level (2d6), 11th level (3d6) and 17th level (4d6).</text>
@@ -206,7 +206,7 @@
       <range>60 feet</range>
       <components>V, S, M (either a lump of alum soaked in vinegar for the antipathy effect or a drop of honey for the sympathy effect)</components>
       <duration>10 days</duration>
-      <classes>Druid, Wizard</classes>
+      <classes>Druid, Wizard, Rogue (Arcane Trickster)</classes>
       <text>This spell attracts or repels creatures of your choice. You target something within range, either a Huge or smaller object or creature or an area that is no larger than a 200-foot cube. Then specify a kind of intelligent creature, such as red dragons, goblins, or vampires. You invest the target with an aura that either attracts or repels the specified creatures for the duration. Choose antipathy or sympathy as the aura's effect.</text>
       <text />
       <text>Antipathy. The enchantment causes creatures of the kind you designated to feel an intense urge to leave the area and avoid the target. When sucha c reature can see the target or comes within 60 feet of it, the creature must succeed on a Wisom saving throw or become frightened. The creature remains frightened while it can see the target or is within 60 feet of it. While frightened by the target, the creature must use its movement to move to the nearest safe spot from which it can't see the target. If the creature moves more than 60 feet from the target and can't see it, the creature is no longer frightened , but the creature becomes frightened again if it regains sight of the target or moves within 60 feet of it.</text>
@@ -532,7 +532,7 @@
       <range>Self</range>
       <components>V, S</components>
       <duration>1 round</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight)</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>You extend your hand and trace a sigil of warding in the air. Until the end of your next turn, you have resistance against bludgeoning, piercing, and slashing damage dealt by weapon attacks.</text>
    </spell>
    <spell>
@@ -618,7 +618,7 @@
       <range>Self</range>
       <components>V</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid (Desert), Sorcerer, Wizard</classes>
+      <classes>Druid (Desert), Sorcerer, Wizard, Rogue (Arcane Trickster)</classes>
       <text>Your body becomes blurred, shifting and wavering to all who can see you. For the duration, any creature has disadvantage on attack rolls against you. An attacker is immune to this effect if it doesn't rely on sight, as with blindsight, or can see through illusions, as with truesight.</text>
    </spell>
    <spell>
@@ -710,7 +710,7 @@
       <range>30 feet</range>
       <components>V, S</components>
       <duration>1 hour</duration>
-      <classes>Bard, Cleric (Trickery), Druid, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Cleric (Trickery), Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You attempt to charm a humanoid you can see within range. It must make a Wisdom saving throw, and does so with advantage if you or your companions are fighting it. If it fails the saving throw, it is charmed by you until the spell ends or until you or your companions do anything harmful to it. The charmed creature regards you as a friendly acquaintance. When the spell ends, the creature knows it was charmed by you.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st. The creatures must be within 30 feet of each other when you target them.</text>
@@ -830,7 +830,7 @@
       <range>Self (15-foot cone)</range>
       <components>V, S, M (a pinch of powder or sand that is colored red, yellow, and blue)</components>
       <duration>1 round</duration>
-      <classes>Sorcerer, Wizard</classes>
+      <classes>Sorcerer, Wizard, Rogue (Arcane Trickster)</classes>
       <text>A dazzling array of flashing, colored light springs from your hand. Roll 6d10, the total is how many hit points of creatures this spell can effect. Creatures in a 15-foot cone originating from you are affected in ascending order of their current hit points (ignoring unconscious creatures and creatures that can't see).</text>
       <text />
       <text>Starting with the creature that has the lowest current hit points, each creature affected by this spell is blinded until the spell ends. Subtract each creature's hit points from the total before moving on to the creature with the next lowest hit points. A creature's hit points must be equal to or less than the remaining total for the creature to be affected.</text>
@@ -959,7 +959,7 @@
       <range>90 feet</range>
       <components>V, S, M (three nut shells)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Cleric (Knowledge), Druid, Paladin (Oathbreaker), Sorcerer, Wizard</classes>
+      <classes>Bard, Cleric (Knowledge), Druid, Paladin (Oathbreaker), Sorcerer, Wizard, Rogue (Arcane Trickster)</classes>
       <text>This spell assaults and twists creatures' minds, spawning delusions and provoking uncontrolled actions. Each creature in a 10-foot-radius sphere centered on a point you choose within range must succeed on a Wisdom saving throw when you cast this spell or be affected by it.</text>
       <text />
       <text>An affected target can't take reactions and must roll a d10 at the start of each of its turns to determine its behavior for that turn.</text>
@@ -1310,7 +1310,7 @@
       <range>30 feet</range>
       <components>V, S, M (a tiny piece of matter of the same type of the item you plan to create)</components>
       <duration>Special</duration>
-      <classes>Sorcerer, Wizard</classes>
+      <classes>Sorcerer, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You pull wisps of shadow material from the Shadowfell to create a nonliving object of vegetable matter within range: soft goods, rope, wood, or something similar. You can also use this spell to create mineral objects such as stone, crystal, or metal. The object created must be no larger than a 5-foot cube, and the object must be of a form and material that you have seen before.</text>
       <text />
       <text>The duration depends on the object's material. If the object is composed of multiple materials, use the shortest duration. Material - Duration: Vegetable matter - 1 day; Stone/crystal - 12 hours; Precious metals - 1 hour; Gems - 10 minutes; Adamantine/Mithral - 1 minute</text>
@@ -1328,7 +1328,7 @@
       <range>120 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Paladin (Oathbreaker), Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Paladin (Oathbreaker), Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>One humanoid of your choice that you can see within range must succeed on a Wisdom saving throw or become charmed by you for the duration. While the target is charmed in this way, a twisted crown of jagged iron appears on its head, and a madness glows in its eyes.</text>
       <text />
       <text>The charmed target must use its action before moving on each of its turns to make a melee attack against a creature other than itself that you mentally choose. The target can act normally on its turn if you choose no creature or if none are within its reach.</text>
@@ -1370,7 +1370,7 @@
       <range>120 feet</range>
       <components>V, S, M</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+      <classes>Bard, Sorcerer, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>You create up to four torch-sized lights within range, making them appear as torches, lanterns, or glowing orbs that hover in the air for the duration. You can also combine the four lights into one glowing vaguely humanoid form of Medium size. Whichever form you choose, each light sheds dim light in a 10-foot radius.</text>
       <text />
       <text>As a bonus action on your turn, you can move the lights up to 60 feet to a new spot within range. A light must be within 20 feet of another light created by this spell, and a light winks out if it exceeds the spell's range.</text>
@@ -1562,7 +1562,7 @@
       <range>Self</range>
       <components>V,S</components>
       <duration>1 hour</duration>
-      <classes>Bard, Cleric (Trickery), Sorcerer, Wizard</classes>
+      <classes>Bard, Cleric (Trickery), Sorcerer, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You make yourself, including your clothing, armor, weapons, and other belongings on your person, look different until the spell ends or until you use your action to dismiss it. You can seem 1 foot shorter or taller and can appear thin, fat, or in between. You can't change your body type, so you must adopt a form that has the same basic arrangement of limbs. Otherwise, the extent of the illusion is up to you.</text>
       <text />
       <text>The changes wrought by this spell fail to hold up to physical inspection. For example, if you use this spell to add a hat to your outfit, objects pass through the hat, and anyone who touches it would feel nothing or would feel your head and hair. If you use this spell to appear thinner than you are, the hand of some one who reaches out to touch you would bump into you while it was seemingly still in midair.</text>
@@ -1708,7 +1708,7 @@
       <range>60 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 hour</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You attempt to beguile a creature that you can see within range. It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw.</text>
       <text />
       <text>While the creature is charmed, you have a telepathic link with it as long as the two of you are on the same plane of existence. You can use this telepathic link to issue commands to the creature while you are conscious (no action required), which it does its best to obey. You can specify a simple and general course of action, such as Attack that creature, Run over there, or Fetch that object. If the creature completes the order and doesn't receive further direction from you, it defends and preserves itself to the best of its ability.</text>
@@ -1728,7 +1728,7 @@
       <range>60 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Cleric (Trickery), Paladin (Oathbreaker), Sorcerer, Warlock (Archfey), Warlock (Great Old One), Wizard</classes>
+      <classes>Bard, Cleric (Trickery), Paladin (Oathbreaker), Sorcerer, Warlock (Archfey), Warlock (Great Old One), Wizard, Rogue (Arcane Trickster)</classes>
       <text>You attempt to beguile a humanoid that you can see within range. It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw.</text>
       <text />
       <text>While the target is charmed, you have a telepathic link with it as long as the two of you are on the same plane of existence. You can use this telepathic link to issue commands to the creature while you are conscious (no action required), which it does its best to obey. You can specify a simple and general course of action, such as Attack that creature, Run over there, or Fetch that object. If the creature completes the order and doesn't receive further direction from you, it defends and preserves itself to the best of its ability.</text>
@@ -1766,7 +1766,7 @@
       <range>Special</range>
       <components>V, S, M (a handful of sand, a dab of ink, and a writing quill plucked from a sleeping bird)</components>
       <duration>8 hours</duration>
-      <classes>Bard, Druid (Grassland), Warlock, Wizard</classes>
+      <classes>Bard, Druid (Grassland), Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>This spell shapes a creature's dreams. Choose a creature known to you as the target of this spell. The target must be on the same plane of existence as you. Creatures that don't sleep, such as elves, can't be contacted by this spell. You, or a willing creature you touch, enters a trance state, acting as a messenger. While in the trance, the messenger is aware of his or her surroundings, but can't take actions or move.</text>
       <text />
       <text>If the target is asleep, the messenger appears in the target's dreams and can converse with the target as long as it remains asleep, through the duration of the spell. The messenger can also shape the environment of the dream, creating landscapes, objects, and other images. The messenger can emerge from the trance at any time, ending the effect of the spell early. The target recalls the dream perfectly upon waking. If the target is awake when you cast the spell, the messenger knows it, and can either end the trance (and the spell) or wait for the target to fall asleep, at which point the messenger appears in the target's dreams.</text>
@@ -2051,7 +2051,7 @@
       <range>Self (30-foot cone)</range>
       <components>V, S, M (a white feather or the heart of a hen)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You project a phantasmal image of a creature's worst fears. Each creature in a 30-foot cone must succeed on a Wisdom saving throw or drop whatever it is holding and become frightened for the duration.</text>
       <text />
       <text>While frightened by this spell, a creature must take the Dash action and move away from you by the safest available route on each of its turns, unless there is nowhere to move. If the creature ends its turn in a location where it doesn't have line of sight to you, the creature can make a Wisdom saving throw. On a successful save, the spell ends for that creature.</text>
@@ -2077,7 +2077,7 @@
       <range>150 feet</range>
       <components>V, S, M (a handful of clay, crystal, glass, or mineral spheres)</components>
       <duration>Instantaneous</duration>
-      <classes>Bard, Druid, Warlock, Wizard</classes>
+      <classes>Bard, Druid, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You blast the mind of a creature that you can see within range, attempting to shatter its intellect and personality. The target takes 4d6 psychic damage and must make an Intelligence saving throw.</text>
       <text />
       <text>On a failed save, the creature's Intelligence and Charisma scores become 1. The creature can't cast spells, activate magic items, understand language, or communicate in any intelligible way. The creature can, however, identify its friends, follow them, and even protect them.</text>
@@ -2193,7 +2193,7 @@
       <range>120 feet</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried.</text>
       <text />
       <text>This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).</text>
@@ -2417,7 +2417,7 @@
       <range>Self</range>
       <components>S, M</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>For the duration, you have advantage on all Charisma checks directed at one creature of your choice that isn't hostile toward you. When the spell ends, the creature realizes that you used magic to influence its mood and becomes hostile toward you. A creature prone to violence might attack you. Another creature might seek retribution in other ways (at the DM's discretion), depending on the nature of your interaction with it.</text>
    </spell>
    <spell>
@@ -2463,7 +2463,7 @@
       <range>60 feet</range>
       <components>V</components>
       <duration>30 days</duration>
-      <classes>Bard, Cleric, Druid, Paladin, Wizard</classes>
+      <classes>Bard, Cleric, Druid, Paladin, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You place a magical command on a creature that you can see within range, forcing it to carry out some service or refrain from some action or course of activity as you decide. If the creature can understand you, it must succeed on a Wisdom saving throw or become charmed by you for the duration. While the creature is charmed by you, it takes 5d10 psychic damage each time it acts in a manner directly counter to your instructions, but no more than once each day. A creature that can't understand you is unaffected by the spell.</text>
       <text />
       <text>You can issue any command you choose, short of an activity that would result in certain death. Should you issue a suicidal command, the spell ends.</text>
@@ -2609,7 +2609,7 @@
       <range>Touch</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Druid (Underdark), Sorcerer, Warlock (Archfey), Wizard</classes>
+      <classes>Bard, Druid (Underdark), Sorcerer, Warlock (Archfey), Wizard, Rogue (Arcane Trickster)</classes>
       <text>You or a creature you touch becomes invisible until the spell ends. Anything the target is wearing or carrying is invisible as long as it is on the target's person.</text>
    </spell>
    <spell>
@@ -2777,7 +2777,7 @@
       <range>300 feet</range>
       <components>V, S, M (a stone, a twig, and a bit of green plant)</components>
       <duration>24 hours</duration>
-      <classes>Bard, Druid, Druid (Desert), Warlock, Wizard</classes>
+      <classes>Bard, Druid, Druid (Desert), Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You make natural terrain in a 150-foot cube in range look, sound, and smell like some other sort of natural terrain. Thus, open fields or a road can be made to resemble a swamp, hill, crevasse, or some other difficult or impassable terrain. A pond can be made to seem like a grassy meadow, a precipice like a gentle slope, or a rock-strewn gully like a wide and smooth road. Manufactured structures, equipment, and creatures within the area aren't changed in appearance.</text>
       <text />
       <text>The tactile characteristics of the terrain are unchanged, so creatures entering the area are likely to see through the illusion. If the difference isn't obvious by touch, a creature carefully examining the illusion can attempt an Intelligence (Investigation) check against your spell save DC to disbelieve it. A creature who discerns the illusion for what it is, sees it as a vague image superimposed on the terrain.</text>
@@ -2921,7 +2921,7 @@
       <range>90 feet</range>
       <components>V, S, M (a small, straight piece of iron)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Cleric (War), Paladin (Vengeance), Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Cleric (War), Paladin (Vengeance), Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>Choose a creature that you can see within range. The target must succeed on a Wisdom saving throw or be paralyzed for the duration. This spell has no effect on undead. At the end of each of its turns, the target can make another Wisdom saving throw. On a success, the spell ends on the target.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 6th level or higher, you can target on additional creature for each slot level above 5th. The creatures must be within 30 feet of each other when you target them.</text>
@@ -2935,7 +2935,7 @@
       <range>60 feet</range>
       <components>V, S, M (a small, straight piece of iron)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Cleric, Druid, Druid (Arctic), Paladin (Vengeance), Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Cleric, Druid, Druid (Arctic), Paladin (Vengeance), Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>Choose a humanoid that you can see within range. The target must succeed on a Wisdom saving throw or be paralyzed for the duration. At the end of each of its turns, the target can make another Wisdom saving throw. On a success, the spell ends on the target.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, you can target on additional humanoid for each slot level above 2nd. The humanoids must be within 30 feet of each other when you target them.</text>
@@ -2989,7 +2989,7 @@
       <range>120 feet</range>
       <components>S, M (a glowing stick o f incense or a crystal vial filled with phosphorescent material)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You create a twisting pattern of colors that weaves through the air inside a 30-foot cube within range. The pattern appears for a moment and vanishes. Each creature in the area who sees the pattern must make a Wisdom saving throw. On a failed save, the creature becomes charmed for the duration. While charmed by this spell, the creature is incapacitated and has a speed of 0.</text>
       <text />
       <text>The spell ends for an affected creature if it takes any damage or if someone else uses an action to shake the creature out of its stupor.</text>
@@ -3033,7 +3033,7 @@
       <range>Touch</range>
       <components>S, M (a lead-based ink worth at least 10 gp, which the spell consumes)</components>
       <duration>10 days</duration>
-      <classes>Bard, Warlock, Wizard</classes>
+      <classes>Bard, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You write on parchment, paper, or some other suitable writing material and imbue it with a potent illusion that lasts for the duration.</text>
       <text />
       <text>To you and any creatures you designate when you cast the spell, the writing appears normal, written in your hand, and conveys whatever meaning you intended when you wrote the text. To all others, the writing appears as if it were written in an unknown or magical script that is unintelligible. Alternatively, you can cause the writing to appear to be an entirely different message, written in a different hand and language, though the language must be one you know.</text>
@@ -3127,7 +3127,7 @@
       <range>Touch</range>
       <components>V, S, M (an eyelash encased in gum arabic)</components>
       <duration>Concentration, up to 1 hour</duration>
-      <classes>Bard, Druid (Grassland), Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Druid (Grassland), Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>A creature you touch becomes invisible until the spell ends. Anything the target is wearing or carrying is invisible as long as it is on the target's person. The spell ends for a target that attacks or casts a spell.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, you can target one additional creature for each slot level above 2nd.</text>
@@ -3363,7 +3363,7 @@
       <range>30 feet</range>
       <components>V, S</components>
       <duration>1 minute</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>A spectral, floating hand appears at a point you choose within range. The hand lasts for the duration or until you dismiss it as an action. The hand vanishes if it is ever more than 30 feet away from you or if you cast this spell again.</text>
       <text />
       <text>You can use your action to control the hand. You can use the hand to manipulate an object, open an unlocked door or container, stow or retrieve an item from an open container, or pour the contents out of a vial. You can move the hand up to 30 feet each time you use it. T</text>
@@ -3441,7 +3441,7 @@
       <range>30 feet</range>
       <components>V, S, M (a small bit of honeycomb and jade dust worth at least 10 gp, which the spell consumes)</components>
       <duration>Until dispelled</duration>
-      <classes>Bard, Wizard</classes>
+      <classes>Bard, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You implant a message within an object in range, a message that is uttered when a trigger condition is met. Choose an object that you can see and that isn't being worn or carried by another creature. Then speak the message, which must be 25 words or less, though it can be delivered over as long as 10 minutes. Finally, determine the circumstance that will trigger the spell to deliver your message.</text>
       <text />
       <text>When that circumstance occurs, a magical mouth appears on the object and recites the message in your voice and at the same volume you spoke. If the object you chose has a mouth or something that looks like a mouth (for example, the mouth of a statue), the magical mouth appears there so that words appear to come from the object's mouth. When you cast this spell, you can have the spell end after it delivers its message, or it can remain and repeats its message whenever the trigger occurs.</text>
@@ -3471,7 +3471,7 @@
       <range>120 feet</range>
       <components>V, S, M (a bit of fleece)</components>
       <duration>Concentration, up to 10 minutes</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 20-foot cube. The image appears at a spot that you can see within range and lasts for the duration. It seems completely real, including sounds, smells, and temperature appropriate to the thing depicted. You can't create sufficient heat or cold to cause damage, a sound loud enough to deal thunder damage or deafen a creature, or a smell that might sicken a creature (like a troglodyte's stench).</text>
       <text />
       <text>As long as you are within range of the illusion, you can use your action to cause the image to move to any other spot within range. As the image changes location, you can alter its appearance so that its movements appear natural for the image. For example, if you create an image of a creature and move it, you can alter the image so that it appears to be walking. Similarly, you can cause the illusion to make different sounds at different times, even making it carry on a conversation, for example.</text>
@@ -3529,7 +3529,7 @@
       <range>60 feet</range>
       <components>V, M (a snake's tongue and either a bit of honeycomb or a drop of sweet oil)</components>
       <duration>24 hours</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You suggest a course of activity (limited to a sentence or two) and magically influence up to twelve creatures of your choice that you can see within range and that can hear and understand you. Creatures that can't be charmed are immune to this effect. The suggestion must be worded in such a manner as to make the course of action sound reasonable. Asking the creature to stab itself, throw itself onto a spear, immolate itself, or do some other obviously harmful act automatically negates the effect of the spell.</text>
       <text />
       <text>Each target must make a Wisdom saving throw. On a failed save, it pursues the course of action you described to the best of its ability. The suggested course of action can continue for the entire duration. If the suggested activity can be completed in a shorter time, the spell ends when the subject finishes what it was asked to do.</text>
@@ -3609,7 +3609,7 @@
       <range>120 feet</range>
       <components>V, S, M (a short piece of copper wire)</components>
       <duration>1 round</duration>
-      <classes>Bard, Sorcerer, Wizard</classes>
+      <classes>Bard, Sorcerer, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>You point your finger toward a creature within range and whisper a message. The target (and only the target) hears the message and can reply in a whisper that only you can hear.</text>
       <text />
       <text>You can cast this spell through solid objects if you are familiar with the target and know it is beyond the barrier. Magical silence, 1 foot of stone, 1 inch of common metal, a thin sheet of lead, or 3 feet of wood blocks the spell. The spell doesn't have to follow a straight line and can travel freely around corners or through openings.</text>
@@ -3649,7 +3649,7 @@
       <range>30 feet</range>
       <components>S, M</components>
       <duration>1 minute</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
       <text>You create a sound or an image of an object within range that lasts for the duration. The illusion also ends if you dismiss it as an action or cast this spell again.</text>
       <text />
       <text>If you create a sound, its volume can range from a whisper to a scream. It can be your voice, someone else's voice, a lion's roar, a beating of drums, or any other sound you choose. The sound continues unabated throughout the duration, or you can make discrete sounds at different times before the spell ends.</text>
@@ -3667,7 +3667,7 @@
       <range>Sight</range>
       <components>V, S</components>
       <duration>10 days</duration>
-      <classes>Bard, Druid, Wizard</classes>
+      <classes>Bard, Druid, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You make terrain in an area up to 1 mile square look, sound, smell, and even feel like some other sort of terrain. The terrain's general shape remains the same, however. Open fields or a road could be made to resemble a swamp, hill, crevasse, or some other difficult or impassable terrain. A pond can be made to seem like a grassy meadow, a precipice like a gentle slope, or a rock-strewn gully like a wide and smooth road.</text>
       <text />
       <text>Similarly, you can alter the appearance of structures, or add them where none are present. The spell doesn't disguise, conceal, or add creatures.</text>
@@ -3685,7 +3685,7 @@
       <range>Self</range>
       <components>V, S</components>
       <duration>1 minute</duration>
-      <classes>Cleric (Trickery), Druid (Coast), Sorcerer, Warlock, Wizard</classes>
+      <classes>Cleric (Trickery), Druid (Coast), Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>Three illusory duplicates of yourself appear in your space. Until the spell ends, the duplicates move with you and mimic your actions, shifting position so it's impossible to track which image is real. You can use your action to dismiss the illusory duplicates.</text>
       <text />
       <text>Each time a creature targets you with an attack during the spell's duration, roll a d20 to determine whether the attack instead targets one of your duplicates.</text>
@@ -3705,7 +3705,7 @@
       <range>Self</range>
       <components>S</components>
       <duration>Concentration, up to 1 hour</duration>
-      <classes>Bard, Wizard</classes>
+      <classes>Bard, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You become invisible at the same time that an illusory double of you appears where you are standing. The double lasts for the duration, but the invisibility ends if you attack or cast a spell.</text>
       <text />
       <text>You can use your action to move your illusory double up to twice your speed and make it gesture, speak, and behave in whatever way you choose. You can see through its eyes and hear through its ears as if you were located where it is. On each of your turns as a bonus action, you can switch from using its senses to using your own, or back again. While you are using its senses, you are blinded and deafened in regard to your own surroundings.</text>
@@ -3731,7 +3731,7 @@
       <range>30 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Cleric (Trickery), Wizard</classes>
+      <classes>Bard, Cleric (Trickery), Wizard, Rogue (Arcane Trickster)</classes>
       <text>You attempt to reshape another creature's memories. One creature that you can see must make a Wisdom saving throw. If you are fighting the creature, it has advantage on the saving throw. On a failed save, the target becomes charmed by you for the duration. The charmed target is incapacitated and unaware of its surroundings, though it can still hear you. If it takes any damage or is targeted by another spell, this spell ends, and none of the target's memories are modified.</text>
       <text />
       <text>While this charm lasts, you can affect the target's memory of an event that it experienced within the last 24 hours and that lasted no more than 10 minutes. You can permanently eliminate all memory of the event, allow the target to recall the event with perfect clarity and exacting detail, change its memory of the details of the event, or create a memory of some other event.</text>
@@ -3875,7 +3875,7 @@
       <range>Touch</range>
       <components>V, S, M (a small square of silk)</components>
       <duration>24 hours</duration>
-      <classes>Wizard</classes>
+      <classes>Wizard, Rogue (Arcane Trickster)</classes>
       <text>You place an illusion on a creature or an object you touch so that divination spells reveal false information about it. The target can be a willing creature or an object that isn't being carried or worn by another creature.</text>
       <text />
       <text>When you cast the spell, choose one or both of the following effects. The effect lasts for the duration. If you cast this spell on the same creature or object every day for 30 days, placing the same effect on it each time, the illusion lasts until it is dispelled.</text>
@@ -3929,7 +3929,7 @@
       <range>30 feet</range>
       <components>V</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Wizard</classes>
+      <classes>Bard, Wizard, Rogue (Arcane Trickster)</classes>
       <text>Choose one creature that you can see within range. The target begins a comic dance in place: shuffling, tapping its feet, and capering for the duration. Creatures that can't be charmed are immune to this spell.</text>
       <text />
       <text>A dancing creature must use all its movement to dance without leaving its space and has disadvantage on Dexterity saving throws and attack rolls. While the target is affected by this spell, other creatures have advantage on attack rolls against it. As an action, a dancing creature makes a Wisdom saving throw to regain control of f itself. On a successful save, the spell ends.</text>
@@ -3969,7 +3969,7 @@
       <range>60 feet</range>
       <components>V, S, M (a bit of fleece)</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Bard, Sorcerer, Warlock (Archfey), Warlock (Great Old One), Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock (Archfey), Warlock (Great Old One), Wizard, Rogue (Arcane Trickster)</classes>
       <text>You craft an illusion that takes root in the mind of a creature that you can see within range. The target must make an Intelligence saving throw. On a failed save, you create a phantasmal object, creature, or other visible phenomenon of your choice that is no larger than a 10-foot cube and that is perceivable only to the target for the duration. This spell has no effect on undead or constructs.</text>
       <text />
       <text>The phantasm includes sound, temperature, and other stimuli, also evident only to the creature.</text>
@@ -3989,7 +3989,7 @@
       <range>120 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Wizard</classes>
+      <classes>Wizard, Rogue (Arcane Trickster)</classes>
       <text>You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a Wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the start of each of the target's turns before the spell ends, the target must succeed on a Wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends.</text>
       <text />
       <text>At Higher Levels. When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d10 for each slot level above 4th.</text>
@@ -4003,7 +4003,7 @@
       <range>30 feet</range>
       <components>V, S</components>
       <duration>1 hour</duration>
-      <classes>Wizard</classes>
+      <classes>Wizard, Rogue (Arcane Trickster)</classes>
       <text>A Large quasi-real, horse-like creature appears on the ground in an unoccupied space of your choice within range. You decide the creature's appearance, but it is equipped with a saddle, bit, and bridle. Any of the equipment created by the spell vanishes in a puff of smoke if it is carried more than 10 feet away from the steed.</text>
       <text />
       <text>For the duration, you or a creature you choose can ride the steed. The creature uses the statistics for a riding horse, except it has a speed of 100 feet and can travel 10 miles in an hour, or 13 miles at a fast pace. When the spell ends, the steed gradually fades, giving the rider 1 minute to dismount. The spell ends if you use an action to dismiss it or if the steed takes any damage.</text>
@@ -4135,7 +4135,7 @@
       <range>60 feet</range>
       <components>V</components>
       <duration>Instantaneous</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You utter a word of power that can compel one creature you can see within range to die instantly. If the creature you chose has 100 hit points or fewer, it dies. Otherwise, the spell has no effect.</text>
    </spell>
    <spell>
@@ -4147,7 +4147,7 @@
       <range>60 feet</range>
       <components>V</components>
       <duration>Instantaneous</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You speak a word of power that can overwhelm the mind of one creature you can see within range, leaving it dumbfounded. If the target has 150 hit points or fewer, it is stunned. Otherwise, the spell has no effect.</text>
       <text />
       <text>The stunned target must make a Constitution saving throw at the end of each of its turns. On a successful save, this stunning effect ends.</text>
@@ -4175,7 +4175,7 @@
       <range>10 feet</range>
       <components>V, S</components>
       <duration>Up to 1 hour</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>This spell is a minor magical trick that novice spellcasters use for practice. You create one of the following magical effects within range:</text>
       <text>*You create an instantaneous, harmless sensory effect, such as a shower of sparks, a puff of wind, faint musical notes, or an odd odor.</text>
       <text>*You instantaneously light or snuff out a candle, a torch, or a small campfire.</text>
@@ -4271,7 +4271,7 @@
       <range>120 feet</range>
       <components>V, S, M</components>
       <duration>Until dispelled</duration>
-      <classes>Bard, Wizard</classes>
+      <classes>Bard, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You create an illusion of an object, a creature, or some other visible phenomenon within range that activates when a specific condition occurs. The illusion is imperceptible until then. It must be no larger than a 30-foot cube, and you decide when you cast the spell how the illusion behaves and what sounds it makes. This scripted performance can last up to 5 minutes.</text>
       <text />
       <text>When the condition you specify occurs, the illusion springs into existence and performs in the manner you described. Once the illusion finishes performing, it disappears and remains dormant for 10 minutes. After this time, the illusion can be activated again.</text>
@@ -4289,7 +4289,7 @@
       <range>500 miles</range>
       <components>V, S, M (a small replica of you made from materials worth at least 5 gp)</components>
       <duration>Concentration, up to 1 day</duration>
-      <classes>Bard, Wizard</classes>
+      <classes>Bard, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You create an illusory copy of yourself that lasts for the duration. The copy can appear at any location within range that you have seen before, regardless of intervening obstacles. The illusion looks and sounds like you but is intangible. If the illusion takes any damage, it disappears, and the spell ends.</text>
       <text />
       <text>You can use your action to move this illusion up to twice your speed, and make it gesture, speak, and behave in whatever way you choose. It mimics your mannerisms perfectly.</text>
@@ -4405,7 +4405,7 @@
       <range>60 feet</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn.</text>
       <text />
       <text>The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</text>
@@ -4653,7 +4653,7 @@
       <range>30 feet</range>
       <components>V, S</components>
       <duration>8 hours</duration>
-      <classes>Bard, Sorcerer, Warlock (Archfey), Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock (Archfey), Wizard, Rogue (Arcane Trickster)</classes>
       <text>This spell allows you to change the appearance of any number of creatures that you can see within range. You give each target you choose a new, illusory appearance. An unwilling target can make a Charisma saving throw, and if it succeeds, it is unaffected by this spell.</text>
       <text />
       <text>The spell disguises physical appearances as well as clothing, armor, weapons, and equipment. You can make each creature seem 1 foot shorter or taller and appear thin, fat, or in-between. You can't change a target's body type, so you must choose a form that has the same basic arrangement of limbs. Otherwise, the extent of the illusion is up to you. The spell lasts for the duration, unless you use your action to dismiss it sooner.</text>
@@ -4773,7 +4773,7 @@
       <range>Touch</range>
       <components>V, S</components>
       <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>Lightning springs from your hand to deliver a shock to a creature you try to touch. Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can't take reactions until the start of its next turn.</text>
       <text />
       <text>The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</text>
@@ -4799,7 +4799,7 @@
       <range>60 feet</range>
       <components>V, S, M (a bit of fleece)</components>
       <duration>Concentration, up to 10 minute</duration>
-      <classes>Bard, Sorcerer, Wizard</classes>
+      <classes>Bard, Sorcerer, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 15-foot cube. The image appears at a spot within range and lasts for the duration. The image is purely visual, it isn't accompanied by sound, smell, or other sensory effects.</text>
       <text />
       <text>You can use your action to cause the image to move to any spot within range. As the image changes location, you can alter its appearance so that its movements appear natural for the image. For example, if you create an image of a creature and move it, you can alter the image so that it appears to be walking.</text>
@@ -4815,7 +4815,7 @@
       <range>Touch</range>
       <components>V, S, M (snow or ice in quantities sufficient to made a life-size copy of the duplicated creature some hair, fingernail clippings, or other piece of that creature's body placed inside the snow or ice and powdered ruby worth 1,500 gp, sprinkled over the duplicate and consumed by the spell)</components>
       <duration>Until dispelled</duration>
-      <classes>Wizard</classes>
+      <classes>Wizard, Rogue (Arcane Trickster)</classes>
       <text>You shape an illusory duplicate of one beast or humanoid that is within range for the entire casting time of the spell. The duplicate is a creature, partially real and formed from ice or snow, and it can take actions and otherwise be affected as a normal creature. It appears to be the same as the original, but it has half the creature's hit point maximum and is formed without any equipment. Otherwise, the illusion uses all the statistics of the creature it duplicates.</text>
       <text />
       <text>The simulacrum is friendly to you and creatures you designate. It obeys your spoken commands, moving and acting in accordance with your wishes and acting on your turn in combat. The simulacrum lacks the ability to learn or become more powerful, so it never increases its level or other abilities, nor can it regain expended spell slots.</text>
@@ -4833,7 +4833,7 @@
       <range>90 feet</range>
       <components>V, S, M (a pinch of find sand, rose petals, or a cricket)</components>
       <duration>1 minute</duration>
-      <classes>Bard, Sorcerer, Warlock (Archfey), Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock (Archfey), Wizard, Rogue (Arcane Trickster)</classes>
       <text>This spell sends creatures into a magical slumber. Roll 5d8, the total is how many hit points of creatures this spell can affect. Creatures within 20 feet of a point you choose within range are affected in ascending order of their current hit points (ignoring unconscious creatures).</text>
       <text />
       <text>Starting with the creature that has the lowest current hit points, each creature affected by this spell falls unconscious until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake. Subtract each creature's hit points from the total before moving on to the creature with the next lowest hit points. A creature's hit points must be equal to or less than the remaining total for that creature to be affected.</text>
@@ -5077,7 +5077,7 @@
       <range>30 feet</range>
       <components>V, M (a snake's tongue and either a bit of honeycomb or a drop of sweet oil)</components>
       <duration>Concentration, up to 8 hours</duration>
-      <classes>Bard, Cleric (Knowledge), Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Cleric (Knowledge), Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster)</classes>
       <text>You suggest a course of activity (limited to a sentence or two) and magically influence a creature you can see within range that can hear and understand you. Creatures that can't be charmed are immune to this effect. The suggestion must be worded in such a manner as to make the course of action sound reasonable. Asking the creature to stab itself, throw itself onto a spear, immolate itself, or do some other obviously harmful act ends the spell.</text>
       <text />
       <text>The target must make a Wisdom saving throw. On a failed save, it purses the course of action you described to the best of its ability. The suggested course of action can continue for the entire duration. If the suggested activity can be completed in a shorter time, the spell ends when the subject finishes what it was asked to do.</text>
@@ -5177,7 +5177,7 @@
       <range>30 feet</range>
       <components>V, S, M (tiny tarts and a feather that waved in the air)</components>
       <duration>Concentration, up to 1min</duration>
-      <classes>Bard, Warlock (Great Old One), Wizard</classes>
+      <classes>Bard, Warlock (Great Old One), Wizard, Rogue (Arcane Trickster)</classes>
       <text>A creature of your choice that you can see within range perceives everything as hilariously funny and falls into fits of laugher if this spell affects it. The target must succeed on a Wisdom saving throw of fall prone, becoming incapacitated and unable to stand up for the duration. A creature with an Intelligence score of 4 or less isn't affected.</text>
       <text />
       <text>At the end of each of its turns, and each time it takes damage, the target can make another Wisdom saving throw. The target has advantage on the saving throw if it's triggered by damage. On a success, the spell ends.</text>
@@ -5443,7 +5443,7 @@
       <range>30 feet</range>
       <components>S</components>
       <duration>Concentration, up to 1 round</duration>
-      <classes>Bard, Sorcerer, Warlock, Wizard</classes>
+      <classes>Bard, Sorcerer, Warlock, Wizard, Fighter (Eldritch Knight), Rogue (Arcane Trickster)</classes>
       <text>You extend your hand and point a finger at a target in range. Your magic grants you a brief insight into the target's defenses. On your next turn, you gain advantage on your first attack roll against the target, provided that this spell hasn't ended.</text>
    </spell>
    <spell>
@@ -5667,7 +5667,7 @@
       <range>120 feet</range>
       <components>V, S</components>
       <duration>Concentration, up to 1 minute</duration>
-      <classes>Wizard</classes>
+      <classes>Wizard, Rogue (Arcane Trickster)</classes>
       <text>Drawing on the deepest fears of a group of creatures, you create illusory creatures in their minds, visible only to them. Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a Wisdom saving throw. On a failed save, a creature becomes frightened for the duration. The illusion calls on the creature's deepest fears, manifesting its worst nightmares as an implacable threat. At the start of each of the frightened creature's turns, it must succeed on a Wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends for that creature.</text>
    </spell>
    <spell>


### PR DESCRIPTION
used CSV file to filter Wizard Enchant and Illusion to add Rogue (Arcane Trickster)
used CSV file to filter Wizard Cantrips to add Rogue (Arcane Trickster) and Fighter (Eldritch Knight)
Fighter (Eldritch Knight) was missing from some Wizard Cantrips when all should be available (see PHB pg75)
*bonus fun fact - spell check thinks "Eldritch" should be "britches"
