### PR TITLE
Fix a bunch of formatting stuff, include fixes for some classes

### DIFF
--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -1227,7 +1227,7 @@
 				<text>Druids of the Circle of the Moon are fierce guardians of the wilds. Their order gathers under the full moon to share news and trade warnings. They haunt the deepest parts of the wilderness, where they might go for weeks on end before crossing paths with another humanoid creature, let alone another druid.</text>
 				<text> </text>
 				<text>Changeable as the moon, a druid of this circle might prowl as a great cat one night, soar over the treetops as an eagle the next day, and crash through the undergrowth in bear form to drive off a trespassing monster. The wild is in the druid's blood.</text>
-			</feature>	
+			</feature>
 			<feature optional="YES">
 				<name>Circle of Land: Bonus Cantrip</name>
 				<text>You learn one additional druid cantrip of your choice.</text>
@@ -1770,7 +1770,7 @@
 			</feature>
 		</autolevel>
 	</class>
-<!--Battlemaster Spells-->
+	<!--Battlemaster Spells-->
 	<spell>
 		<name>Commander's Strike</name>
 		<level>1</level>
@@ -2098,14 +2098,14 @@
 				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="9">
 			<feature>
 				<name>Unarmored Movement (Vertical Surfaces)</name>
 				<text>You gain the ability to move along vertical surfaces and across liquids on your turn without falling during the move.</text>
 			</feature>
-		</autolevel>	
-		
+		</autolevel>
+
 		<autolevel level="10">
 			<feature>
 				<name>Purity of Body</name>
@@ -2141,8 +2141,8 @@
 				<text> </text>
 				<text>Whenever you learn a new elemental discipline, you can also replace one elemental discipline that you already know with a different discipline.</text>
 			</feature>
-		</autolevel>					
-		
+		</autolevel>
+
 		<autolevel level="12">
 			<feature>
 				<name>Ability Score Improvement</name>
@@ -2185,13 +2185,13 @@
 				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="17">
 			<feature>
 				<name>Martial Arts (1d10)</name>
 				<text>You can  now roll a d10 in the place of the normal damage of your unarmed strike or monk weapon.</text>
 			</feature>
-			<feature optional="YES">			
+			<feature optional="YES">
 				<name>Way of Shadow: Opportunist</name>
 				<text>At 17th level, you can exploit a creature's momentary distraction when it is hit by an attack. Whenever a creature within 5 feet of you is hit by an attack made by a creature other than you, you can use your reaction to make a melee attack against that creature.</text>
 			</feature>
@@ -2207,8 +2207,8 @@
 				<text> </text>
 				<text>Whenever you learn a new elemental discipline, you can also replace one elemental discipline that you already know with a different discipline.</text>
 			</feature>
-		</autolevel>				
-		
+		</autolevel>
+
 		<autolevel level="18">
 			<feature>
 				<name>Empty Body</name>
@@ -2237,7 +2237,7 @@
 			</feature>
 		</autolevel>
 	</class>
-<!--Elemental Monk Spells-->
+	<!--Elemental Monk Spells-->
 	<spell>
 		<name>Breath of Winter (17th level required)</name>
 		<level>4</level>
@@ -2471,7 +2471,7 @@
 		<text/>
 		<text>If you maintain your concentration on this spell for its whole duration, the wall becomes permanent and can't be dispelled. Otherwise, the wall disappears when the spell ends.</text>
 	</spell>
-<!--Shadow Monk Spells-->
+	<!--Shadow Monk Spells-->
 	<spell>
 		<name>Darkness (Monk)</name>
 		<level>1</level>
@@ -2537,7 +2537,7 @@
 		<text/>
 		<text>If a creature uses its action to examine the sound or image, the creature can determine that it is an illusion with a successful Intelligence (Investigation) check against your spell save DC. If a creature discerns the illusion for what it is, the illusion becomes faint to the creature.</text>
 	</spell>
-		
+
 	<class>
 		<name>Paladin</name>
 		<hd>8</hd>
@@ -2656,7 +2656,7 @@
 				<name>Sacred Oath</name>
 				<text>When you reach 3rd level, you swear the oath that binds you as a paladin forever. Up to this time you have been in a preparatory stage, committed to the path but not yet sworn to it. Now you choose the Oath of Devotion, the Oath of the Ancients, ar the Oath of Vengeance, all detailed at the end of the c1ass description.</text>
 				<text>    Your choice grants you features at 3rd level and again at 7th, 15th, and 20th level. Those features include oath spells and the Channel Divinity feature.</text>
-				</feature>
+			</feature>
 			<feature optional="YES">
 				<name>Oath of the Ancients Channel Divinity: Nature's Wrath</name>
 				<text>You can use your Channel Divinity to invoke primeval forces to ensnare a foe. As an action, you can cause spectral vines to spring up and reach for a creature within 10 feet of you that you can see. The creature must succeed on a Strength or Dexterity saving throw (its choice) or be restrained. While restrained by the vines, the creature repeats the saving throw at the end of each of its turns. On a success, it frees itself and the vines vanish.</text>
@@ -2772,8 +2772,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Oathbreaker: Aura of Hate</name>
-				<text>Starting at 7th level, the paladin, as well any fiends and undead within 10 feet of the paladin, gains a bonus
-to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum of +1). A creature can benefit from this feature from only one paladin at a time.</text>
+				<text>Starting at 7th level, the paladin, as well any fiends and undead within 10 feet of the paladin, gains a bonus to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum of +1). A creature can benefit from this feature from only one paladin at a time.</text>
 				<text>    At 18th level, the range of this aura increases to 30 feet.</text>
 			</feature>
 		</autolevel>
@@ -3022,11 +3021,11 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 			<feature optional="YES">
 				<name>Ranger Archetype: Hunter</name>
 				<text>Emulating the Hunter archetype means accepting your place as a bulwark between civilization and the terrors of the wilderness. As you walk the Hunter's path, you learn specialized techniques for fighting the threats you face, from rampaging ogres and hordes of orc s to towering giants and terrifying dragons.</text>
-			</feature>	
+			</feature>
 			<feature optional="YES">
 				<name>Ranger Archetype: Beast Master</name>
 				<text>The Beast Master archetype embodies a friendship between the civilized races and the beasts of the world. United in focus, beast and ranger work as one to fight the monstrous foes that threaten civilization and the wilderness alike. Emulating the Beast Master archetype means committing yourself to this ideal, working in partnership with an animal as its companion and friend.</text>
-			</feature>		
+			</feature>
 			<feature optional="YES">
 				<name>Hunter: Hunter's Prey</name>
 				<text>At 3rd level, you gain one of the following features of your choice: Colossus Slayer, Giant Killer, or Horde Breaker.</text>
@@ -3070,7 +3069,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="6">
 			<feature>
 				<name>Additional Favored Terrains</name>
@@ -3081,7 +3080,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>You choose one additional favored enemy, as well as an associated language. Your choice should reflect the types of monsters you have encountered on your adventures.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="7">
 			<feature optional="YES">
 				<name>Hunter: Defensive Tactics</name>
@@ -3131,18 +3130,18 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 		</autolevel>
 
 		<autolevel level="11">
-		<feature optional="YES">
-			<name>Hunter: Multiattack</name>
-			<text>At 11th level, you gain one of the following features of your choice: Volley or Whirlwind Attack.</text>
-		</feature>
-		<feature optional="YES">
-			<name>Multiattack: Volley</name>
-			<text>You can use your action to make a ranged attack against any number of creatures within 10 feet of a point you can see within your weapon's range. You must have ammunition for each target, as normal, and you make a separate attack roll for each target. </text>
-		</feature>
-		<feature optional="YES">
-			<name>Multiattack: Whirlwind Attack</name>
-			<text>You can use your action to make a melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</text>
-		</feature>
+			<feature optional="YES">
+				<name>Hunter: Multiattack</name>
+				<text>At 11th level, you gain one of the following features of your choice: Volley or Whirlwind Attack.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Multiattack: Volley</name>
+				<text>You can use your action to make a ranged attack against any number of creatures within 10 feet of a point you can see within your weapon's range. You must have ammunition for each target, as normal, and you make a separate attack roll for each target. </text>
+			</feature>
+			<feature optional="YES">
+				<name>Multiattack: Whirlwind Attack</name>
+				<text>You can use your action to make a melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</text>
+			</feature>
 			<feature optional="YES">
 				<name>Beast Master: Bestial Fury</name>
 				<text>Your beast companion can make two attacks when you command it to use the Attack action.</text>
@@ -3221,7 +3220,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 			</feature>
 		</autolevel>
 	</class>
-	
+
 	<class>
 		<name>Ranger (Variant)</name>
 		<hd>10</hd>
@@ -3346,7 +3345,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 			<feature optional="YES">
 				<name>Maneuver: Trip Attack</name>
 				<text>When you hit a creature with a weapon attack, you can expend one superiority die to attempt to knock the target down. You add the superiority die to the attack's damage roll, and if the target is Large or smaller, it must make a Strength saving throw. On a failed save, you knock the target prone.</text>
-			</feature>	
+			</feature>
 			<feature>
 				<name>Fighting Style</name>
 				<text>At 2nd level, you adopt a particular style of fighting as your specialty. Choose one of the following options: Archery, Defense, Dueling, Mariner, or Two-Weapon Fighting. You can't take a Fighting Style option more than once, even if you later get to choose again.</text>
@@ -3387,7 +3386,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 			<feature optional="YES">
 				<name>Ranger Archetype: Hunter</name>
 				<text>Emulating the Hunter archetype means accepting your place as a bulwark between civilization and the terrors of the wilderness. As you walk the Hunter's path, you learn specialized techniques for fighting the threats you face, from rampaging ogres and hordes of orc s to towering giants and terrifying dragons.</text>
-			</feature>	
+			</feature>
 			<feature optional="YES">
 				<name>Hunter: Hunter's Prey</name>
 				<text>At 3rd level, you gain one of the following features of your choice: Colossus Slayer, Giant Killer, or Horde Breaker.</text>
@@ -3499,7 +3498,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>When you hit a creature with a weapon attack, you can expend one superiority die to attempt to knock the target down. You add the superiority die to the attack's damage roll, and if the target is Large or smaller, it must make a Strength saving throw. On a failed save, you knock the target prone.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="6">
 			<feature>
 				<name>Additional Favored Terrains</name>
@@ -3510,7 +3509,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>You choose one additional favored enemy, as well as an associated language. Your choice should reflect the types of monsters you have encountered on your adventures.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="7">
 			<feature optional="YES">
 				<name>Hunter: Defensive Tactics</name>
@@ -3621,7 +3620,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>When you hit a creature with a weapon attack, you can expend one superiority die to attempt to knock the target down. You add the superiority die to the attack's damage roll, and if the target is Large or smaller, it must make a Strength saving throw. On a failed save, you knock the target prone.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="10">
 			<feature>
 				<name>Hide in Plain Sight</name>
@@ -3631,7 +3630,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 			<feature>
 				<name>Additional Favored Terrains</name>
 				<text>You gain an additional favored terrain.</text>
-			</feature>			
+			</feature>
 		</autolevel>
 
 		<autolevel level="11">
@@ -3660,7 +3659,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="13">
 			<feature>
 				<name>Call Natural Allies</name>
@@ -3743,7 +3742,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>When you hit a creature with a weapon attack, you can expend one superiority die to attempt to knock the target down. You add the superiority die to the attack's damage roll, and if the target is Large or smaller, it must make a Strength saving throw. On a failed save, you knock the target prone.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="14">
 			<feature>
 				<name>Vanish</name>
@@ -3785,7 +3784,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="17">
 			<feature>
 				<name>Relentless</name>
@@ -3860,7 +3859,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>When you hit a creature with a weapon attack, you can expend one superiority die to attempt to knock the target down. You add the superiority die to the attack's damage roll, and if the target is Large or smaller, it must make a Strength saving throw. On a failed save, you knock the target prone.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="18">
 			<feature>
 				<name>Feral Senses</name>
@@ -4386,7 +4385,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>9th — flame strike, hold monster</text>
 			</feature>
 			<feature optional="YES">
-			<name>Dragon Ancestor</name>
+				<name>Dragon Ancestor</name>
 				<text>At 1st level, you choose one type of dragon as your ancestor. The damage type associated with each dragon is used by features you gain later.</text>
 				<text> </text>
 				<text>chose one and delete the others</text>
@@ -4956,7 +4955,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>You learn an additional eldritch invocation</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="8">
 			<feature>
 				<name>Ability Score Improvement</name>
@@ -4971,7 +4970,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>You learn an additional eldritch invocation</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="10">
 			<feature optional="YES">
 				<name>The Archfey: Beguiling Defenses</name>
@@ -5015,7 +5014,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>    You can cast your arcanum spell once without expending a spell slot. You must finish a long rest before you can do so again.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="14">
 			<feature optional="YES">
 				<name>The Archfey: Dark Delirium</name>
@@ -5047,7 +5046,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>    You can cast your arcanum spell once without expending a spell slot. You must finish a long rest before you can do so again.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="16">
 			<feature>
 				<name>Ability Score Improvement</name>
@@ -5063,14 +5062,14 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>    You can cast your arcanum spell once without expending a spell slot. You must finish a long rest before you can do so again.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="18">
 			<feature>
 				<name>Eldritch Invocation</name>
 				<text>You learn an additional eldritch invocation</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="19">
 			<feature>
 				<name>Ability Score Improvement</name>
@@ -5265,7 +5264,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>You can communicate telepathically with your familiar and perceive through your familiar's senses as long as you are on the same plane of existence. Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="7">
 			<feature optional="YES">
 				<name>Eldritch Invocation: Agonizing Blast</name>
@@ -5385,7 +5384,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>You can communicate telepathically with your familiar and perceive through your familiar's senses as long as you are on the same plane of existence. Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="9">
 			<feature optional="YES">
 				<name>Eldritch Invocation: Agonizing Blast</name>
@@ -5529,7 +5528,7 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<text>You can cast speak with dead at will, without expending a spell slot.</text>
 			</feature>
 		</autolevel>
-		
+
 		<autolevel level="12">
 			<feature optional="YES">
 				<name>Eldritch Invocation: Agonizing Blast</name>
@@ -6093,14 +6092,14 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 				<name>Arcane Tradition: Artificer</name>
 				<text>Artificers are a key part of the world of Eberron. They illustrate the evolution of magic from a wild, unpredictable force to one that is becoming available to the masses. Magic items are part of everyday life in the Five Nations of Khorvaire; with an artificer in your party, they become part of every adventuring expedition.</text>
 				<text></text>
-				<text>The artificer was a separate class in prior editions of the Eberron setting, a melee combatant who specialized in mystically enhanced arms and armor. The fifth edition rules treat the artificer as a new wizard tradition that focuses on mystical invention, which you can choose starting at 2nd level.</text>				
-			</feature>			
+				<text>The artificer was a separate class in prior editions of the Eberron setting, a melee combatant who specialized in mystically enhanced arms and armor. The fifth edition rules treat the artificer as a new wizard tradition that focuses on mystical invention, which you can choose starting at 2nd level.</text>
+			</feature>
 			<feature optional="YES">
 				<name>Arcane Tradition: Abjuration</name>
 				<text>The School of Abjuration emphasizes magic that blocks, banishes, or protects. Detractors of this school say that its tradition is about denial, negation rather than positive assertion. You understand, however, that ending harmful effects, protecting the weak, and banishing evil influences is anything but a philosophical void. It is a proud and respected vocation.</text>
 				<text> </text>
 				<text>Called abjurers, members of this school are sought when baleful spirits require exorcism, when important locations must be guarded against magical spying, and when portals to other planes of existence must be closed.</text>
-			</feature>			
+			</feature>
 			<feature optional="YES">
 				<name>Arcane Tradition: Conjuration</name>
 				<text>As a conjurer, you favor spells that produce objects and creatures out of thin air. You can conjure billowing clouds of killing fog or summon creatures from elsewhere to fight on your behalf. As your mastery grows, you learn spells of transportation and can teleport yourself across vast distances, even to other planes of existence, in an instant.</text>
@@ -6108,31 +6107,31 @@ to melee weapon damage rolls equal to the paladin's Charisma modifier (minimum o
 			<feature optional="YES">
 				<name>Arcane Tradition: Divination</name>
 				<text>The counsel of a diviner is sought by royalty and commoners alike, for all seek a clearer understanding of the past, present, and future. As a diviner, you strive to part the veils of space, time, and consciousness so that you can see clearly. You work to master spells of discernment, remote viewing, supernatural knowledge, and foresight.</text>
-			</feature>			
+			</feature>
 			<feature optional="YES">
 				<name>Arcane Tradition: Enchantment</name>
 				<text>As a member of the School of Enchantment, you have honed your ability to magically entrance and beguile other people and monsters. Some enchanters are peacemakers who bewitch the violent to lay down their arms and charm the cruel into showing mercy. Others are tyrants who magically bind the unwilling into their service. Most enchanters fall somewhere in between.</text>
-			</feature>			
+			</feature>
 			<feature optional="YES">
 				<name>Arcane Tradition: Evocation</name>
 				<text>You focus your study on magic that creates powerful elemental effects such as bitter cold, searing flame, rolling thunder, crackling lightning, and burning acid. Some evokers find employment in military forces, serving as artillery to blast enemy armies from afar. Others use their spectacular power to protect the weak, while some seek their own gain as bandits, adventurers, or aspiring tyrants.</text>
-			</feature>			
+			</feature>
 			<feature optional="YES">
 				<name>Arcane Tradition: Illusion</name>
 				<text>You focus your studies on magic that dazzles the senses, befuddles the mind, and tricks even the wisest folk. Your magic is subtle, but the illusions crafted by your keen mind make the impossible seem real. Some illusionists - including many gnome wizards - are benign tricksters who use their spells to entertain. Others are more sinister masters of deception, using their illusions to frighten and fool others for their personal gain.</text>
-			</feature>			
+			</feature>
 			<feature optional="YES">
 				<name>Arcane Tradition: Transmutation</name>
 				<text>You are a student of spells that modify energy and matter. To you, the world is not a fixed thing, but eminently mutable, and you delight in being an agent of change. You wield the raw stuff of creation and learn to alter both physical forms and mental qualities. Your magic gives you the tools to become a smith on reality's forge.</text>
 				<text> </text>
 				<text>Some transmuters are tinkerers and pranksters, turning people into toads and transforming copper into silver for fun and occasional profit. Others pursue their magical studies with deadly seriousness, seeking the power of the gods to make and destroy worlds.</text>
-			</feature>			
+			</feature>
 			<feature optional="YES">
 				<name>Arcane Tradition: Necromancy</name>
 				<text>The School of Necromancy explores the cosmic forces of life, death, and undeath. As you focus your studies in this tradition, you learn to manipulate the energy that animates all living things. As you progress, you learn to sap the life force from a creature as your magic destroys its body, transforming that vital energy into magical power you can manipulate.</text>
 				<text> </text>
 				<text>Most people see necromancers as menacing, or even villainous, due to the close association with death. Not all necromancers are evil, but the forces they manipulate are considered taboo by many societies.</text>
-			</feature>			
+			</feature>
 			<feature optional="YES">
 				<name>School of Abjuration: Abjuration Savant</name>
 				<text>Beginning when you select this school at 2nd level, the gold and time you must spend to copy an abjuration spell into your spellbook is halved.</text>

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -3958,23 +3958,23 @@
 				<text>At 3rd level, you choose an archetype that you emulate in the exercise of your rogue abilities: Thief, Assassin, or Arcane Trickster, all detailed at the end of the class description. Your archetype choice grants you features at 3rd level and then again at 9th, 13th, and 17th level.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Rogueish Archetype: Arcane Trickster</name>
+				<name>Roguish Archetype: Arcane Trickster</name>
 				<text>Some rogues enhance their fine-honed skills of stealth and agility with magic, learning tricks of enchantment and illusion. These rogues include pickpockets and burglars, but also pranksters, mischief-makers, and a significant number of adventurers.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Rogueish Archetype: Assassin</name>
+				<name>Roguish Archetype: Assassin</name>
 				<text>You focus your training on the grim art of the death. Those who adhere to this archetype are diverse - hired killers, spies, bounty hunters, and even specially anointed priests trained to exterminate the enemies of their deity. Stealth, poison, and disguise help you eliminate your foes with deadly efficiency.</text>
 				<text> </text>
 				<text>Your archetype grants you features at 3rd level and then again at 9th, 13th, and 17th level.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Rogueish Archetype: Swashbuckler</name>
+				<name>Roguish Archetype: Swashbuckler</name>
 				<text>You focus your training on the art of the blade, relying on speed, elegance, and charisma in equal parts. While other warriors are brutes clad in heavy armor, your method of fighting looks more like performance. Rakes, duelists, and pirates typically follow this archetype.</text>
 				<text> </text>
 				<text>A swashbuckler excels in single combat, and can fight with two weapons while safely darting away from an opponent. Swashbucklers are especially talented at making difficult maneuvers to escape enemies or attack from an unexpected direction.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Rogueish Archetype: Thief</name>
+				<name>Roguish Archetype: Thief</name>
 				<text>You hone your skills in the larcenous arts. Burglars, bandits, cutpurses, and other criminals typically follow this archetype, but so do rogues who prefer to think of themselves as professional treasure seekers, explorers, delvers, and investigators. In addition to improving your agility and stealth, you learn skills useful for delving into ancient ruins, reading unfamiliar languages, and using magic items you normally couldn't employ.</text>
 				<text> </text>
 				<text>Your archetype grants you features at 3rd level and then again at 9th, 13th, and 17th level.</text>

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -2628,9 +2628,6 @@
 				<name>Spellcasting</name>
 				<text>By 2nd level, you have learned to draw on divine magic through meditation and prayer to cast spells as a cleric does. See chapter 10 for the general rules of spellcasting and chapter 11 for the paladin spell list.</text>
 				<text> </text>
-				<text>Cantrips</text>
-				<text>At 1st level, you know three cantrips of your choice from the cleric spell list. You learn additional cleric cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Cleric table.</text>
-				<text> </text>
 				<text>Preparing and Casting Spells</text>
 				<text>The Paladin table shows how many spell slots you have to cast your spells. To cast one of your paladin spells of 1st level or higher, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.</text>
 				<text>    You prepare the list of paladin spells that are available for you to cast, choosing from the paladin spell list. When you do so, choose a number of paladin spells equal to your Charisma modifier + half your paladin level, rounded down (minimum of one spell). The spells must be of a level for which you have spell slots.</text>

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -4288,7 +4288,7 @@
 				<text>You have been chosen by a deity, and bestowed with a fragment of their divine power. You have been fundamentally changed by the touch of this deity, which awakens powerful magical abilities inside you</text>
 			</feature>
 			<feature optional="YES">
-				<name>Sorcerous Origin: Storm Sorcerer</name>
+				<name>Sorcerous Origin: Storm</name>
 				<text>Your innate magic comes from the power of elemental air. Perhaps you were born during a howling gale so powerful that folk still tell stories of it. Your lineage might include the influence of potent air creatures such as vaati or djinni. Whatever the case, the magic of the storm permeates your soul.</text>
 				<text> </text>
 				<text>Storm sorcerers are invaluable members of a ship's crew. Their magic allows them to exert control over wind and weather in their immediate area. Their abilities also prove useful in repelling attacks by sahuagin, pirates, and other waterborne threats.</text>
@@ -4405,7 +4405,7 @@
 				<text>    Additionally, parts of your skin are covered by a thin sheen of dragon-like scales. When you aren't wearing armor, your AC equals 13 + your Dexterity modifier.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Storm Sorcerer: Bonus Spells</name>
+				<name>Storm: Bonus Spells</name>
 				<text>Add the following spells to your list of known spells when you reach the indicated level. These spells count as sorcerer spells for you and do not count against your number of spells known.</text>
 				<text> </text>
 				<text>1st — fog cloud, thunderwave</text>
@@ -4418,7 +4418,7 @@
 				<text>**Unless you gain this spell from another source, you can summon only air elementals with it.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Storm Sorcerer: Tempestuous Magic</name>
+				<name>Storm: Tempestuous Magic</name>
 				<text>At 1st level, you are attuned to elemental air magic. Whenever you cast a spell other than a cantrip during your turn, whirling gusts of elemental air surround you. You can use a bonus action to fly 10 feet without provoking opportunity attacks.</text>
 			</feature>
 			<feature optional="YES">
@@ -4567,11 +4567,11 @@
 				<text>Starting at 6th level, you have the ability to twist fate using your wild magic. When another creature you can see makes an attack roll, an ability check, or a saving throw, you can use your reaction and spend 2 sorcery points to roll 1d4 and apply the number rolled as a bonus or penalty (your choice) to the creature's roll. You can do so after the creature rolls but before any effects of the roll occur.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Storm Sorcerer: Heart of the Storm</name>
+				<name>Storm: Heart of the Storm</name>
 				<text>At 6th level, you gain resistance to lightning and thunder damage. Whenever you cast a spell other than a cantrip that deals lightning or thunder damage, a stormy aura surrounds you. In addition to the spell's effects, creatures of your choice within 10 feet of you take lightning or thunder damage (choose each time this ability activates) equal to half your sorcerer level.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Storm Sorcerer: Storm Guide</name>
+				<name>Storm: Storm Guide</name>
 				<text>At 6th level, you gain the ability to subtly control the weather around you.</text>
 				<text>If it is raining, you can use an action to cause the rain to stop falling in a 20-foot radius centered on you. You can end this effect as a bonus action.</text>
 				<text>If it is windy, you can use a bonus action each round to choose the direction that the wind blows in a 100-foot radius around you. The wind blows in that direction until the end of your next turn. You have no ability to alter the speed of the wind.</text>
@@ -4651,7 +4651,7 @@
 				<text>You can't manifest your wings while wearing armor unless the armor is made to accommodate them, and clothing not made to accommodate your wings might be destroyed when you manifest them.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Storm Sorcerer: Storm's FUry</name>
+				<name>Storm: Storm's Fury</name>
 				<text>At 14th level, the storm energy you channel through your magic seethes within your soul. When you are hit by a melee attack, you can use your reaction to deal lightning damage to the attacker equal to your sorcerer level. The attacker must also make a Strength saving throw, with a DC equal to 8+your Charisma bonus+your proficiency bonus. On a failed save, the attacker is pushed in a straight line 20 feet away from you.</text>
 			</feature>
 			<feature optional="YES">
@@ -4723,7 +4723,7 @@
 				<text>Starting at 18th level, when you cast one of the spells you learned from your Chosen of the Gods class feature, you regain hit points equal to your Charisma modifier (minimum of +1) + the spell's level.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Storm Sorcerer: Wind Soul</name>
+				<name>Storm: Wind Soul</name>
 				<text>At 18th level, you gain a flying speed of 60 feet and immunity to lightning and thunder damage.</text>
 				<text>As an action, you can reduce your flying speed to 30 feet for one hour and choose a number of creatures within 30 feet of you equal to 3+your Charisma modifier. The chosen creatures gain a flying speed of 30 feet for 1 hour.</text>
 			</feature>

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -2499,7 +2499,7 @@
 		<text>You touch a willing creature to grant it the ability to see in the dark. For the duration, that creature has darkvision out to a range of 60 feet.</text>
 	</spell>
 	<spell>
-		<name>Pass without trace (Monk)</name>
+		<name>Pass without Trace (Monk)</name>
 		<level>1</level>
 		<school>A</school>
 		<time>1 action</time>

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -4258,17 +4258,17 @@
 				<text> </text>
 				<text>Spell Slots</text>
 				<text>The Sorcerer table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these sorcerer spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.</text>
-				<text>For example, if you know the 1st-level spell burning hands and have a 1st-level and a 2nd-level spell slot available, you can cast burning hands using either slot.</text>
+				<text>    For example, if you know the 1st-level spell burning hands and have a 1st-level and a 2nd-level spell slot available, you can cast burning hands using either slot.</text>
 				<text> </text>
 				<text>Spells Known of 1st Level and Higher</text>
 				<text>You know two 1st-level spells of your choice from the sorcerer spell list.</text>
-				<text>You learn an additional sorcerer spell of your choice at each level except 12th, 14th, 16th, 18th, 19th, and 20th. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 3rd level in this class, you can learn one new spell of 1st or 2nd level.</text>
-				<text>Additionally, when you gain a level in this class, you can choose one of the sorcerer spells you know and replace it with another spell from the sorcerer spell list, which also must be of a level for which you have spell slots.</text>
+				<text>    You learn an additional sorcerer spell of your choice at each level except 12th, 14th, 16th, 18th, 19th, and 20th. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 3rd level in this class, you can learn one new spell of 1st or 2nd level.</text>
+				<text>    Additionally, when you gain a level in this class, you can choose one of the sorcerer spells you know and replace it with another spell from the sorcerer spell list, which also must be of a level for which you have spell slots.</text>
 				<text> </text>
 				<text>Spellcasting Ability</text>
 				<text>Charisma is your spellcasting ability for your sorcerer spells, since the power of your magic relies on your ability to project your will into the world. You use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a sorcerer spell you cast and when making an attack roll with one.</text>
-				<text>Spell save DC = 8 + your proficiency bonus + your Charisma modifier</text>
-				<text>Spell attack modifier = your proficiency bonus + your Charisma modifier</text>
+				<text>    Spell save DC = 8 + your proficiency bonus + your Charisma modifier</text>
+				<text>    Spell attack modifier = your proficiency bonus + your Charisma modifier</text>
 			</feature>
 			<feature>
 				<name>Sorcerous Origin</name>

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -2970,16 +2970,16 @@
 				<name>Spellcasting</name>
 				<text>By the time you reach 2nd level, you have learned to use the magical essence of nature to cast spells, much as a druid does. See chapter 10 for the general rules of spellcasting and chapter 11 for the ranger spell list. </text>
 				<text> </text>
-				<text>Spell Slots:</text>
+				<text>Spell Slots</text>
 				<text>The Ranger table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.</text>
 				<text>    For example, if you know the 1st-level spell animal friendship and have a 1st-level and a 2nd-level spell slot available, you can cast animal friendship using either slot. </text>
 				<text> </text>
-				<text>Spells Known of 1st Level and Higher:</text>
+				<text>Spells Known of 1st Level and Higher</text>
 				<text>You know two 1st-level spells of your choice from the ranger spell list.</text>
 				<text>    You learn an additional ranger spell of your choice at each odd numbered level thereafter. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st or 2nd level.</text>
 				<text>    Additionally, when you gain a level in this class, you can choose one of the ranger spells you know and replace it with another spell from the ranger spell list, which also must be of a level for which you have spell slots. </text>
 				<text> </text>
-				<text>Spellcasting Ability:</text>
+				<text>Spellcasting Ability</text>
 				<text>Wisdom is your spellcasting ability for your ranger spells, since your magic draws on your attunement to nature. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a ranger spell you cast and when making an attack roll with one.</text>
 				<text>    Spell save DC = 8 + your proficiency bonus + your Wisdom modifier</text>
 				<text>    Spell attack modifier = your proficiency bonus + your Wisdom modifier</text>
@@ -4253,19 +4253,19 @@
 				<name>Spellcasting</name>
 				<text>An event in your past, or in the life of a parent or ancestor, left an indelible mark on you, infusing you with arcane magic. This font of magic, whatever its origin, fuels your spells. See chapter 10 for the general rules of spellcasting and chapter 11 for the sorcerer spell list.</text>
 				<text> </text>
-				<text>Cantrips:</text>
+				<text>Cantrips</text>
 				<text>At 1st level, you know four cantrips of your choice from the sorcerer spell list. You learn an additional sorcerer cantrip of your choice at 4th level and another at 10th level.</text>
 				<text> </text>
-				<text>Spell Slots:</text>
+				<text>Spell Slots</text>
 				<text>The Sorcerer table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these sorcerer spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.</text>
 				<text>For example, if you know the 1st-level spell burning hands and have a 1st-level and a 2nd-level spell slot available, you can cast burning hands using either slot.</text>
 				<text> </text>
-				<text>Spells Known of 1st Level and Higher:</text>
+				<text>Spells Known of 1st Level and Higher</text>
 				<text>You know two 1st-level spells of your choice from the sorcerer spell list.</text>
 				<text>You learn an additional sorcerer spell of your choice at each level except 12th, 14th, 16th, 18th, 19th, and 20th. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 3rd level in this class, you can learn one new spell of 1st or 2nd level.</text>
 				<text>Additionally, when you gain a level in this class, you can choose one of the sorcerer spells you know and replace it with another spell from the sorcerer spell list, which also must be of a level for which you have spell slots.</text>
 				<text> </text>
-				<text>Spellcasting Ability:</text>
+				<text>Spellcasting Ability</text>
 				<text>Charisma is your spellcasting ability for your sorcerer spells, since the power of your magic relies on your ability to project your will into the world. You use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a sorcerer spell you cast and when making an attack roll with one.</text>
 				<text>Spell save DC = 8 + your proficiency bonus + your Charisma modifier</text>
 				<text>Spell attack modifier = your proficiency bonus + your Charisma modifier</text>
@@ -4425,7 +4425,7 @@
 				<name>Wild Magic: Wild Magic Surge</name>
 				<text>Starting when you choose this origin at 1st level, your spellcasting can unleash surges of untamed magic. Immediately after you cast a sorcerer spell of 1st level or higher, the DM can have you roll a d20. If you roll a 1, roll on the Wild Magic Surge table to create a random magical effect.</text>
 				<text></text>
-				<text>Wild Magic Surge:</text>
+				<text>Wild Magic Surge</text>
 				<text>d100 — Effect</text>
 				<text>01-02 — Roll on this table at the start of each of your turns for the next minute, ignoring this result on subsequent rolls.</text>
 				<text>03-04 — For the next minute, you can see any invisible creature if you have line of sight to it.</text>

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -38,7 +38,7 @@
 				<text></text>
 				<text>If you are able to cast spells, you can't cast them or concentrate on them while raging.</text>
 				<text>    Your rage lasts for 1 minute. It ends early if you are knocked unconscious or if your turn ends and you haven't attacked a hostile creature since your last turn or taken damage since then. You can also end your rage on your turn as a bonus action.</text>
-				<text>Once you have raged the maximum number of times for your barbarian level, you must finish a long rest before you can rage again.  You may rage 2 times at 1st level, 3 at 3rd, 4 at 6th, 5 at 12th, and 6 at 17th.</text>
+				<text>    Once you have raged the maximum number of times for your barbarian level, you must finish a long rest before you can rage again.  You may rage 2 times at 1st level, 3 at 3rd, 4 at 6th, 5 at 12th, and 6 at 17th.</text>
 			</feature>
 			<feature>
 				<name>Unarmored Defense</name>
@@ -107,7 +107,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -162,7 +162,7 @@
 			<feature>
 				<name>Ability Score Improvement></name>
 				<text>When you reach 8th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM uses the optional Feats, you can instead take a feat.</text>
+				<text>    If your DM uses the optional Feats, you can instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -202,7 +202,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM uses the optional Feats, you can instead take a feat.</text>
+				<text>    If your DM uses the optional Feats, you can instead take a feat.</text>
 			</feature>
 			<feature>
 				<name>Increased Rages</name>
@@ -251,7 +251,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM uses the optional Feats, you can instead take a feat.</text>
+				<text>    If your DM uses the optional Feats, you can instead take a feat.</text>
 			</feature>
 			<feature>
 				<name>Increased Rage Damage</name>
@@ -281,7 +281,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM uses the optional Feats, you can instead take a feat.</text>
+				<text>    If your DM uses the optional Feats, you can instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -445,7 +445,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -479,7 +479,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -511,7 +511,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -549,7 +549,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -572,7 +572,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -912,7 +912,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -970,7 +970,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 			<feature>
 				<name>Destroy Undead (CR 1)</name>
@@ -1033,7 +1033,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1048,7 +1048,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1105,7 +1105,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1259,7 +1259,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1279,7 +1279,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1298,7 +1298,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1318,7 +1318,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1337,7 +1337,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1578,7 +1578,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1594,7 +1594,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 6th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1633,7 +1633,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1679,7 +1679,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1694,7 +1694,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 14th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1725,7 +1725,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1759,7 +1759,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -1899,6 +1899,7 @@
 		<classes>Fighter (Battle Master)</classes>
 		<text>When you hit a creature with a weapon attack, you can expend one superiority die to attempt to knock the target down. You add the superiority die to the attack's damage roll, and if the target is Large or smaller, it must make a Strength saving throw. On a failed save, you knock the target prone.</text>
 	</spell>
+
 	<class>
 		<name>Monk</name>
 		<hd>8</hd>
@@ -1932,8 +1933,7 @@
 			<feature>
 				<name>Martial Arts</name>
 				<text>Your practice of martial arts gives you mastery of combat styles that use unarmed strikes and monk weapons, which are shortswords and any simple melee weapons that don't have the two-handed or heavy property.</text>
-				<text> </text>
-				<text>You gain the following benefits while you are unarmed or wielding only monk weapons and you aren't wearing armor or wielding a shield.</text>
+				<text>    You gain the following benefits while you are unarmed or wielding only monk weapons and you aren't wearing armor or wielding a shield.</text>
 				<text> </text>
 				<text>• You can use Dexterity instead of Strength for the attack and damage rolls of your unarmed strikes and monk weapons.</text>
 				<text> </text>
@@ -1941,7 +1941,7 @@
 				<text> </text>
 				<text>• When you use the Attack action with an unarmed strike or a monk weapon on your turn, you can make one unarmed strike as a bonus action. For example, if you take the Attack action and attack with a quarterstaff, you can also make an unarmed strike as a bonus action, assuming you haven't already taken a bonus action this turn.</text>
 				<text> </text>
-				<text>Certain monasteries use specialized forms of the monk weapons. For example, you might use a club that is two lengths of wood connected by a short chain (called a nunchaku) or a sickle with a shorter, straighter blade (called a kama).</text>
+				<text>    Certain monasteries use specialized forms of the monk weapons. For example, you might use a club that is two lengths of wood connected by a short chain (called a nunchaku) or a sickle with a shorter, straighter blade (called a kama).</text>
 			</feature>
 		</autolevel>
 
@@ -2031,7 +2031,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 			<feature>
 				<name>Slow Fall</name>
@@ -2095,7 +2095,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2147,7 +2147,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2182,7 +2182,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2226,7 +2226,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2733,7 +2733,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2778,7 +2778,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2801,7 +2801,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2837,7 +2837,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2852,7 +2852,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -2972,17 +2972,17 @@
 				<text> </text>
 				<text>Spell Slots:</text>
 				<text>The Ranger table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.</text>
-				<text>For example, if you know the 1st-level spell animal friendship and have a 1st-level and a 2nd-level spell slot available, you can cast animal friendship using either slot. </text>
+				<text>    For example, if you know the 1st-level spell animal friendship and have a 1st-level and a 2nd-level spell slot available, you can cast animal friendship using either slot. </text>
 				<text> </text>
 				<text>Spells Known of 1st Level and Higher:</text>
 				<text>You know two 1st-level spells of your choice from the ranger spell list.</text>
-				<text>You learn an additional ranger spell of your choice at each odd numbered level thereafter. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st or 2nd level.</text>
-				<text>Additionally, when you gain a level in this class, you can choose one of the ranger spells you know and replace it with another spell from the ranger spell list, which also must be of a level for which you have spell slots. </text>
+				<text>    You learn an additional ranger spell of your choice at each odd numbered level thereafter. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st or 2nd level.</text>
+				<text>    Additionally, when you gain a level in this class, you can choose one of the ranger spells you know and replace it with another spell from the ranger spell list, which also must be of a level for which you have spell slots. </text>
 				<text> </text>
 				<text>Spellcasting Ability:</text>
 				<text>Wisdom is your spellcasting ability for your ranger spells, since your magic draws on your attunement to nature. You use your Wisdom whenever a spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a ranger spell you cast and when making an attack roll with one.</text>
-				<text>Spell save DC = 8 + your proficiency bonus + your Wisdom modifier</text>
-				<text>Spell attack modifier = your proficiency bonus + your Wisdom modifier</text>
+				<text>    Spell save DC = 8 + your proficiency bonus + your Wisdom modifier</text>
+				<text>    Spell attack modifier = your proficiency bonus + your Wisdom modifier</text>
 			</feature>
 			<feature>
 				<name>Fighting Style</name>
@@ -3056,7 +3056,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3105,7 +3105,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 			<feature>
 				<name>Land's Stride</name>
@@ -3149,7 +3149,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3191,7 +3191,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3206,7 +3206,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3417,7 +3417,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3534,7 +3534,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 			<feature>
 				<name>Land's Stride</name>
@@ -3653,7 +3653,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3778,7 +3778,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3868,7 +3868,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -3987,7 +3987,7 @@
 				<text>• You can retrieve an object in a container worn or carried by another creature.</text>
 				<text>• You can use thieves' tools to pick lock and disarm traps at range.</text>
 				<text></text>
-				<text>    You can perform one of these tasks without being noticed by a creature if you succeed on a Dexterity (Sleight of Hand) check contested by the creature's Wisdom (Perception) check.</text>
+				<text>You can perform one of these tasks without being noticed by a creature if you succeed on a Dexterity (Sleight of Hand) check contested by the creature's Wisdom (Perception) check.</text>
 				<text>    In addition, you can use the bonus action granted by your Cunning Action to control the hand.</text>
 			</feature>
 			<feature>
@@ -4044,7 +4044,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4066,7 +4066,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4096,7 +4096,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 10th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4111,7 +4111,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4153,7 +4153,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4189,7 +4189,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4552,7 +4552,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4586,7 +4586,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4635,7 +4635,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4664,7 +4664,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4733,7 +4733,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4918,7 +4918,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4957,7 +4957,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -4996,7 +4996,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 			<feature>
 				<name>Eldritch Invocation</name>
@@ -5048,7 +5048,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -5071,7 +5071,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -6182,7 +6182,7 @@
 			<feature optional="YES">
 				<name>School of Illusion: Improved Minor Illusion</name>
 				<text>When you choose this school at 2nd level, you learn the minor illusion cantrip. If you already know this cantrip, you learn a different wizard cantrip of your choice. The cantrip doesn't count against your number of cantrips known.</text>
-				<text>   When you cast minor illusion, you can create both a sound and an image with a single casting of the spell.</text>
+				<text>    When you cast minor illusion, you can create both a sound and an image with a single casting of the spell.</text>
 			</feature>
 			<feature optional="YES">
 				<name>School of Necromancy: Necromancy Savant</name>
@@ -6226,7 +6226,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 4th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -6299,7 +6299,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 8th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -6354,7 +6354,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -6459,7 +6459,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 16th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 
@@ -6475,7 +6475,7 @@
 			<feature>
 				<name>Ability Score Improvement</name>
 				<text>When you reach 19th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
-				<text>   If your DM allows the use of feats, you may instead take a feat.</text>
+				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
 		</autolevel>
 

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -6071,12 +6071,40 @@
 				<text>Alternatively, you may start with 4d4 x 10 gp to buy your own equipment.</text>
 			</feature>
 		</autolevel>
+
 		<autolevel level="1">
 			<feature>
 				<name>Arcane Recovery</name>
 				<text>You have learned to regain some of your magical energy by studying your spellbook. Once per day when you finish a short rest, you can choose expended spell slots to recover. The spell slots can have a combined level that is equal to or less than half your wizard level (rounded up), and none of the slots can be 6th level or higher.</text>
 				<text>    For example, if you're a 4th-level wizard, you can recover up to two levels worth of spell slots.</text>
 				<text>    You can recover either a 2nd-level spell slot or two 1st-level spell slots.</text>
+			</feature>
+			<feature>
+				<name>Spellcasting</name>
+				<text>As a student of arcane magic, you have a spellbook containing spells that show the first glimmerings of your true power. See chapter 10 for the general rules of spellcasting and chapter 11 for the wizard spell list.</text>
+				<text> </text>
+				<text>Cantrips</text>
+				<text>At 1st level, you know three cantrips of your choice from the wizard spell list. You learn additional wizard cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Wizard table.</text>
+				<text> </text>
+				<text>Spellbook</text>
+				<text>At 1st level, you have a spellbook containing six 1st-level wizard spells of your choice.</text>
+				<text> </text>
+				<text>Preparing and Casting Spells</text>
+				<text>The Wizard table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.</text>
+				<text>    You prepare the list of wizard spells that are available for you to cast. To do so, choose a number of wizard spells from your spellbook equal to your Intelligence modifier + your wizard level (minimum of one spell). The spells must be of a level for which you have spell slots.</text>
+				<text>    For example, if you're a 3rd-level wizard, you have four 1st-level and two 2nd-level spell slots. With an Intelligence of 16, your list of prepared spells can include six spells of 1st or 2nd level, in any combination, chosen from your spellbook. If you prepare the 1st-level spell magic missile, you can cast it using a 1st-level or a 2nd-level slot. Casting the spell doesn't remove it from your list of prepared spells.</text>
+				<text>    You can change your list of prepared spells when you finish a long rest. Preparing a new list of wizard spells requires time spent studying your spellbook and memorizing the incantations and gestures you must make to cast the spell: at least 1 minute per spell level for each spell on your list.</text>
+				<text> </text>
+				<text>Spellcasting Ability</text>
+				<text>Intelligence is your spellcasting ability for your wizard spells, since you learn your spells through dedicated study and memorization. You use your Intelligence whenever a spell refers to your spellcasting ability. In addition, you use your Intelligence modifier when setting the saving throw DC for a wizard spell you cast and when making an attack roll with one.</text>
+				<text>    Spell save DC = 8 + your proficiency bonus + your Intelligence modifier</text>
+				<text>    Spell attack modifier = your proficiency bonus + your Intelligence modifier</text>
+				<text> </text>
+				<text>Ritual Casting</text>
+				<text>You can cast a wizard spell as a ritual if that spell has the ritual tag and you have the spell in your spellbook. You don't need to have the spell prepared.</text>
+				<text> </text>
+				<text>Spellcasting Focus</text>
+				<text>You can use an arcane focus (found in chapter 5) as a spellcasting focus for your wizard spells.</text>
 			</feature>
 		</autolevel>
 

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -4862,25 +4862,25 @@
 				<name>Pact Magic</name>
 				<text>Your arcane research and the magic bestowed on you by your patron have given you facility with spells. See chapter 10 for the general rules of spellcasting and chapter 11 for the warlock spell list.</text>
 				<text> </text>
-				<text>Cantrips: You know two cantrips of your choice from the warlock spell list. You learn additional warlock cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Warlock table.</text>
+				<text>Cantrips</text>
+				<text>You know two cantrips of your choice from the warlock spell list. You learn additional warlock cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Warlock table.</text>
 				<text> </text>
-				<text>Spell Slots: The Warlock table shows how many spell slots you have. The table also shows what the level of those slots is; all of your spell slots are the same level. To cast one of your warlock spells of 1st level or higher, you must expend a spell slot. You regain all expended spell slots when you finish a short or long rest.</text>
+				<text>Spell Slots</text>
+				<text>The Warlock table shows how many spell slots you have. The table also shows what the level of those slots is; all of your spell slots are the same level. To cast one of your warlock spells of 1st level or higher, you must expend a spell slot. You regain all expended spell slots when you finish a short or long rest.</text>
+				<text>    For example, when you are 5th level, you have two 3rd-level spell slots. To cast the 1st-level spell thunderwave, you must spend one of those slots, and you cast it as a 3rd-level spell.</text>
 				<text> </text>
-				<text>For example, when you are 5th level, you have two 3rd-level spell slots. To cast the 1st-level spell thunderwave, you must spend one of those slots, and you cast it as a 3rd-level spell.</text>
+				<text>Spells Known of 1st Level and Higher</text>
+				<text>At 1st level, you know two 1st-level spells of your choice from the warlock spell list.</text>
+				<text>    You learn a new warlock spell every time you gain a level from 2 through 9, as well as at level 19. A spell you choose must be of a level no higher than what's shown in the table's Slot Level column for your level. When you reach 6th level, for example, you learn a new warlock spell, which can be 1st, 2nd, or 3rd level.</text>
+				<text>    Additionally, when you gain a level in this class, you can choose one of the warlock spells you know and replace it with another spell from the warlock spell list, which also must be of a level for which you have spell slots.</text>
 				<text> </text>
-				<text>Spells Known of 1st Level and Higher: At 1st level, you know two 1st-level spells of your choice from the warlock spell list.</text>
+				<text>Spellcasting Ability</text>
+				<text>Charisma is your spellcasting ability for your warlock spells, so you use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a warlock spell you cast and when making an attack roll with one.</text>
+				<text>    Spell save DC: 8 + Proficiency bonus + Charisma modifier</text>
+				<text>    Spell attack modifier: Proficiency bonus + Charisma modifier</text>
 				<text> </text>
-				<text> You learn a new warlock spell every time you gain a level from 2 through 9, as well as at level 19. A spell you choose must be of a level no higher than what's shown in the table's Slot Level column for your level. When you reach 6th level, for example, you learn a new warlock spell, which can be 1st, 2nd, or 3rd level.</text>
-				<text> </text>
-				<text>Additionally, when you gain a level in this class, you can choose one of the warlock spells you know and replace it with another spell from the warlock spell list, which also must be of a level for which you have spell slots.</text>
-				<text> </text>
-				<text>Spellcasting Ability: Charisma is your spellcasting ability for your warlock spells, so you use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a warlock spell you cast and when making an attack roll with one.</text>
-				<text> </text>
-				<text>Spell save DC: 8 + Proficiency bonus + Charisma modifier</text>
-				<text> </text>
-				<text>Spell attack modifier: Proficiency bonus + Charisma modifier</text>
-				<text> </text>
-				<text>Spellcasting Focus: You can use an arcane focus (found in chapter 5) as a spellcasting focus for your warlock spells.</text>
+				<text>Spellcasting Focus</text>
+				<text>You can use an arcane focus (found in chapter 5) as a spellcasting focus for your warlock spells.</text>
 			</feature>
 		</autolevel>
 

--- a/Character Files/Class (Subclass Update).xml
+++ b/Character Files/Class (Subclass Update).xml
@@ -1770,7 +1770,7 @@
 			</feature>
 		</autolevel>
 	</class>
-	<!--Battlemaster Spells-->
+<!--Battlemaster Spells-->
 	<spell>
 		<name>Commander's Strike</name>
 		<level>1</level>
@@ -2237,7 +2237,7 @@
 			</feature>
 		</autolevel>
 	</class>
-	<!--Elemental Monk Spells-->
+<!--Elemental Monk Spells-->
 	<spell>
 		<name>Breath of Winter (17th level required)</name>
 		<level>4</level>
@@ -2471,7 +2471,7 @@
 		<text/>
 		<text>If you maintain your concentration on this spell for its whole duration, the wall becomes permanent and can't be dispelled. Otherwise, the wall disappears when the spell ends.</text>
 	</spell>
-	<!--Shadow Monk Spells-->
+<!--Shadow Monk Spells-->
 	<spell>
 		<name>Darkness (Monk)</name>
 		<level>1</level>


### PR DESCRIPTION
I accidentally left the Cleric's Cantrip section in the Paladin; removed that.
I added the Spellcasting feature to the Wizard
I fixed the formatting for the Pact Magic feature so it matches the others' spellcasting features
More typo fixes and formatting changes
