### PR TITLE
edited file to prepare for BOLD with ":"

### DIFF
--- a/Spells/EE Spells.xml
+++ b/Spells/EE Spells.xml
@@ -1,808 +1,810 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spells version="5">
-   <spell>
-      <name>Abi-Dalzim's Horrid Wilting (EE)</name>
-      <level>8</level>
-      <school>N</school>
-      <ritual />
-      <time>1 action</time>
-      <range>150 feet</range>
-      <components>V, S, M (a bit of sponge)</components>
-      <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard</classes>
-      <text>You draw the moisture from every creature in a 30-foot cube centered on a point you choose within range. Each creature in that area must make a Constitution saving throw. Constructs and undead aren't affected, and plants and water elementals make this saving throw with disadvantage. A creature takes 10d8 necrotic damage on a failed save, or half as much damage on a successful one.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>10d8</roll>
-   </spell>
-   <spell>
-      <name>Absorb Elements (EE)</name>
-      <level>1</level>
-      <school>A</school>
-      <ritual />
-      <time>1 reaction, which you take when you take acid, cold, fire, lightning, or thunder damage</time>
-      <range>Self</range>
-      <components>S</components>
-      <duration>1 round</duration>
-      <classes>Druid, Ranger, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>The spell captures some of the incoming energy, lessening its effect on you and storing it for your next melee attack. You have resistance to the triggering damage type until the start of your next turn. Also, the first time you hit with a melee attack on your next turn, the target takes an extra 1d6 damage of the triggering type, and the spell ends.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each slot level above 1st.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d6</roll>
-   </spell>
-   <spell>
-      <name>Aganazzar's Scorcher (EE)</name>
-      <level>2</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>30 feet</range>
-      <components>V, S, M (a red dragon's scale)</components>
-      <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>A line of roaring flame 30 feet long and 5 feet wide emanates from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 3d8 fire damage on a failed save, or half as much damage on a successful one.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>3d8</roll>
-   </spell>
-   <spell>
-      <name>Beast Bond (EE)</name>
-      <level>1</level>
-      <school>D</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Touch</range>
-      <components>V, S, M (a bit of fur wrapped in a cloth)</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid, Ranger</classes>
-      <text>You establish a telepathic link with one beast you touch that is friendly to you or charmed by you. The spell fails if the beast's Intelligence is 4 or higher. Until the spell ends, the link is active while you and the beast are within line of sight of each other. Through the link, the beast can understand your telepathic messages to it, and it can telepathically communicate simple emotions and concepts back to you. While the link is active, the beast gains advantage on attack rolls against any creature within 5 feet of you that you can see.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Bones of the Earth (EE)</name>
-      <level>6</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>120 feet</range>
-      <components>V, S</components>
-      <duration>Instantaneous</duration>
-      <classes>Druid</classes>
-      <text>You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius. The rubble lasts until cleared.</text>
-      <text />
-      <text>If a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 7th level or higher, you can create</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Catapult (EE)</name>
-      <level>1</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>150 feet</range>
-      <components>S</components>
-      <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard</classes>
-      <text>Choose one object weighing 1 to 5 pounds within range that isn't being worn or carried. The object flies in a straight line up to 90 feet in a direction you choose before falling to the ground, stopping early if it impacts against a solid surface. If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. In either case, both the object and the creature or solid surface take 3d8 bludgeoning damage.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the maximum weight of objects that you can target with this spell increases by 5 pounds, and the damage</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>3d8</roll>
-   </spell>
-   <spell>
-      <name>Control Flames (EE)</name>
-      <level>0</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>60 feet</range>
-      <components>S</components>
-      <duration>Instantaneous or 1 hour (see below)</duration>
-      <classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
-      <text>You choose nonmagical flame that you can see within range and that fits within a 5-foot cube. You affect it in one of the following ways:</text>
-      <text />
-      <text>You instantaneously expand the flame 5 feet in one direction, provided that wood or other fuel is present in the new location.</text>
-      <text />
-      <text>You instantaneously extinguish the flames within the cube.</text>
-      <text />
-      <text>You double or halve the area of bright light and dim light cast by the flame, change its color, or both. The change lasts for 1 hour.</text>
-      <text />
-      <text>You cause simple shapes-such as the vague form of a creature, an inanimate object, or a location-to appear within the flames and animate as you like. The shapes last for 1 hour.</text>
-      <text />
-      <text>If you cast this spell multiple times, you can have up to three of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Control Winds (EE)</name>
-      <level>5</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>300 feet</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 1 hour</duration>
-      <classes>Druid, Sorcerer, Wizard</classes>
-      <text>You take control of the air in a 100-foot cube that you can see within range. Choose one of the following effects when you cast the spell. The effect lasts for the spell's duration, unless you use your action on a later turn to switch to a different effect. You can also use your action to temporarily halt the effect or to restart one you've halted.</text>
-      <text />
-      <text>Gusts. A wind picks up within the cube, continually blowing in a horizontal direction that you choose. You choose the intensity of the wind: calm, moderate, or strong. If the wind is moderate or strong, ranged weapon attacks that pass through it or that are made against targets within the cube have disadvantage on their attack rolls. If the wind is strong, any creature moving against the wind must spend 1 extra foot of movement for each foot moved.</text>
-      <text />
-      <text>Downdraft. You cause a sustained blast of strong wind to blow downward from the top of the cube. Ranged weapon attacks that pass through the cube or that are made against targets within it have disadvantage on their attack rolls. A creature must make a Strength saving throw if it flies into the cube for the first time on a turn or starts its turn there flying. On a failed save, the creature is knocked prone.</text>
-      <text />
-      <text>Updraft. You cause a sustained updraft within the cube, rising upward from the cube's bottom edge. Creatures that end a fall within the cube take only half damage from the fall. When a creature in the cube makes a vertical jump, the creature can jump up to 10 feet higher than normal.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Create Bonfire (EE)</name>
-      <level>0</level>
-      <school>C</school>
-      <ritual />
-      <time>1 action</time>
-      <range>60 feet</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
-      <text>You create a bonfire on ground that you can see within range. Until the spells ends, the bonfire fills a 5-foot cube. Any creature in the bonfire's space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage. A creature must also make the saving throw when it enters the bonfire's space for the first time on a turn or ends its turn there.</text>
-      <text />
-      <text>The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d8</roll>
-	  <roll>2d8</roll>
-	  <roll>3d8</roll>
-	  <roll>4d8</roll>
-   </spell>
-   <spell>
-      <name>Dust Devil (EE)</name>
-      <level>2</level>
-      <school>C</school>
-      <ritual />
-      <time>1 action</time>
-      <range>60 feet</range>
-      <components>V, S, M (a pinch of dust)</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid, Sorcerer, Wizard</classes>
-      <text>Choose an unoccupied 5-foot cube of air that you can see within range. An elemental force that resembles a dust devil appears in the cube and lasts for the spell's duration.</text>
-      <text />
-      <text>Any creature that ends its turn within 5 feet of the dust devil must make a Strength saving throw. On a failed save, the creature takes 1d8 bludgeoning damage and is pushed 10 feet away. On a successful save, the creature takes half as much damage and isn't pushed.</text>
-      <text />
-      <text>As a bonus action, you can move the dust devil up to 30 feet in any direction. If the dust devil moves over sand, dust, loose dirt, or small gravel, it sucks up the material and forms a 10-foot-radius cloud of debris around itself that lasts until the start of your next turn. The cloud heavily obscures its area.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d8</roll>
-   </spell>
-   <spell>
-      <name>Earth Tremor (EE)</name>
-      <level>1</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self (10-foot radius)</range>
-      <components>V, S</components>
-      <duration>Instantaneous</duration>
-      <classes>Bard, Druid, Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>You cause a tremor in the ground in a 10-foot radius. Each creature other than you in that area must make a Dexterity saving throw. On a failed save, a creature takes 1d6 bludgeoning damage and is knocked prone. If the ground in that area is loose earth or stone, it becomes difficult terrain until cleared.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d6</roll>
-   </spell>
-   <spell>
-      <name>Earthbind (EE)</name>
-      <level>2</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>300 feet</range>
-      <components>V</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
-      <text>Choose one creature you can see within range. Yellow strips of magical energy loop around the creature. The target must succeed on a Strength saving throw or its flying speed (if any) is reduced to 0 feet for the spell's duration. An airborne creature affected by this spell descends at 60 feet per round until it reaches the ground or the spell ends.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Elemental Bane (EE)</name>
-      <level>4</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>90 feet</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid, Warlock, Wizard</classes>
-      <text>Choose one creature you can see within range, and choose one of the following damage types: acid, cold, fire, lightning, or thunder. The target must succeed on a Constitution saving throw or be affected by the spell for its duration. The first time each turn the affected target takes damage of the chosen type, the target takes an extra 2d6 damage of that type. Moreover, the target loses any resistance to that damage type until the spell ends.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>2d6</roll>
-   </spell>
-   <spell>
-      <name>Erupting Earth (EE)</name>
-      <level>3</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>120 feet</range>
-      <components>V, S, M (a piece of obsidian)</components>
-      <duration>Instantaneous</duration>
-      <classes>Druid, Sorcerer, Wizard</classes>
-      <text>Choose a point you can see on the ground within range. A fountain of churned earth and stone erupts in a 20-foot cube centered on that point. Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared away. Each 5-foot-square portion of the area requires at least 1 minute to clear by hand.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d12 for each slot level above 2nd.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>3d12</roll>
-   </spell>
-   <spell>
-      <name>Flame Arrows (EE)</name>
-      <level>3</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Touch</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 1 hour</duration>
-      <classes>Druid, Ranger, Sorcerer, Wizard</classes>
-      <text>You touch a quiver containing arrows or bolts. When a target is hit by a ranged weapon attack using a piece of ammunition drawn from the quiver, the target takes an extra 1d6 fire damage. The spell's magic ends on the piece of ammunition when it hits or misses, and the spell ends when twelve pieces of ammunition have been drawn from the quiver.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 4th level or higher, the number of pieces of ammunition you can affect with this spell increases by two for each slot level above 3rd.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d6</roll>
-   </spell>
-   <spell>
-      <name>Frostbite (EE)</name>
-      <level>0</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>60 feet</range>
-      <components>V, S</components>
-      <duration>Instantaneous</duration>
-      <classes>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
-      <text>You cause numbing frost to form on one creature that you can see within range. The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn.</text>
-      <text />
-      <text>The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d6</roll>
-	  <roll>2d6</roll>
-	  <roll>3d6</roll>
-	  <roll>4d6</roll>
-   </spell>
-   <spell>
-      <name>Gust (EE)</name>
-      <level>0</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>30 feet</range>
-      <components>V, S</components>
-      <duration>Instantaneous</duration>
-      <classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
-      <text>You seize the air and compel it to create one of the following effects at a point you can see within range:</text>
-      <text />
-      <text>• One Medium or smaller creature that you choose must succeed on a Strength saving throw or be pushed up to 5 feet away from you.</text>
-      <text />
-      <text>• You create a small blast of air capable of moving one object that is neither held nor carried and that weighs no more than 5 pounds. The object is pushed up to 10 feet away from you. It isn't pushed with enough force to cause damage.</text>
-      <text />
-      <text>• You create a harmless sensory affect using air, such as causing leaves to rustle, wind to slam shutters shut, or your clothing to ripple in a breeze.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Ice Knife (EE)</name>
-      <level>1</level>
-      <school>C</school>
-      <ritual />
-      <time>1 action</time>
-      <range>60 feet</range>
-      <components>S, M (a drop of water or piece of ice)</components>
-      <duration>Instantaneous</duration>
-      <classes>Druid, Sorcerer, Wizard</classes>
-      <text>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of the point where the ice exploded must succeed on a Dexterity saving throw or take 2d6 cold damage.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 2nd level or higher, the cold damage increases by 1d6 for each slot level above 1st.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d20+%0+%8</roll>
-	  <roll>1d10</roll>
-   </spell>
-   <spell>
-      <name>Immolation (EE)</name>
-      <level>5</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>90 feet</range>
-      <components>V</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Sorcerer, Wizard</classes>
-      <text>Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 7d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell's duration. The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. At the end of each of its turns, the target repeats the saving throw. It takes 3d6 fire damage on a failed save, and the spell ends on a successful one. These magical flames can't be extinguished through nonmagical means.</text>
-      <text />
-      <text>If damage from this spell reduces a target to 0 hit points, the target is turned to ash.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>7d6</roll>
-	  <roll>3d6</roll>
-   </spell>
-   <spell>
-      <name>Investiture of Flame (EE)</name>
-      <level>6</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
-      <text>Flames race across your body, shedding bright light in a 30-foot radius and dim light for an additional 30 feet for the spell's duration. The flames don't harm you. Until the spell ends, you gain the following benefits:</text>
-      <text />
-      <text>• You are immune to fire damage and have resistance to cold damage.</text>
-      <text />
-      <text>• Any creature that moves within 5 feet of you for the first time on a turn or ends its turn there takes 1d10 fire damage.</text>
-      <text />
-      <text>• You can use your action to create a line of fire 15 feet long and 5 feet wide extending from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 4d8 fire damage on a failed save, or half as much damage on a successful one.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d10</roll>
-   </spell>
-   <spell>
-      <name>Investiture of Ice (EE)</name>
-      <level>6</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
-      <text>Until the spell ends, ice rimes your body, and you gain the following benefits:</text>
-      <text />
-      <text>• You are immune to cold damage and have resistance to fire damage.</text>
-      <text />
-      <text>• You can move across difficult terrain created by ice or snow without spending extra movement.</text>
-      <text />
-      <text>• The ground in a 10-foot radius around you is icy and is difficult terrain for creatures other than you. The radius moves with you.</text>
-      <text />
-      <text>• You can use your action to create a 15-foot cone of freezing wind extending from your outstretched hand in a direction you choose. Each creature in the cone must make a Constitution saving throw. A creature takes 4d6 cold damage on a failed save, or half as much damage on a successful one. A creature that fails its save against this effect has its speed halved until the start of your next turn.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Investiture of Stone (EE)</name>
-      <level>6</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
-      <text>Until the spell ends, bits of rock spread across your body, and you gain the following benefits:</text>
-      <text />
-      <text>• You have resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons.</text>
-      <text />
-      <text>• You can use your action to create a small earthquake on the ground in a 15-foot radius centered on you. Other creatures on that ground must succeed on a Dexterity saving throw or be knocked prone.</text>
-      <text />
-      <text>• You can move across difficult terrain made of earth or stone without spending extra movement. You can move through solid earth or stone as if it was air and without destabilizing it, but you can't end your movement there. If you do so, you are ejected to the nearest unoccupied space, this spell ends, and you are stunned until the end of your next turn.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Investiture of Wind (EE)</name>
-      <level>6</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid, Sorcerer, Warlock, Wizard</classes>
-      <text>Until the spell ends, wind whirls around you, and you gain the following benefits:</text>
-      <text />
-      <text>• Ranged weapon attacks made against you have disadvantage on the attack roll.</text>
-      <text />
-      <text>• You gain a flying speed of 60 feet. If you are still flying when the spell ends, you fall, unless you can somehow prevent it.</text>
-      <text />
-      <text>• You can use your action to create a 15-foot cube of swirling wind centered on a point you can see within 60 feet of you. Each creature in that area must make a Constitution saving throw. A creature takes 2d10 bludgeoning damage on a failed save, or half as much damage on a successful one. If a Large or smaller creature fails the save, that creature is also pushed up to 10 feet away from the center of the cube.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>2d10</roll>
-   </spell>
-   <spell>
-      <name>Maelstrom (EE)</name>
-      <level>5</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>120 feet</range>
-      <components>V, S, M (paper or leaf in the shape of a funnel)</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid</classes>
-      <text>A mass of 5-foot-deep water appears and swirls in a 30-foot radius centered on a point you can see within range. The point must be on ground or in a body of water. Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>6d6</roll>
-   </spell>
-   <spell>
-      <name>Magic Stone (EE)</name>
-      <level>0</level>
-      <school>T</school>
-      <ritual />
-      <time>1 bonus action</time>
-      <range>Touch</range>
-      <components>V, S</components>
-      <duration>1 minute</duration>
-      <classes>Druid, Warlock</classes>
-      <text>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker's, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</text>
-      <text />
-      <text>If you cast this spell again, the spell ends early on any pebbles still affected by it.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d20+%0+%8</roll>
-      <roll>1d6+%0</roll>
-   </spell>
-   <spell>
-      <name>Maximilian's Earthen Grasp (EE)</name>
-      <level>2</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>30 feet</range>
-      <components>V, S, M (a miniature hand sculpted from clay)</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Sorcerer, Wizard</classes>
-      <text>You choose a 5-foot-square unoccupied space on the ground that you can see within range. A Medium hand made from compacted soil rises there and reaches for one creature you can see within 5 feet of it. The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell's duration.</text>
-      <text />
-      <text>As an action, you can cause the hand to crush the restrained target, who must make a Strength saving throw. It takes 2d6 bludgeoning damage on a failed save, or half as much damage on a successful one.</text>
-      <text />
-      <text>To break out, the restrained target can make a Strength check against your spell save DC. On a success, the target escapes and is no longer restrained by the hand.</text>
-      <text />
-      <text>As an action, you can cause the hand to reach for a different creature or to move to a different unoccupied space within range. The hand releases a restrained target if you do either.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>2d6</roll>
-   </spell>
-   <spell>
-      <name>Melf's Minute Meteors (EE)</name>
-      <level>3</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self</range>
-      <components>V, S, M (niter, sulfur, and pine tar formed into a bead)</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>You create six tiny meteors in your space. They float in the air and orbit you for the spell's duration. When you cast the spell-and as a bonus action on each of your turns thereafter-you can expend one or two of the meteors, sending them streaking toward a point or points you choose within 120 feet of you. Once a meteor reaches its destination or impacts against a solid surface, the meteor explodes. Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 4th level or higher, the number of meteors created increases by two for each slot level above 3rd.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>2d6</roll>
-   </spell>
-   <spell>
-      <name>Mold Earth (EE)</name>
-      <level>0</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>30 feet</range>
-      <components>S</components>
-      <duration>Instantaneous or 1 hour (see below)</duration>
-      <classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
-      <text>You choose a portion of dirt or stone that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways:</text>
-      <text />
-      <text>• If you target an area of loose earth, you can instantaneously excavate it, move it along the ground, and deposit it up to 5 feet away. This movement doesn't have enough force to cause damage.</text>
-      <text />
-      <text>• You cause shapes, colors, or both to appear on the dirt or stone, spelling out words, creating images, or shaping patterns. The changes last for 1 hour.</text>
-      <text />
-      <text>• If the dirt or stone you target is on the ground, you cause it to become difficult terrain. Alternatively, you can cause the ground to become normal terrain if it is already difficult terrain. This change lasts for 1 hour.</text>
-      <text />
-      <text>If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Primordial Ward (EE)</name>
-      <level>6</level>
-      <school>A</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid</classes>
-      <text>You have resistance to acid, cold, fire, lightning, and thunder damage for the spell's duration.</text>
-      <text />
-      <text>When you take damage of one of those types, you can use your reaction to gain immunity to that type of damage, including against the triggering damage. If you do so, the resistances end, and you have the immunity until the end of your next turn, at which time the spell ends.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Pyrotechnics (EE)</name>
-      <level>2</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>60 feet</range>
-      <components>V, S</components>
-      <duration>Instantaneous</duration>
-      <classes>Bard, Sorcerer, Wizard</classes>
-      <text>Choose an area of flame that you can see and that can fit within a 5-foot cube within range. You can extinguish the fire in that area, and you create either fireworks or smoke.</text>
-      <text />
-      <text>Fireworks. The target explodes with a dazzling display of colors. Each creature within 10 feet of the target must succeed on a Constitution saving throw or become blinded until the end of your next turn.</text>
-      <text />
-      <text>Smoke. Thick black smoke spreads out from the target in a 20-foot radius, moving around corners. The area of the smoke is heavily obscured. The smoke persists for 1 minute or until a strong wind disperses it.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Shape Water (EE)</name>
-      <level>0</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>30 feet</range>
-      <components>S</components>
-      <duration>Instantaneous or 1 hour (see below)</duration>
-      <classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
-      <text>You choose an area of water that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways:</text>
-      <text />
-      <text>• You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn't have enough force to cause damage.</text>
-      <text />
-      <text>• You cause the water to form into simple shapes and animate at your direction. This change lasts for 1 hour.</text>
-      <text />
-      <text>• You change the water's color or opacity. The water must be changed in the same way throughout. This change lasts for 1 hour.</text>
-      <text />
-      <text>• You freeze the water, provided that there are no creatures in it. The water unfreezes in 1 hour.</text>
-      <text />
-      <text>If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Skywrite (EE)</name>
-      <level>2</level>
-      <school>T</school>
-      <ritual>YES</ritual>
-      <time>1 action</time>
-      <range>Sight</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 1 hour</duration>
-      <classes>Bard, Druid, Wizard</classes>
-      <text>You cause up to ten words to form in a part of the sky you can see. The words appear to be made of cloud and remain in place for the spell's duration. The words dissipate when the spell ends. A strong wind can disperse the clouds and end the spell early.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Snilloc's Snowball Swarm (EE)</name>
-      <level>2</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>90 feet</range>
-      <components>V, S, M (a piece of ice or a small white rock chip)</components>
-      <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>A flurry of magic snowballs erupts from a point you choose within range. Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>3d6</roll>
-   </spell>
-   <spell>
-      <name>Storm Sphere (EE)</name>
-      <level>4</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>150 feet</range>
-      <components>V, S</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell's duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere's space is difficult terrain.</text>
-      <text />
-      <text>Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</text>
-      <text />
-      <text>Creatures within 30 feet of the sphere have disadvantage on Wisdom (Perception) checks made to listen.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 5th level or higher, the damage increases for each of its effects by 1d6 for each slot level above 4th</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d20+%0+%8</roll>
-	  <roll>2d6</roll>
-	  <roll>4d6</roll>
-   </spell>
-   <spell>
-      <name>Thunderclap (EE)</name>
-      <level>0</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self (5-foot radius)</range>
-      <components>S</components>
-      <duration>Instantaneous</duration>
-      <classes>Bard, Druid, Sorcerer, Warlock, Wizard, , Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
-      <text>You create a burst of thunderous sound, which can be heard 100 feet away. Each creature other than you within 5 feet of you must make a Constitution saving throw. On a failed save, the creature takes 1d6 thunder damage.</text>
-      <text />
-      <text>The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>1d6</roll>
-	  <roll>2d6</roll>
-	  <roll>3d6</roll>
-	  <roll>4d6</roll>
-   </spell>
-   <spell>
-      <name>Tidal Wave (EE)</name>
-      <level>3</level>
-      <school>C</school>
-      <ritual />
-      <time>1 action</time>
-      <range>120 feet</range>
-      <components>V, S, M (a drop of water)</components>
-      <duration>Instantaneous</duration>
-      <classes>Druid, Wizard</classes>
-      <text>You conjure up a wave of water that crashes down on an area within range. The area can be up to 30 feet long, up to 10 feet wide, and up to 10 feet tall. Each creature in that area must make a Dexterity saving throw. On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone. On a success, a creature takes half as much damage and isn't knocked prone. The water then spreads out across the ground in all directions, extinguishing unprotected flames in its area and within 30 feet of it.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>4d8</roll>
-   </spell>
-   <spell>
-      <name>Transmute Rock (EE)</name>
-      <level>5</level>
-      <school>T</school>
-      <ritual />
-      <time>1 action</time>
-      <range>120 feet</range>
-      <components>V, S, M (clay and water)</components>
-      <duration>Instantaneous</duration>
-      <classes>Druid, Wizard</classes>
-      <text>You choose an area of stone or mud that you can see that fits within a 40-foot cube and that is within range, and choose one of the following effects.</text>
-      <text />
-      <text>Transmute Rock to Mud. Nonmagical rock of any sort in the area becomes an equal volume of thick and flowing mud that remains for the spell's duration.</text>
-      <text />
-      <text>If you cast the spell on an area of ground, it becomes muddy enough that creatures can sink into it. Each foot that a creature moves through the mud costs 4 feet of movement, and any creature on the ground when you cast the spell must make a Strength saving throw. A creature must also make this save the first time it enters the area on a turn or ends its turn there. On a failed save, a creature sinks into the mud and is restrained, though it can use an action to end the restrained condition on itself by pulling itself free of the mud.</text>
-      <text />
-      <text>If you cast the spell on a ceiling, the mud falls. Any creature under the mud when it falls must make a Dexterity saving throw. A creature takes 4d8 bludgeoning damage on a failed save, or half as much damage on a successful one.</text>
-      <text />
-      <text>Transmute Mud to Rock. Nonmagical mud or quicksand in the area no more than 10 feet deep transforms into soft stone for the spell's duration. Any creature in the mud when it transforms must make a Dexterity saving throw. On a failed save, a creature becomes restrained by the rock. The restrained creature can use an action to try to break free by succeeding on a Strength check (DC 20) or by dealing 25 damage to the rock around it. On a successful save, a creature is shunted safely to the surface to an unoccupied space.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>4d8</roll>
-   </spell>
-   <spell>
-      <name>Vitriolic Sphere (EE)</name>
-      <level>4</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>150 feet</range>
-      <components>V, S, M (a drop of giant slug bile)</components>
-      <duration>Instantaneous</duration>
-      <classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>You point at a place within range, and a glowing 1-foot ball of emerald acid streaks there and explodes in a 20-foot radius. Each creature in that area must make a Dexterity saving throw. On a failed save, a creature takes 10d4 acid damage and 5d4 acid damage at the end of its next turn. On a successful save, a creature takes half the initial damage and no damage at the end of its next turn.</text>
-      <text />
-      <text>At Higher Levels. When you cast this spell using a spell slot of 5th level or higher, the initial damage increases by 2d4 for each slot level above 4th.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>10d4</roll>
-	  <roll>5d4</roll>
-   </spell>
-   <spell>
-      <name>Wall of Sand (EE)</name>
-      <level>3</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>90 feet</range>
-      <components>V, S, M (a handful of sand)</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Wizard, Fighter (Eldritch Knight)</classes>
-      <text>You conjure up a wall of swirling sand on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 10 feet thick, and it vanishes when the spell ends. It blocks line of sight but not movement. A creature is blinded while in the wall's space and must spend 3 feet of movement for every 1 foot it moves there.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Wall of Water (EE)</name>
-      <level>3</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>60 feet</range>
-      <components>V, S, M (a drop of water)</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Druid, Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
-      <text>You conjure up a wall of water on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 1 foot thick, or you can make a ringed wall up to 20 feet in diameter, 20 feet high, and 1 foot thick. The wall vanishes when the spell ends. The wall's space is difficult terrain.</text>
-      <text />
-      <text>Any ranged weapon attack that enters the wall's space has disadvantage on the attack roll, and fire damage is halved if the fire effect passes through the wall to reach its target. Spells that deal cold damage that pass through the wall cause the area of the wall they pass through to freeze solid (at least a 5-foot square section is frozen). Each 5-foot-square frozen section has AC 5 and 15 hit points. Reducing a frozen section to 0 hit points destroys it. When a section is destroyed, the wall's water doesn't fill it.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Warding Wind (EE)</name>
-      <level>2</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>Self</range>
-      <components>V</components>
-      <duration>Concentration, up to 10 minutes</duration>
-      <classes>Bard, Druid, Sorcerer</classes>
-      <text>A strong wind (20 miles per hour) blows around you in a 10-foot radius and moves with you, remaining centered on you. The wind lasts for the spell's duration.</text>
-      <text />
-      <text>The wind has the following effects:</text>
-      <text />
-      <text>• It deafens you and other creatures in its area.</text>
-      <text />
-      <text>• It extinguishes unprotected flames in its area that are torch-sized or smaller.</text>
-      <text />
-      <text>• The area is difficult terrain for creatures other than you.</text>
-      <text />
-      <text>• The attack rolls of ranged weapon attacks have disadvantage if they pass in or out of the wind.</text>
-      <text />
-      <text>• It hedges out vapor, gas, and fog that can be dispersed by strong wind.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Watery Sphere (EE)</name>
-      <level>4</level>
-      <school>C</school>
-      <ritual />
-      <time>1 action</time>
-      <range>90 feet</range>
-      <components>V, S, M (a droplet of water)</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid, Sorcerer, Wizard</classes>
-      <text>You conjure up a sphere of water with a 10-foot radius on a point you can see within range. The sphere can hover in the air, but no more than 10 feet off the ground. The sphere remains for the spell's duration.</text>
-      <text />
-      <text>Any creature in the sphere's space must make a Strength saving throw. On a successful save, a creature is ejected from that space to the nearest unoccupied space outside it. A Huge or larger creature succeeds on the saving throw automatically. On a failed save, a creature is restrained by the sphere and is engulfed by the water. At the end of each of its turns, a restrained target can repeat the saving throw.</text>
-      <text />
-      <text>The sphere can restrain a maximum of four Medium or smaller creatures or one Large creature. If the sphere restrains a creature in excess of these numbers, a random creature that was already restrained by the sphere falls out of it and lands prone in a space within 5 feet of it.</text>
-      <text />
-      <text>As an action, you can move the sphere up to 30 feet in a straight line. If it moves over a pit, cliff, or other drop, it safely descends until it is hovering 10 feet over ground. Any creature restrained by the sphere moves with it. You can ram the sphere into creatures, forcing them to make the saving throw, but no more than once per turn.</text>
-      <text />
-      <text>When the spell ends, the sphere falls to the ground and extinguishes all normal flames within 30 feet of it. Any creature restrained by the sphere is knocked prone in the space where it falls.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-   </spell>
-   <spell>
-      <name>Whirlwind (EE)</name>
-      <level>7</level>
-      <school>EV</school>
-      <ritual />
-      <time>1 action</time>
-      <range>300 feet</range>
-      <components>V, M (a piece of straw)</components>
-      <duration>Concentration, up to 1 minute</duration>
-      <classes>Druid, Wizard</classes>
-      <text>A whirlwind howls down to a point on the ground you specify. The whirlwind is a 10-foot-radius, 30-foot-high cylinder centered on that point. Until the spell ends, you can use your action to move the whirlwind up to 30 feet in any direction along the ground. The whirlwind sucks up any Medium or smaller objects that aren't secured to anything and that aren't worn or carried by anyone.</text>
-      <text />
-      <text>A creature must make a Dexterity saving throw the first time on a turn that it enters the whirlwind or that the whirlwind enters its space, including when the whirlwind first appears. A creature takes 10d6 bludgeoning damage on a failed save, or half as much damage on a successful one. In addition, a Large or smaller creature that fails the save must succeed on a Strength saving throw or become restrained in the whirlwind until the spell ends. When a creature starts its turn restrained by the whirlwind, the creature is pulled 5 feet higher inside it, unless the creature is at the top. A restrained creature moves with the whirlwind and falls when the spell ends, unless the creature has some means to stay aloft.</text>
-      <text />
-      <text>A restrained creature can use an action to make a Strength or Dexterity check against your spell save DC. If successful, the creature is no longer restrained by the whirlwind and is hurled 3d6 x 10 feet away from it in a random direction.</text>
-      <text />
-      <text>This spell can be found in the Elemental Evil Player's Companion</text>
-	  <roll>10d6</roll>
-	  <roll>3d6*10</roll>
-	  <roll>1d8</roll>
-   </spell>
+<!--Spell Attack rolls assume PROF added to roll, not applicable for Ranged while engaged in Melee range-->
+<!--replaced ":" as intro to list with ".", and as in-line text with " - "-->
+	<spell>
+		<name>Abi-Dalzim's Horrid Wilting (EE)</name>
+		<level>8</level>
+		<school>N</school>
+		<ritual />
+		<time>1 action</time>
+		<range>150 feet</range>
+		<components>V, S, M (a bit of sponge)</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Wizard</classes>
+		<text>You draw the moisture from every creature in a 30-foot cube centered on a point you choose within range. Each creature in that area must make a Constitution saving throw. Constructs and undead aren't affected, and plants and water elementals make this saving throw with disadvantage. A creature takes 10d8 necrotic damage on a failed save, or half as much damage on a successful one.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>10d8</roll>
+	</spell>
+	<spell>
+		<name>Absorb Elements (EE)</name>
+		<level>1</level>
+		<school>A</school>
+		<ritual />
+		<time>1 reaction, which you take when you take acid, cold, fire, lightning, or thunder damage</time>
+		<range>Self</range>
+		<components>S</components>
+		<duration>1 round</duration>
+		<classes>Druid, Ranger, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>The spell captures some of the incoming energy, lessening its effect on you and storing it for your next melee attack. You have resistance to the triggering damage type until the start of your next turn. Also, the first time you hit with a melee attack on your next turn, the target takes an extra 1d6 damage of the triggering type, and the spell ends.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each slot level above 1st.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d6</roll>
+	</spell>
+	<spell>
+		<name>Aganazzar's Scorcher (EE)</name>
+		<level>2</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>V, S, M (a red dragon's scale)</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>A line of roaring flame 30 feet long and 5 feet wide emanates from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 3d8 fire damage on a failed save, or half as much damage on a successful one.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>3d8</roll>
+	</spell>
+	<spell>
+		<name>Beast Bond (EE)</name>
+		<level>1</level>
+		<school>D</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Touch</range>
+		<components>V, S, M (a bit of fur wrapped in a cloth)</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Ranger</classes>
+		<text>You establish a telepathic link with one beast you touch that is friendly to you or charmed by you. The spell fails if the beast's Intelligence is 4 or higher. Until the spell ends, the link is active while you and the beast are within line of sight of each other. Through the link, the beast can understand your telepathic messages to it, and it can telepathically communicate simple emotions and concepts back to you. While the link is active, the beast gains advantage on attack rolls against any creature within 5 feet of you that you can see.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Bones of the Earth (EE)</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid</classes>
+		<text>You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius. The rubble lasts until cleared.</text>
+		<text />
+		<text>If a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 7th level or higher, you can create</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Catapult (EE)</name>
+		<level>1</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>150 feet</range>
+		<components>S</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Wizard</classes>
+		<text>Choose one object weighing 1 to 5 pounds within range that isn't being worn or carried. The object flies in a straight line up to 90 feet in a direction you choose before falling to the ground, stopping early if it impacts against a solid surface. If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. In either case, both the object and the creature or solid surface take 3d8 bludgeoning damage.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, the maximum weight of objects that you can target with this spell increases by 5 pounds, and the damage</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>3d8</roll>
+	</spell>
+	<spell>
+		<name>Control Flames (EE)</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>S</components>
+		<duration>Instantaneous or 1 hour (see below)</duration>
+		<classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You choose nonmagical flame that you can see within range and that fits within a 5-foot cube. You affect it in one of the following ways.</text>
+		<text />
+		<text>You instantaneously expand the flame 5 feet in one direction, provided that wood or other fuel is present in the new location.</text>
+		<text />
+		<text>You instantaneously extinguish the flames within the cube.</text>
+		<text />
+		<text>You double or halve the area of bright light and dim light cast by the flame, change its color, or both. The change lasts for 1 hour.</text>
+		<text />
+		<text>You cause simple shapes-such as the vague form of a creature, an inanimate object, or a location-to appear within the flames and animate as you like. The shapes last for 1 hour.</text>
+		<text />
+		<text>If you cast this spell multiple times, you can have up to three of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Control Winds (EE)</name>
+		<level>5</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>300 feet</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 hour</duration>
+		<classes>Druid, Sorcerer, Wizard</classes>
+		<text>You take control of the air in a 100-foot cube that you can see within range. Choose one of the following effects when you cast the spell. The effect lasts for the spell's duration, unless you use your action on a later turn to switch to a different effect. You can also use your action to temporarily halt the effect or to restart one you've halted.</text>
+		<text />
+		<text>Gusts: A wind picks up within the cube, continually blowing in a horizontal direction that you choose. You choose the intensity of the wind - calm, moderate, or strong. If the wind is moderate or strong, ranged weapon attacks that pass through it or that are made against targets within the cube have disadvantage on their attack rolls. If the wind is strong, any creature moving against the wind must spend 1 extra foot of movement for each foot moved.</text>
+		<text />
+		<text>Downdraft: You cause a sustained blast of strong wind to blow downward from the top of the cube. Ranged weapon attacks that pass through the cube or that are made against targets within it have disadvantage on their attack rolls. A creature must make a Strength saving throw if it flies into the cube for the first time on a turn or starts its turn there flying. On a failed save, the creature is knocked prone.</text>
+		<text />
+		<text>Updraft: You cause a sustained updraft within the cube, rising upward from the cube's bottom edge. Creatures that end a fall within the cube take only half damage from the fall. When a creature in the cube makes a vertical jump, the creature can jump up to 10 feet higher than normal.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Create Bonfire (EE)</name>
+		<level>0</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You create a bonfire on ground that you can see within range. Until the spells ends, the bonfire fills a 5-foot cube. Any creature in the bonfire's space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage. A creature must also make the saving throw when it enters the bonfire's space for the first time on a turn or ends its turn there.</text>
+		<text />
+		<text>The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d8</roll>
+		<roll>2d8</roll>
+		<roll>3d8</roll>
+		<roll>4d8</roll>
+	</spell>
+	<spell>
+		<name>Dust Devil (EE)</name>
+		<level>2</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>V, S, M (a pinch of dust)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Sorcerer, Wizard</classes>
+		<text>Choose an unoccupied 5-foot cube of air that you can see within range. An elemental force that resembles a dust devil appears in the cube and lasts for the spell's duration.</text>
+		<text />
+		<text>Any creature that ends its turn within 5 feet of the dust devil must make a Strength saving throw. On a failed save, the creature takes 1d8 bludgeoning damage and is pushed 10 feet away. On a successful save, the creature takes half as much damage and isn't pushed.</text>
+		<text />
+		<text>As a bonus action, you can move the dust devil up to 30 feet in any direction. If the dust devil moves over sand, dust, loose dirt, or small gravel, it sucks up the material and forms a 10-foot-radius cloud of debris around itself that lasts until the start of your next turn. The cloud heavily obscures its area.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d8</roll>
+	</spell>
+	<spell>
+		<name>Earth Tremor (EE)</name>
+		<level>1</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self (10-foot radius)</range>
+		<components>V, S</components>
+		<duration>Instantaneous</duration>
+		<classes>Bard, Druid, Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You cause a tremor in the ground in a 10-foot radius. Each creature other than you in that area must make a Dexterity saving throw. On a failed save, a creature takes 1d6 bludgeoning damage and is knocked prone. If the ground in that area is loose earth or stone, it becomes difficult terrain until cleared.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d6</roll>
+	</spell>
+	<spell>
+		<name>Earthbind (EE)</name>
+		<level>2</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>300 feet</range>
+		<components>V</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Choose one creature you can see within range. Yellow strips of magical energy loop around the creature. The target must succeed on a Strength saving throw or its flying speed (if any) is reduced to 0 feet for the spell's duration. An airborne creature affected by this spell descends at 60 feet per round until it reaches the ground or the spell ends.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Elemental Bane (EE)</name>
+		<level>4</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Warlock, Wizard</classes>
+		<text>Choose one creature you can see within range, and choose one of the following damage types - acid, cold, fire, lightning, or thunder. The target must succeed on a Constitution saving throw or be affected by the spell for its duration. The first time each turn the affected target takes damage of the chosen type, the target takes an extra 2d6 damage of that type. Moreover, the target loses any resistance to that damage type until the spell ends.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>2d6</roll>
+	</spell>
+	<spell>
+		<name>Erupting Earth (EE)</name>
+		<level>3</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S, M (a piece of obsidian)</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Sorcerer, Wizard</classes>
+		<text>Choose a point you can see on the ground within range. A fountain of churned earth and stone erupts in a 20-foot cube centered on that point. Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared away. Each 5-foot-square portion of the area requires at least 1 minute to clear by hand.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d12 for each slot level above 2nd.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>3d12</roll>
+	</spell>
+	<spell>
+		<name>Flame Arrows (EE)</name>
+		<level>3</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Touch</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 hour</duration>
+		<classes>Druid, Ranger, Sorcerer, Wizard</classes>
+		<text>You touch a quiver containing arrows or bolts. When a target is hit by a ranged weapon attack using a piece of ammunition drawn from the quiver, the target takes an extra 1d6 fire damage. The spell's magic ends on the piece of ammunition when it hits or misses, and the spell ends when twelve pieces of ammunition have been drawn from the quiver.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 4th level or higher, the number of pieces of ammunition you can affect with this spell increases by two for each slot level above 3rd.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d6</roll>
+	</spell>
+	<spell>
+		<name>Frostbite (EE)</name>
+		<level>0</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>V, S</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You cause numbing frost to form on one creature that you can see within range. The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn.</text>
+		<text />
+		<text>The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d6</roll>
+		<roll>2d6</roll>
+		<roll>3d6</roll>
+		<roll>4d6</roll>
+	</spell>
+	<spell>
+		<name>Gust (EE)</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>V, S</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You seize the air and compel it to create one of the following effects at a point you can see within range.</text>
+		<text />
+		<text>• One Medium or smaller creature that you choose must succeed on a Strength saving throw or be pushed up to 5 feet away from you.</text>
+		<text />
+		<text>• You create a small blast of air capable of moving one object that is neither held nor carried and that weighs no more than 5 pounds. The object is pushed up to 10 feet away from you. It isn't pushed with enough force to cause damage.</text>
+		<text />
+		<text>• You create a harmless sensory affect using air, such as causing leaves to rustle, wind to slam shutters shut, or your clothing to ripple in a breeze.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Ice Knife (EE)</name>
+		<level>1</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>S, M (a drop of water or piece of ice)</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Sorcerer, Wizard</classes>
+		<text>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of the point where the ice exploded must succeed on a Dexterity saving throw or take 2d6 cold damage.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, the cold damage increases by 1d6 for each slot level above 1st.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d20+%0+%8</roll>
+		<roll>1d10</roll>
+	</spell>
+	<spell>
+		<name>Immolation (EE)</name>
+		<level>5</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Sorcerer, Wizard</classes>
+		<text>Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 7d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell's duration. The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. At the end of each of its turns, the target repeats the saving throw. It takes 3d6 fire damage on a failed save, and the spell ends on a successful one. These magical flames can't be extinguished through nonmagical means.</text>
+		<text />
+		<text>If damage from this spell reduces a target to 0 hit points, the target is turned to ash.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>7d6</roll>
+		<roll>3d6</roll>
+	</spell>
+	<spell>
+		<name>Investiture of Flame (EE)</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Flames race across your body, shedding bright light in a 30-foot radius and dim light for an additional 30 feet for the spell's duration. The flames don't harm you. Until the spell ends, you gain the following benefits.</text>
+		<text />
+		<text>• You are immune to fire damage and have resistance to cold damage.</text>
+		<text />
+		<text>• Any creature that moves within 5 feet of you for the first time on a turn or ends its turn there takes 1d10 fire damage.</text>
+		<text />
+		<text>• You can use your action to create a line of fire 15 feet long and 5 feet wide extending from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 4d8 fire damage on a failed save, or half as much damage on a successful one.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d10</roll>
+	</spell>
+	<spell>
+		<name>Investiture of Ice (EE)</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Until the spell ends, ice rimes your body, and you gain the following benefits.</text>
+		<text />
+		<text>• You are immune to cold damage and have resistance to fire damage.</text>
+		<text />
+		<text>• You can move across difficult terrain created by ice or snow without spending extra movement.</text>
+		<text />
+		<text>• The ground in a 10-foot radius around you is icy and is difficult terrain for creatures other than you. The radius moves with you.</text>
+		<text />
+		<text>• You can use your action to create a 15-foot cone of freezing wind extending from your outstretched hand in a direction you choose. Each creature in the cone must make a Constitution saving throw. A creature takes 4d6 cold damage on a failed save, or half as much damage on a successful one. A creature that fails its save against this effect has its speed halved until the start of your next turn.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Investiture of Stone (EE)</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Until the spell ends, bits of rock spread across your body, and you gain the following benefits.</text>
+		<text />
+		<text>• You have resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons.</text>
+		<text />
+		<text>• You can use your action to create a small earthquake on the ground in a 15-foot radius centered on you. Other creatures on that ground must succeed on a Dexterity saving throw or be knocked prone.</text>
+		<text />
+		<text>• You can move across difficult terrain made of earth or stone without spending extra movement. You can move through solid earth or stone as if it was air and without destabilizing it, but you can't end your movement there. If you do so, you are ejected to the nearest unoccupied space, this spell ends, and you are stunned until the end of your next turn.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Investiture of Wind (EE)</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Until the spell ends, wind whirls around you, and you gain the following benefits.</text>
+		<text />
+		<text>• Ranged weapon attacks made against you have disadvantage on the attack roll.</text>
+		<text />
+		<text>• You gain a flying speed of 60 feet. If you are still flying when the spell ends, you fall, unless you can somehow prevent it.</text>
+		<text />
+		<text>• You can use your action to create a 15-foot cube of swirling wind centered on a point you can see within 60 feet of you. Each creature in that area must make a Constitution saving throw. A creature takes 2d10 bludgeoning damage on a failed save, or half as much damage on a successful one. If a Large or smaller creature fails the save, that creature is also pushed up to 10 feet away from the center of the cube.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>2d10</roll>
+	</spell>
+	<spell>
+		<name>Maelstrom (EE)</name>
+		<level>5</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S, M (paper or leaf in the shape of a funnel)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid</classes>
+		<text>A mass of 5-foot-deep water appears and swirls in a 30-foot radius centered on a point you can see within range. The point must be on ground or in a body of water. Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>6d6</roll>
+	</spell>
+	<spell>
+		<name>Magic Stone (EE)</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 bonus action</time>
+		<range>Touch</range>
+		<components>V, S</components>
+		<duration>1 minute</duration>
+		<classes>Druid, Warlock</classes>
+		<text>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker's, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</text>
+		<text />
+		<text>If you cast this spell again, the spell ends early on any pebbles still affected by it.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d20+%0+%8</roll>
+		<roll>1d6+%0</roll>
+	</spell>
+	<spell>
+		<name>Maximilian's Earthen Grasp (EE)</name>
+		<level>2</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>V, S, M (a miniature hand sculpted from clay)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Sorcerer, Wizard</classes>
+		<text>You choose a 5-foot-square unoccupied space on the ground that you can see within range. A Medium hand made from compacted soil rises there and reaches for one creature you can see within 5 feet of it. The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell's duration.</text>
+		<text />
+		<text>As an action, you can cause the hand to crush the restrained target, who must make a Strength saving throw. It takes 2d6 bludgeoning damage on a failed save, or half as much damage on a successful one.</text>
+		<text />
+		<text>To break out, the restrained target can make a Strength check against your spell save DC. On a success, the target escapes and is no longer restrained by the hand.</text>
+		<text />
+		<text>As an action, you can cause the hand to reach for a different creature or to move to a different unoccupied space within range. The hand releases a restrained target if you do either.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>2d6</roll>
+	</spell>
+	<spell>
+		<name>Melf's Minute Meteors (EE)</name>
+		<level>3</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S, M (niter, sulfur, and pine tar formed into a bead)</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You create six tiny meteors in your space. They float in the air and orbit you for the spell's duration. When you cast the spell-and as a bonus action on each of your turns thereafter-you can expend one or two of the meteors, sending them streaking toward a point or points you choose within 120 feet of you. Once a meteor reaches its destination or impacts against a solid surface, the meteor explodes. Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 4th level or higher, the number of meteors created increases by two for each slot level above 3rd.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>2d6</roll>
+	</spell>
+	<spell>
+		<name>Mold Earth (EE)</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>S</components>
+		<duration>Instantaneous or 1 hour (see below)</duration>
+		<classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You choose a portion of dirt or stone that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways.</text>
+		<text />
+		<text>• If you target an area of loose earth, you can instantaneously excavate it, move it along the ground, and deposit it up to 5 feet away. This movement doesn't have enough force to cause damage.</text>
+		<text />
+		<text>• You cause shapes, colors, or both to appear on the dirt or stone, spelling out words, creating images, or shaping patterns. The changes last for 1 hour.</text>
+		<text />
+		<text>• If the dirt or stone you target is on the ground, you cause it to become difficult terrain. Alternatively, you can cause the ground to become normal terrain if it is already difficult terrain. This change lasts for 1 hour.</text>
+		<text />
+		<text>If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Primordial Ward (EE)</name>
+		<level>6</level>
+		<school>A</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid</classes>
+		<text>You have resistance to acid, cold, fire, lightning, and thunder damage for the spell's duration.</text>
+		<text />
+		<text>When you take damage of one of those types, you can use your reaction to gain immunity to that type of damage, including against the triggering damage. If you do so, the resistances end, and you have the immunity until the end of your next turn, at which time the spell ends.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Pyrotechnics (EE)</name>
+		<level>2</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>V, S</components>
+		<duration>Instantaneous</duration>
+		<classes>Bard, Sorcerer, Wizard</classes>
+		<text>Choose an area of flame that you can see and that can fit within a 5-foot cube within range. You can extinguish the fire in that area, and you create either fireworks or smoke.</text>
+		<text />
+		<text>Fireworks: The target explodes with a dazzling display of colors. Each creature within 10 feet of the target must succeed on a Constitution saving throw or become blinded until the end of your next turn.</text>
+		<text />
+		<text>Smoke: Thick black smoke spreads out from the target in a 20-foot radius, moving around corners. The area of the smoke is heavily obscured. The smoke persists for 1 minute or until a strong wind disperses it.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Shape Water (EE)</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>S</components>
+		<duration>Instantaneous or 1 hour (see below)</duration>
+		<classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You choose an area of water that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways.</text>
+		<text />
+		<text>• You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn't have enough force to cause damage.</text>
+		<text />
+		<text>• You cause the water to form into simple shapes and animate at your direction. This change lasts for 1 hour.</text>
+		<text />
+		<text>• You change the water's color or opacity. The water must be changed in the same way throughout. This change lasts for 1 hour.</text>
+		<text />
+		<text>• You freeze the water, provided that there are no creatures in it. The water unfreezes in 1 hour.</text>
+		<text />
+		<text>If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Skywrite (EE)</name>
+		<level>2</level>
+		<school>T</school>
+		<ritual>YES</ritual>
+		<time>1 action</time>
+		<range>Sight</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 hour</duration>
+		<classes>Bard, Druid, Wizard</classes>
+		<text>You cause up to ten words to form in a part of the sky you can see. The words appear to be made of cloud and remain in place for the spell's duration. The words dissipate when the spell ends. A strong wind can disperse the clouds and end the spell early.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Snilloc's Snowball Swarm (EE)</name>
+		<level>2</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V, S, M (a piece of ice or a small white rock chip)</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>A flurry of magic snowballs erupts from a point you choose within range. Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>3d6</roll>
+	</spell>
+	<spell>
+		<name>Storm Sphere (EE)</name>
+		<level>4</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>150 feet</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell's duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere's space is difficult terrain.</text>
+		<text />
+		<text>Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</text>
+		<text />
+		<text>Creatures within 30 feet of the sphere have disadvantage on Wisdom (Perception) checks made to listen.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 5th level or higher, the damage increases for each of its effects by 1d6 for each slot level above 4th</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d20+%0+%8</roll>
+		<roll>2d6</roll>
+		<roll>4d6</roll>
+	</spell>
+	<spell>
+		<name>Thunderclap (EE)</name>
+		<level>0</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self (5-foot radius)</range>
+		<components>S</components>
+		<duration>Instantaneous</duration>
+		<classes>Bard, Druid, Sorcerer, Warlock, Wizard, , Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You create a burst of thunderous sound, which can be heard 100 feet away. Each creature other than you within 5 feet of you must make a Constitution saving throw. On a failed save, the creature takes 1d6 thunder damage.</text>
+		<text />
+		<text>The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>1d6</roll>
+		<roll>2d6</roll>
+		<roll>3d6</roll>
+		<roll>4d6</roll>
+	</spell>
+	<spell>
+		<name>Tidal Wave (EE)</name>
+		<level>3</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S, M (a drop of water)</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Wizard</classes>
+		<text>You conjure up a wave of water that crashes down on an area within range. The area can be up to 30 feet long, up to 10 feet wide, and up to 10 feet tall. Each creature in that area must make a Dexterity saving throw. On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone. On a success, a creature takes half as much damage and isn't knocked prone. The water then spreads out across the ground in all directions, extinguishing unprotected flames in its area and within 30 feet of it.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>4d8</roll>
+	</spell>
+	<spell>
+		<name>Transmute Rock (EE)</name>
+		<level>5</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S, M (clay and water)</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Wizard</classes>
+		<text>You choose an area of stone or mud that you can see that fits within a 40-foot cube and that is within range, and choose one of the following effects.</text>
+		<text />
+		<text>Transmute Rock to Mud: Nonmagical rock of any sort in the area becomes an equal volume of thick and flowing mud that remains for the spell's duration.</text>
+		<text />
+		<text>If you cast the spell on an area of ground, it becomes muddy enough that creatures can sink into it. Each foot that a creature moves through the mud costs 4 feet of movement, and any creature on the ground when you cast the spell must make a Strength saving throw. A creature must also make this save the first time it enters the area on a turn or ends its turn there. On a failed save, a creature sinks into the mud and is restrained, though it can use an action to end the restrained condition on itself by pulling itself free of the mud.</text>
+		<text />
+		<text>If you cast the spell on a ceiling, the mud falls. Any creature under the mud when it falls must make a Dexterity saving throw. A creature takes 4d8 bludgeoning damage on a failed save, or half as much damage on a successful one.</text>
+		<text />
+		<text>Transmute Mud to Rock: Nonmagical mud or quicksand in the area no more than 10 feet deep transforms into soft stone for the spell's duration. Any creature in the mud when it transforms must make a Dexterity saving throw. On a failed save, a creature becomes restrained by the rock. The restrained creature can use an action to try to break free by succeeding on a Strength check (DC 20) or by dealing 25 damage to the rock around it. On a successful save, a creature is shunted safely to the surface to an unoccupied space.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>4d8</roll>
+	</spell>
+	<spell>
+		<name>Vitriolic Sphere (EE)</name>
+		<level>4</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>150 feet</range>
+		<components>V, S, M (a drop of giant slug bile)</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You point at a place within range, and a glowing 1-foot ball of emerald acid streaks there and explodes in a 20-foot radius. Each creature in that area must make a Dexterity saving throw. On a failed save, a creature takes 10d4 acid damage and 5d4 acid damage at the end of its next turn. On a successful save, a creature takes half the initial damage and no damage at the end of its next turn.</text>
+		<text />
+		<text>At Higher Levels: When you cast this spell using a spell slot of 5th level or higher, the initial damage increases by 2d4 for each slot level above 4th.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>10d4</roll>
+		<roll>5d4</roll>
+	</spell>
+	<spell>
+		<name>Wall of Sand (EE)</name>
+		<level>3</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V, S, M (a handful of sand)</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You conjure up a wall of swirling sand on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 10 feet thick, and it vanishes when the spell ends. It blocks line of sight but not movement. A creature is blinded while in the wall's space and must spend 3 feet of movement for every 1 foot it moves there.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Wall of Water (EE)</name>
+		<level>3</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>V, S, M (a drop of water)</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You conjure up a wall of water on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 1 foot thick, or you can make a ringed wall up to 20 feet in diameter, 20 feet high, and 1 foot thick. The wall vanishes when the spell ends. The wall's space is difficult terrain.</text>
+		<text />
+		<text>Any ranged weapon attack that enters the wall's space has disadvantage on the attack roll, and fire damage is halved if the fire effect passes through the wall to reach its target. Spells that deal cold damage that pass through the wall cause the area of the wall they pass through to freeze solid (at least a 5-foot square section is frozen). Each 5-foot-square frozen section has AC 5 and 15 hit points. Reducing a frozen section to 0 hit points destroys it. When a section is destroyed, the wall's water doesn't fill it.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Warding Wind (EE)</name>
+		<level>2</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Bard, Druid, Sorcerer</classes>
+		<text>A strong wind (20 miles per hour) blows around you in a 10-foot radius and moves with you, remaining centered on you. The wind lasts for the spell's duration.</text>
+		<text />
+		<text>The wind has the following effects.</text>
+		<text />
+		<text>• It deafens you and other creatures in its area.</text>
+		<text />
+		<text>• It extinguishes unprotected flames in its area that are torch-sized or smaller.</text>
+		<text />
+		<text>• The area is difficult terrain for creatures other than you.</text>
+		<text />
+		<text>• The attack rolls of ranged weapon attacks have disadvantage if they pass in or out of the wind.</text>
+		<text />
+		<text>• It hedges out vapor, gas, and fog that can be dispersed by strong wind.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Watery Sphere (EE)</name>
+		<level>4</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V, S, M (a droplet of water)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Sorcerer, Wizard</classes>
+		<text>You conjure up a sphere of water with a 10-foot radius on a point you can see within range. The sphere can hover in the air, but no more than 10 feet off the ground. The sphere remains for the spell's duration.</text>
+		<text />
+		<text>Any creature in the sphere's space must make a Strength saving throw. On a successful save, a creature is ejected from that space to the nearest unoccupied space outside it. A Huge or larger creature succeeds on the saving throw automatically. On a failed save, a creature is restrained by the sphere and is engulfed by the water. At the end of each of its turns, a restrained target can repeat the saving throw.</text>
+		<text />
+		<text>The sphere can restrain a maximum of four Medium or smaller creatures or one Large creature. If the sphere restrains a creature in excess of these numbers, a random creature that was already restrained by the sphere falls out of it and lands prone in a space within 5 feet of it.</text>
+		<text />
+		<text>As an action, you can move the sphere up to 30 feet in a straight line. If it moves over a pit, cliff, or other drop, it safely descends until it is hovering 10 feet over ground. Any creature restrained by the sphere moves with it. You can ram the sphere into creatures, forcing them to make the saving throw, but no more than once per turn.</text>
+		<text />
+		<text>When the spell ends, the sphere falls to the ground and extinguishes all normal flames within 30 feet of it. Any creature restrained by the sphere is knocked prone in the space where it falls.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+	</spell>
+	<spell>
+		<name>Whirlwind (EE)</name>
+		<level>7</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>300 feet</range>
+		<components>V, M (a piece of straw)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Wizard</classes>
+		<text>A whirlwind howls down to a point on the ground you specify. The whirlwind is a 10-foot-radius, 30-foot-high cylinder centered on that point. Until the spell ends, you can use your action to move the whirlwind up to 30 feet in any direction along the ground. The whirlwind sucks up any Medium or smaller objects that aren't secured to anything and that aren't worn or carried by anyone.</text>
+		<text />
+		<text>A creature must make a Dexterity saving throw the first time on a turn that it enters the whirlwind or that the whirlwind enters its space, including when the whirlwind first appears. A creature takes 10d6 bludgeoning damage on a failed save, or half as much damage on a successful one. In addition, a Large or smaller creature that fails the save must succeed on a Strength saving throw or become restrained in the whirlwind until the spell ends. When a creature starts its turn restrained by the whirlwind, the creature is pulled 5 feet higher inside it, unless the creature is at the top. A restrained creature moves with the whirlwind and falls when the spell ends, unless the creature has some means to stay aloft.</text>
+		<text />
+		<text>A restrained creature can use an action to make a Strength or Dexterity check against your spell save DC. If successful, the creature is no longer restrained by the whirlwind and is hurled 3d6 x 10 feet away from it in a random direction.</text>
+		<text />
+		<text>This spell can be found in the Elemental Evil Player's Companion</text>
+		<roll>10d6</roll>
+		<roll>3d6*10</roll>
+		<roll>1d8</roll>
+	</spell>
 </spells>


### PR DESCRIPTION
Spell Attack rolls assume PROF added to roll, not applicable for Ranged while engaged in Melee range
replaced ":" as intro to list with ".", and as in-line text with " - "
