### PR TITLE
Adds Graz'zt.

### DIFF
--- a/Bestiary/Out of the Abyss.xml
+++ b/Bestiary/Out of the Abyss.xml
@@ -1372,7 +1372,7 @@
 		</legendary>
 		<spells>detect magic, major image, dispel magic, fear, telekinesis, feeblemind, project image</spells>
 	</monster>
-		<monster>
+	<monster>
 		<name>Fraz-Urb'luu</name>
 		<size>L</size>
 		<type>fiend (demon), out of the abyss</type>
@@ -1443,5 +1443,83 @@
 			<text>Fraz-Urb'luu casts phantasmal killer, no concentration required.</text>
 		</legendary>
 		<spells>alter self, detect magic, dispel magic, phantasamal force, confusion, dream, mislead, programmed illusion, seeming, mirage arcane, modify memory, project image</spells>
+	</monster>
+	<monster>
+		<name>Graz'zt</name>
+		<size>L</size>
+		<type>fiend (demon, shapechanger), out of the abyss</type>
+		<alignment>chaotic evil</alignment>
+		<ac>20 (natural armor)</ac>
+		<hp>378 (36d10 + 180)</hp>
+		<speed>40 ft.</speed>
+		<str>22</str><dex>15</dex><con>21</con><int>23</int><wis>21</wis><cha>26</cha>
+		<save>Dex +9, Con +12, Wis +12</save>
+		<skill>Deception +15, Insight +12, Perception +12, Persuasion +15</skill>
+		<resist>cold, fire, lightning</resist>
+		<vulnerable></vulnerable>
+		<immune>poison; bludgeoning, piercing, and slashing that is nonmagical</immune>
+		<conditionImmune>charmed, exhaustion, frightened, poisoned</conditionImmune>
+		<senses>truesight 120 ft.</senses>
+		<passive>22</passive>
+		<languages>all, telepathy 120 ft.</languages>
+		<cr>24</cr>
+		<trait>
+			<name>Shapechanger</name>
+			<text>Graz'zt can use his action to polymorph into a form that resembles a Medium humanoid, or back into his true form. Aside from his size, his statistics are the same in each form, Any equipment he is wearing or carrying isn't transformed.</text>
+		</trait>		
+		<trait>
+			<name>Innate Spellcasting</name>
+			<text>Graz'zt's spellcasting ability is Charisma (spell save DC 23). Graz'zt can innately cast the following spells, requiring no material components</text>
+			<text></text>
+			<text>At will: charm person, crown of madness, detect magic, dispel magic, dissonant whispers</text>
+			<text>3/day each: counterspell, darkness, dominate person, sanctuary, telekinesis, teleport</text>
+			<text>1/day each: dominate monster, greater invisibility</text>
+		</trait>
+		<trait>
+			<name>Legendary Resistance (3/Day)</name>
+			<text>If Graz'zt fails a saving throw, he can choose to succeed instead.</text>
+		</trait>
+		<trait>
+			<name>Magic Resistance</name>
+			<text>Graz'zt has advantage on saving throws against spell and other magic effects.</text>
+		</trait>
+		<trait>
+			<name>Magic Weapon</name>
+			<text>Graz'zt's weapon attacks are magical.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>Graz'zt attacks twice with the Wave of Sorrow.</text>
+		</action>
+		<action>
+			<name>Wave of Sorrow (Greatsword)</name>
+			<text>Melee Weapon Attack: +13 to hit, reach 10 ft., one target, Hit; 20 (4d6 + 6) slashing damage plus 14 (4d6) acid damage.</text>
+			<attack>|13|4d6+6+4d6</attack>
+		</action>
+		<action>
+			<name>Teleport</name>
+			<text>Graz'zt magically teleports, along with any equipment he is wearing or carrying, up to 120 feet to an unoccupied space he can see.</text>
+		</action>
+		<legendary>
+			<name></name>
+			<text>Graz'zt can take 3 legendary actions, choosing from the options below. Only one legendary action can be used at a time and only at the end of another creautre's turn. Graz'zt regains spent legendary actions at the start of his turn.</text>
+		</legendary>
+		<legendary>
+			<name>Attack</name>
+			<text>Graz'zt attacks once with the Wave of Sorrow.</text>
+		</legendary>
+		<legendary>
+			<name>Dance, My Puppet!</name>
+			<text>One creature charmed by Graz'zt that Graz'zt can see must use its reaction to move up to its speed as Graz'zt directs.</text>
+		</legendary>
+		<legendary>
+			<name>Sow Discord</name>
+			<text>Graz'zt casts crown of madness or dissonant whispers.</text>
+		</legendary>
+		<legendary>
+			<name>Teleport</name>
+			<text>Graz'zt uses his Teleport action.</text>
+		</legendary>
+		<spells>charm person, crown of madness, detect magic, dispel magic, dissonant whispers, counterspell, darkness, dominate person, sanctuary, telekinesis, teleport, dominate monster, greater invisibility</spells>
 	</monster>
 </compendium>


### PR DESCRIPTION
Note that Graz'zt as written has the Bluff skill, which is replaced by Deception in 5e. Couldn't find official errata for the book yet, but this seems correct.
