### PR TITLE
Renamed Holy Symbol items; spells and Duergar from SCAG

### DIFF
--- a/Character Files/Races.xml
+++ b/Character Files/Races.xml
@@ -865,4 +865,42 @@
 			<text>You can speak, read, and write Common.</text>
 		</trait>
 	</race>
+	<race>
+		<name>Dwarf (Duergar)</name>
+		<size>M</size>
+		<speed>25</speed>
+		<ability>Con 2, Str 1</ability>
+		<trait>
+			<name>Superior Darkvision</name>
+			<text>Accustomed to life underground, you have superior vision in dark and dim conditions. You can see in dim light within 120 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray.</text>
+		</trait>
+		<trait>
+			<name>Duergar Resilience</name>
+			<text>You have advantage on saving throws against poison, and you have resistance against poison damage. You also have advantage on saving throws against illusions and against being charmed or paralyzed.</text>
+		</trait>
+		<trait>
+			<name>Dwarven Combat Training</name>
+			<text>You have proficiency with the battleaxe, handaxe, light hammer, and warhammer.</text>
+		</trait>
+		<trait>
+			<name>Tool Proficiency</name>
+			<text>You gain proficiency with the artisan's tools of your choice: smith's tools, brewer's supplies, or mason's tools.</text>
+		</trait>
+		<trait>
+			<name>Stonecunning</name>
+			<text>Whenever you make an Intelligence (History) check related to the origin of stonework, you are considered proficient in the History skill and add double your proficiency bonus to the check, instead of your normal proficiency bonus.</text>
+		</trait>
+		<trait>
+			<name>Languages</name>
+			<text>You can speak, read, and write Common, Dwarvish, and Undercommon.</text>
+		</trait>
+		<trait>
+			<name>Duergar Magic</name>
+			<text>When you reach 3rd level, you can cast the Enlarge/Reduce spell on yourself once with this trait, using only the spell's enlarge option. When reach 5th level, you can cast the Invisibility spell on yourself once with this trait. You don't need material components for either spell, and you can't cast them while you're in direct sunlight, although sunlight has no effect on them once cast. You regain the ability to cast these spells with this trait when you finish a long rest. Intelligence is your spellcasting ability for these spells.</text>
+		</trait>
+		<trait>
+			<name>Sunlight Sensitivity</name>
+			<text>You have disadvantage on attack rolls and Wisdom (Perception) checks that rely on sight when you, the target of your attack, or whatever you are trying to perceive is in direct sunlight.</text>
+		</trait>
+	</race>
 </compendium>

--- a/Items/Mundane Items.xml
+++ b/Items/Mundane Items.xml
@@ -161,17 +161,6 @@
 		<text>Source: Player's Handbook, page 154</text>
 	</item>
 	<item>
-		<name>Amulet</name>
-		<type>G</type>
-		<weight>1</weight>
-		<range></range>
-		<text>A holy symbol is a representation of a god or pantheon</text>
-		<text />
-		<text>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</text>
-		<text />
-		<text>Source: Player's Handbook, page 151</text>
-	</item>
-	<item>
 		<name>Antitoxin</name>
 		<type>G</type>
 		<range></range>
@@ -583,15 +572,6 @@
 		<text>Source: Player's Handbook, page 151</text>
 	</item>
 	<item>
-		<name>Emblem</name>
-		<type>G</type>
-		<text>A holy symbol is a representation of a god or pantheon</text>
-		<text />
-		<text>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</text>
-		<text />
-		<text>Source: Player's Handbook, page 151</text>
-	</item>
-	<item>
 		<name>Entertainer's Pack</name>
 		<type>G</type>
 		<weight>38</weight>
@@ -740,6 +720,36 @@
 		<text>This kit contains a variety of instruments such as clippers, mortar and pestle, and pouches and vials used by herbalists to create remedies and potions. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to identify or apply herbs. Also, proficiency with this kit is required to create antitoxin and potions of healing.</text>
 		<text />
 		<text>Source: Player's Handbook, page 154</text>
+	</item>
+	<item>
+		<name>Holy Symbol (Amulet)</name>
+		<type>G</type>
+		<weight>1</weight>
+		<range></range>
+		<text>A holy symbol is a representation of a god or pantheon</text>
+		<text />
+		<text>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</text>
+		<text />
+		<text>Source: Player's Handbook, page 151</text>
+	</item>
+	<item>
+		<name>Holy Symbol (Emblem)</name>
+		<type>G</type>
+		<text>A holy symbol is a representation of a god or pantheon</text>
+		<text />
+		<text>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</text>
+		<text />
+		<text>Source: Player's Handbook, page 151</text>
+	</item>
+	<item>
+		<name>Holy Symbol (Reliquary)</name>
+		<type>G</type>
+		<weight>2</weight>
+		<text>A holy symbol is a representation of a god or pantheon</text>
+		<text />
+		<text>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</text>
+		<text />
+		<text>Source: Player's Handbook, page 151</text>
 	</item>
 	<item>
 		<name>Holy Water (flask)</name>
@@ -1104,16 +1114,6 @@
 		<text>Rations consist of dry foods suitable for extended travel, including jerky, dried fruit, hardtack, and nuts.</text>
 		<text />
 		<text>Source: Player's Handbook, page 153</text>
-	</item>
-	<item>
-		<name>Reliquary</name>
-		<type>G</type>
-		<weight>2</weight>
-		<text>A holy symbol is a representation of a god or pantheon</text>
-		<text />
-		<text>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</text>
-		<text />
-		<text>Source: Player's Handbook, page 151</text>
 	</item>
 	<item>
 		<name>Robes</name>

--- a/Spells/SCAG Spells.xml
+++ b/Spells/SCAG Spells.xml
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spells version="5">
+<!--Spell Attack rolls assume PROF added to roll, not applicable for Ranged while engaged in Melee range-->
+<!--replaced ":" as intro to list with ".", and as in-line text with " - "-->
+	<spell>
+		<name>Booming Blade</name>
+		<level>0</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>5 feet</range>
+		<components>V, M (a weapon)</components>
+		<duration>1 round</duration>
+		<classes>Sorcerer, Warlock, Wizard</classes>
+		<text>As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and it becomes sheathed in booming energy until the start of your next turn. If the target willingly moves before then, it immediately takes 1d8 thunder damage, and the spell ends.</text>
+		<text>    This spell's damage increases when you reach higher levels. At 5th level, the melee attack deals an extra 1d8 thunder damage to the target, and the damage the target takes for moving increases to 2d8. Both damage rolls increase by 1d8 at 11th level and 17th level.</text>
+		<roll>1d8</roll>
+		<roll>2d8</roll>
+		<roll>3d8</roll>
+		<roll>4d8</roll>
+	</spell>
+	<spell>
+		<name>Green-Flame Blade</name>
+		<level>0</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>5 feet</range>
+		<components>V, M (a weapon)</components>
+		<duration>1 round</duration>
+		<classes>Sorcerer, Warlock, Wizard</classes>
+		<text>As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and green fire leaps from the target to a different creature of your choice that you can see within 5 feet of it. The second creature takes fire damage equal to your spellcasting ability modifier.</text>
+		<text>    This spell's damage increases when you reach higher levels. At 5th level, the melee attack deals an extra 1d8 fire damage to the target, and the fire damage to the second creature increases to 1d8 + your spellcasting ability modifier. Both damage rolls increase by 1d8 at 11th level and 17th level.</text>
+		<roll>1d8</roll>
+		<roll>2d8</roll>
+		<roll>3d8</roll>
+	</spell>
+	<spell>
+		<name>Lightning Lure</name>
+		<level>0</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>15 feet</range>
+		<components>V</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Warlock, Wizard</classes>
+		<text>You create a lash of lightning energy that strikes at one creature of your choice that you can see within range. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you.</text>
+		<text>    The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</text>
+		<roll>1d8</roll>
+		<roll>2d8</roll>
+		<roll>3d8</roll>
+		<roll>4d8</roll>
+	</spell>
+	<spell>
+		<name>Sword Burst</name>
+		<level>0</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>5 feet</range>
+		<components>V</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Warlock, Wizard</classes>
+		<text>You create a momentary circle of spectral blades that sweep around you. Each creature within range, other than you, must succeed on a Dexterity saving throw or take 1d6 force damage.</text>
+		<text>    The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
+		<roll>1d6</roll>
+		<roll>2d6</roll>
+		<roll>3d6</roll>
+		<roll>4d6</roll>
+	</spell>
+	<spell>
+		<name>Gust</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>V, S</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You seize the air and compel it to create one of the following effects at a point you can see within range.</text>
+		<text>    • One Medium or smaller creature that you choose must succeed on a Strength saving throw or be pushed up to 5 feet away from you.</text>
+		<text>    • You create a small blast of air capable of moving one object that is neither held nor carried and that weighs no more than 5 pounds. The object is pushed up to 10 feet away from you. It isn't pushed with enough force to cause damage.</text>
+		<text>    • You create a harmless sensory affect using air, such as causing leaves to rustle, wind to slam shutters shut, or your clothing to ripple in a breeze.</text>
+	</spell>
+	<spell>
+		<name>Ice Knife</name>
+		<level>1</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>S, M (a drop of water or piece of ice)</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Sorcerer, Wizard</classes>
+		<text>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of the point where the ice exploded must succeed on a Dexterity saving throw or take 2d6 cold damage.</text>
+		<text>    At Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, the cold damage increases by 1d6 for each slot level above 1st.</text>
+		<roll>1d20+SPELL+PROF</roll>
+		<roll>1d10</roll>
+	</spell>
+	<spell>
+		<name>Immolation</name>
+		<level>5</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Sorcerer, Wizard</classes>
+		<text>Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 7d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell's duration. The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. At the end of each of its turns, the target repeats the saving throw. It takes 3d6 fire damage on a failed save, and the spell ends on a successful one. These magical flames can't be extinguished through nonmagical means.</text>
+		<text>    If damage from this spell reduces a target to 0 hit points, the target is turned to ash.</text>
+		<roll>7d6</roll>
+		<roll>3d6</roll>
+	</spell>
+	<spell>
+		<name>Investiture of Flame</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Flames race across your body, shedding bright light in a 30-foot radius and dim light for an additional 30 feet for the spell's duration. The flames don't harm you. Until the spell ends, you gain the following benefits.</text>
+		<text>    • You are immune to fire damage and have resistance to cold damage.</text>
+		<text>    • Any creature that moves within 5 feet of you for the first time on a turn or ends its turn there takes 1d10 fire damage.</text>
+		<text>    • You can use your action to create a line of fire 15 feet long and 5 feet wide extending from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 4d8 fire damage on a failed save, or half as much damage on a successful one.</text>
+		<roll>1d10</roll>
+	</spell>
+	<spell>
+		<name>Investiture of Ice</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Until the spell ends, ice rimes your body, and you gain the following benefits.</text>
+		<text>    • You are immune to cold damage and have resistance to fire damage.</text>
+		<text>    • You can move across difficult terrain created by ice or snow without spending extra movement.</text>
+		<text>    • The ground in a 10-foot radius around you is icy and is difficult terrain for creatures other than you. The radius moves with you.</text>
+		<text>    • You can use your action to create a 15-foot cone of freezing wind extending from your outstretched hand in a direction you choose. Each creature in the cone must make a Constitution saving throw. A creature takes 4d6 cold damage on a failed save, or half as much damage on a successful one. A creature that fails its save against this effect has its speed halved until the start of your next turn.</text>
+	</spell>
+	<spell>
+		<name>Investiture of Stone</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Until the spell ends, bits of rock spread across your body, and you gain the following benefits.</text>
+		<text>    • You have resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons.</text>
+		<text>    • You can use your action to create a small earthquake on the ground in a 15-foot radius centered on you. Other creatures on that ground must succeed on a Dexterity saving throw or be knocked prone.</text>
+		<text>    • You can move across difficult terrain made of earth or stone without spending extra movement. You can move through solid earth or stone as if it was air and without destabilizing it, but you can't end your movement there. If you do so, you are ejected to the nearest unoccupied space, this spell ends, and you are stunned until the end of your next turn.</text>
+	</spell>
+	<spell>
+		<name>Investiture of Wind</name>
+		<level>6</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Warlock, Wizard</classes>
+		<text>Until the spell ends, wind whirls around you, and you gain the following benefits.</text>
+		<text>    • Ranged weapon attacks made against you have disadvantage on the attack roll.</text>
+		<text>    • You gain a flying speed of 60 feet. If you are still flying when the spell ends, you fall, unless you can somehow prevent it.</text>
+		<text>    • You can use your action to create a 15-foot cube of swirling wind centered on a point you can see within 60 feet of you. Each creature in that area must make a Constitution saving throw. A creature takes 2d10 bludgeoning damage on a failed save, or half as much damage on a successful one. If a Large or smaller creature fails the save, that creature is also pushed up to 10 feet away from the center of the cube.</text>
+		<roll>2d10</roll>
+	</spell>
+	<spell>
+		<name>Maelstrom</name>
+		<level>5</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S, M (paper or leaf in the shape of a funnel)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid</classes>
+		<text>A mass of 5-foot-deep water appears and swirls in a 30-foot radius centered on a point you can see within range. The point must be on ground or in a body of water. Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center.</text>
+		<roll>6d6</roll>
+	</spell>
+	<spell>
+		<name>Magic Stone</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 bonus action</time>
+		<range>Touch</range>
+		<components>V, S</components>
+		<duration>1 minute</duration>
+		<classes>Druid, Warlock</classes>
+		<text>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker's, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</text>
+		<text>    If you cast this spell again, the spell ends early on any pebbles still affected by it.</text>
+		<roll>1d20+SPELL+PROF</roll>
+		<roll>1d6+SPELL</roll>
+	</spell>
+	<spell>
+		<name>Maximilian's Earthen Grasp</name>
+		<level>2</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>V, S, M (a miniature hand sculpted from clay)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Sorcerer, Wizard</classes>
+		<text>You choose a 5-foot-square unoccupied space on the ground that you can see within range. A Medium hand made from compacted soil rises there and reaches for one creature you can see within 5 feet of it. The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell's duration.</text>
+		<text>    As an action, you can cause the hand to crush the restrained target, who must make a Strength saving throw. It takes 2d6 bludgeoning damage on a failed save, or half as much damage on a successful one.</text>
+		<text>    To break out, the restrained target can make a Strength check against your spell save DC. On a success, the target escapes and is no longer restrained by the hand.</text>
+		<text>    As an action, you can cause the hand to reach for a different creature or to move to a different unoccupied space within range. The hand releases a restrained target if you do either.</text>
+		<roll>2d6</roll>
+	</spell>
+	<spell>
+		<name>Melf's Minute Meteors</name>
+		<level>3</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S, M (niter, sulfur, and pine tar formed into a bead)</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You create six tiny meteors in your space. They float in the air and orbit you for the spell's duration. When you cast the spell-and as a bonus action on each of your turns thereafter-you can expend one or two of the meteors, sending them streaking toward a point or points you choose within 120 feet of you. Once a meteor reaches its destination or impacts against a solid surface, the meteor explodes. Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one.</text>
+		<text>    At Higher Levels: When you cast this spell using a spell slot of 4th level or higher, the number of meteors created increases by two for each slot level above 3rd.</text>
+		<roll>2d6</roll>
+	</spell>
+	<spell>
+		<name>Mold Earth</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>S</components>
+		<duration>Instantaneous or 1 hour (see below)</duration>
+		<classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You choose a portion of dirt or stone that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways.</text>
+		<text>    • If you target an area of loose earth, you can instantaneously excavate it, move it along the ground, and deposit it up to 5 feet away. This movement doesn't have enough force to cause damage.</text>
+		<text>    • You cause shapes, colors, or both to appear on the dirt or stone, spelling out words, creating images, or shaping patterns. The changes last for 1 hour.</text>
+		<text>    • If the dirt or stone you target is on the ground, you cause it to become difficult terrain. Alternatively, you can cause the ground to become normal terrain if it is already difficult terrain. This change lasts for 1 hour.</text>
+		<text>    If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
+	</spell>
+	<spell>
+		<name>Primordial Ward</name>
+		<level>6</level>
+		<school>A</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid</classes>
+		<text>You have resistance to acid, cold, fire, lightning, and thunder damage for the spell's duration.</text>
+		<text>    When you take damage of one of those types, you can use your reaction to gain immunity to that type of damage, including against the triggering damage. If you do so, the resistances end, and you have the immunity until the end of your next turn, at which time the spell ends.</text>
+	</spell>
+	<spell>
+		<name>Pyrotechnics</name>
+		<level>2</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>V, S</components>
+		<duration>Instantaneous</duration>
+		<classes>Bard, Sorcerer, Wizard</classes>
+		<text>Choose an area of flame that you can see and that can fit within a 5-foot cube within range. You can extinguish the fire in that area, and you create either fireworks or smoke.</text>
+		<text>    Fireworks: The target explodes with a dazzling display of colors. Each creature within 10 feet of the target must succeed on a Constitution saving throw or become blinded until the end of your next turn.</text>
+		<text>    Smoke: Thick black smoke spreads out from the target in a 20-foot radius, moving around corners. The area of the smoke is heavily obscured. The smoke persists for 1 minute or until a strong wind disperses it.</text>
+	</spell>
+	<spell>
+		<name>Shape Water</name>
+		<level>0</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>30 feet</range>
+		<components>S</components>
+		<duration>Instantaneous or 1 hour (see below)</duration>
+		<classes>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You choose an area of water that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways.</text>
+		<text>    • You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn't have enough force to cause damage.</text>
+		<text>    • You cause the water to form into simple shapes and animate at your direction. This change lasts for 1 hour.</text>
+		<text>    • You change the water's color or opacity. The water must be changed in the same way throughout. This change lasts for 1 hour.</text>
+		<text>    • You freeze the water, provided that there are no creatures in it. The water unfreezes in 1 hour.</text>
+		<text>    If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.</text>
+	</spell>
+	<spell>
+		<name>Skywrite</name>
+		<level>2</level>
+		<school>T</school>
+		<ritual>YES</ritual>
+		<time>1 action</time>
+		<range>Sight</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 hour</duration>
+		<classes>Bard, Druid, Wizard</classes>
+		<text>You cause up to ten words to form in a part of the sky you can see. The words appear to be made of cloud and remain in place for the spell's duration. The words dissipate when the spell ends. A strong wind can disperse the clouds and end the spell early.</text>
+	</spell>
+	<spell>
+		<name>Snilloc's Snowball Swarm</name>
+		<level>2</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V, S, M (a piece of ice or a small white rock chip)</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>A flurry of magic snowballs erupts from a point you choose within range. Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one.</text>
+		<text>    At Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.</text>
+		<roll>3d6</roll>
+	</spell>
+	<spell>
+		<name>Storm Sphere</name>
+		<level>4</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>150 feet</range>
+		<components>V, S</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell's duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere's space is difficult terrain.</text>
+		<text>    Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</text>
+		<text>    Creatures within 30 feet of the sphere have disadvantage on Wisdom (Perception) checks made to listen.</text>
+		<text>    At Higher Levels: When you cast this spell using a spell slot of 5th level or higher, the damage increases for each of its effects by 1d6 for each slot level above 4th</text>
+		<roll>1d20+SPELL+PROF</roll>
+		<roll>2d6</roll>
+		<roll>4d6</roll>
+	</spell>
+	<spell>
+		<name>Thunderclap</name>
+		<level>0</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self (5-foot radius)</range>
+		<components>S</components>
+		<duration>Instantaneous</duration>
+		<classes>Bard, Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
+		<text>You create a burst of thunderous sound, which can be heard 100 feet away. Each creature other than you within 5 feet of you must make a Constitution saving throw. On a failed save, the creature takes 1d6 thunder damage.</text>
+		<text>    The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</text>
+		<roll>1d6</roll>
+		<roll>2d6</roll>
+		<roll>3d6</roll>
+		<roll>4d6</roll>
+	</spell>
+	<spell>
+		<name>Tidal Wave</name>
+		<level>3</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S, M (a drop of water)</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Wizard</classes>
+		<text>You conjure up a wave of water that crashes down on an area within range. The area can be up to 30 feet long, up to 10 feet wide, and up to 10 feet tall. Each creature in that area must make a Dexterity saving throw. On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone. On a success, a creature takes half as much damage and isn't knocked prone. The water then spreads out across the ground in all directions, extinguishing unprotected flames in its area and within 30 feet of it.</text>
+		<roll>4d8</roll>
+	</spell>
+	<spell>
+		<name>Transmute Rock</name>
+		<level>5</level>
+		<school>T</school>
+		<ritual />
+		<time>1 action</time>
+		<range>120 feet</range>
+		<components>V, S, M (clay and water)</components>
+		<duration>Instantaneous</duration>
+		<classes>Druid, Wizard</classes>
+		<text>You choose an area of stone or mud that you can see that fits within a 40-foot cube and that is within range, and choose one of the following effects.</text>
+		<text>    Transmute Rock to Mud: Nonmagical rock of any sort in the area becomes an equal volume of thick and flowing mud that remains for the spell's duration.</text>
+		<text>    If you cast the spell on an area of ground, it becomes muddy enough that creatures can sink into it. Each foot that a creature moves through the mud costs 4 feet of movement, and any creature on the ground when you cast the spell must make a Strength saving throw. A creature must also make this save the first time it enters the area on a turn or ends its turn there. On a failed save, a creature sinks into the mud and is restrained, though it can use an action to end the restrained condition on itself by pulling itself free of the mud.</text>
+		<text>    If you cast the spell on a ceiling, the mud falls. Any creature under the mud when it falls must make a Dexterity saving throw. A creature takes 4d8 bludgeoning damage on a failed save, or half as much damage on a successful one.</text>
+		<text>    Transmute Mud to Rock: Nonmagical mud or quicksand in the area no more than 10 feet deep transforms into soft stone for the spell's duration. Any creature in the mud when it transforms must make a Dexterity saving throw. On a failed save, a creature becomes restrained by the rock. The restrained creature can use an action to try to break free by succeeding on a Strength check (DC 20) or by dealing 25 damage to the rock around it. On a successful save, a creature is shunted safely to the surface to an unoccupied space.</text>
+		<roll>4d8</roll>
+	</spell>
+	<spell>
+		<name>Vitriolic Sphere</name>
+		<level>4</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>150 feet</range>
+		<components>V, S, M (a drop of giant slug bile)</components>
+		<duration>Instantaneous</duration>
+		<classes>Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You point at a place within range, and a glowing 1-foot ball of emerald acid streaks there and explodes in a 20-foot radius. Each creature in that area must make a Dexterity saving throw. On a failed save, a creature takes 10d4 acid damage and 5d4 acid damage at the end of its next turn. On a successful save, a creature takes half the initial damage and no damage at the end of its next turn.</text>
+		<text>    At Higher Levels: When you cast this spell using a spell slot of 5th level or higher, the initial damage increases by 2d4 for each slot level above 4th.</text>
+		<roll>10d4</roll>
+		<roll>5d4</roll>
+	</spell>
+	<spell>
+		<name>Wall of Sand</name>
+		<level>3</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V, S, M (a handful of sand)</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You conjure up a wall of swirling sand on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 10 feet thick, and it vanishes when the spell ends. It blocks line of sight but not movement. A creature is blinded while in the wall's space and must spend 3 feet of movement for every 1 foot it moves there.</text>
+	</spell>
+	<spell>
+		<name>Wall of Water</name>
+		<level>3</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>60 feet</range>
+		<components>V, S, M (a drop of water)</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Druid, Sorcerer, Wizard, Fighter (Eldritch Knight)</classes>
+		<text>You conjure up a wall of water on the ground at a point you can see within range. You can make the wall up to 30 feet long, 10 feet high, and 1 foot thick, or you can make a ringed wall up to 20 feet in diameter, 20 feet high, and 1 foot thick. The wall vanishes when the spell ends. The wall's space is difficult terrain.</text>
+		<text>    Any ranged weapon attack that enters the wall's space has disadvantage on the attack roll, and fire damage is halved if the fire effect passes through the wall to reach its target. Spells that deal cold damage that pass through the wall cause the area of the wall they pass through to freeze solid (at least a 5-foot square section is frozen). Each 5-foot-square frozen section has AC 5 and 15 hit points. Reducing a frozen section to 0 hit points destroys it. When a section is destroyed, the wall's water doesn't fill it.</text>
+	</spell>
+	<spell>
+		<name>Warding Wind</name>
+		<level>2</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>Self</range>
+		<components>V</components>
+		<duration>Concentration, up to 10 minutes</duration>
+		<classes>Bard, Druid, Sorcerer</classes>
+		<text>A strong wind (20 miles per hour) blows around you in a 10-foot radius and moves with you, remaining centered on you. The wind lasts for the spell's duration.</text>
+		<text>    The wind has the following effects.</text>
+		<text>    • It deafens you and other creatures in its area.</text>
+		<text>    • It extinguishes unprotected flames in its area that are torch-sized or smaller.</text>
+		<text>    • The area is difficult terrain for creatures other than you.</text>
+		<text>    • The attack rolls of ranged weapon attacks have disadvantage if they pass in or out of the wind.</text>
+		<text>    • It hedges out vapor, gas, and fog that can be dispersed by strong wind.</text>
+	</spell>
+	<spell>
+		<name>Watery Sphere</name>
+		<level>4</level>
+		<school>C</school>
+		<ritual />
+		<time>1 action</time>
+		<range>90 feet</range>
+		<components>V, S, M (a droplet of water)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Sorcerer, Wizard</classes>
+		<text>You conjure up a sphere of water with a 10-foot radius on a point you can see within range. The sphere can hover in the air, but no more than 10 feet off the ground. The sphere remains for the spell's duration.</text>
+		<text>    Any creature in the sphere's space must make a Strength saving throw. On a successful save, a creature is ejected from that space to the nearest unoccupied space outside it. A Huge or larger creature succeeds on the saving throw automatically. On a failed save, a creature is restrained by the sphere and is engulfed by the water. At the end of each of its turns, a restrained target can repeat the saving throw.</text>
+		<text>    The sphere can restrain a maximum of four Medium or smaller creatures or one Large creature. If the sphere restrains a creature in excess of these numbers, a random creature that was already restrained by the sphere falls out of it and lands prone in a space within 5 feet of it.</text>
+		<text>    As an action, you can move the sphere up to 30 feet in a straight line. If it moves over a pit, cliff, or other drop, it safely descends until it is hovering 10 feet over ground. Any creature restrained by the sphere moves with it. You can ram the sphere into creatures, forcing them to make the saving throw, but no more than once per turn.</text>
+		<text>    When the spell ends, the sphere falls to the ground and extinguishes all normal flames within 30 feet of it. Any creature restrained by the sphere is knocked prone in the space where it falls.</text>
+	</spell>
+	<spell>
+		<name>Whirlwind</name>
+		<level>7</level>
+		<school>EV</school>
+		<ritual />
+		<time>1 action</time>
+		<range>300 feet</range>
+		<components>V, M (a piece of straw)</components>
+		<duration>Concentration, up to 1 minute</duration>
+		<classes>Druid, Wizard</classes>
+		<text>A whirlwind howls down to a point on the ground you specify. The whirlwind is a 10-foot-radius, 30-foot-high cylinder centered on that point. Until the spell ends, you can use your action to move the whirlwind up to 30 feet in any direction along the ground. The whirlwind sucks up any Medium or smaller objects that aren't secured to anything and that aren't worn or carried by anyone.</text>
+		<text>    A creature must make a Dexterity saving throw the first time on a turn that it enters the whirlwind or that the whirlwind enters its space, including when the whirlwind first appears. A creature takes 10d6 bludgeoning damage on a failed save, or half as much damage on a successful one. In addition, a Large or smaller creature that fails the save must succeed on a Strength saving throw or become restrained in the whirlwind until the spell ends. When a creature starts its turn restrained by the whirlwind, the creature is pulled 5 feet higher inside it, unless the creature is at the top. A restrained creature moves with the whirlwind and falls when the spell ends, unless the creature has some means to stay aloft.</text>
+		<text>    A restrained creature can use an action to make a Strength or Dexterity check against your spell save DC. If successful, the creature is no longer restrained by the whirlwind and is hurled 3d6 x 10 feet away from it in a random direction.</text>
+		<roll>10d6</roll>
+		<roll>3d6*10</roll>
+		<roll>1d8</roll>
+	</spell>
+</spells>


### PR DESCRIPTION
I renamed the Holy Symbol items to make them easier to find.
I've added the cantrips and the Duergar from the Sword Coast Adventurer's Guide.
