### PR TITLE
fixes #159, changes oathbreaker channel description, removed trailing spaces

### DIFF
--- a/Character Files/Classes.xml
+++ b/Character Files/Classes.xml
@@ -869,7 +869,7 @@
 			<feature optional="YES">
 				<name>Arcana Domain: Arcane Initiate</name>
 				<text>When you choose this domain at 1st level, you gain proficiency in the Arcana skill, and you gain two cantrips of your choice from the wizard spell list. For you, these cantrips count as cleric cantrips.</text>
-			</feature>	
+			</feature>
 			<feature optional="YES">
 				<name>Death Domain: Bonus Proficiency</name>
 				<text>When the cleric chooses this domain at 1st level, he or she gains proficiency with martial weapons.</text>
@@ -945,7 +945,7 @@
 				<text>    A turned creature must spend its turns trying to move as far away from you as it can, and it can't willingly move to a space within 30 feet of you. It also can't take reactions. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If there's nowhere to move, the creature can use the Dodge action.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Arcana Domain Channel Divinity: Arcane Abjuration</name>	
+				<name>Arcana Domain Channel Divinity: Arcane Abjuration</name>
 				<text>Starting at 2nd level, you can use your Channel Divinity to abjure otherworldly creatures</text>
 				<text></text>
 				<text>As an action, you present your holy symbol, and one celestial, elemental, fey, or fiend of your choice that is within 30 feet of you must make a Wisdom saving throw, provided that the creature can see or hear you. IF the creature fails its saving throw, it is turned for 1 minute or until it takes any damage.</text>
@@ -2252,7 +2252,7 @@
 				<name>Way of the Sun Soul: Searing Arc Strike</name>
 				<text>At 6th level, you gain the ability to channel your ki into searing waves of energy. Immediately after you take the Attack action on your turn, you can spend 2 ki points to cast the 1st-level spell burning hands as a bonus action.</text>
 				<text>	You can spend additional ki points to cast burning hands as a higher level spell. Each additional ki point you spend increases the spell's level by 1. The maximum number of ki points (2 plus any additional points) that you can spend on the spell equals half your monk level (round down).</text>
-			</feature>		
+			</feature>
 		</autolevel>
 
 		<autolevel level="7">
@@ -2759,7 +2759,7 @@
                 <text>Alternatively, you may start with gold and choose your own equipment. (Unearthed Arcana does not </text>-->
             </feature>
         </autolevel>
- 
+
     <autolevel level="1">
 		<feature>
 			<name>Note</name>
@@ -2906,7 +2906,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="2">
         <feature optional="YES">
             <name>Discipline: Conquering Mind</name>
@@ -2986,7 +2986,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="3">
         <feature optional="YES">
             <name>Object Reading (Order of the Awakened)</name>
@@ -2999,7 +2999,7 @@
             <text>At 3rd level, you learn to use psionic energy to augment and speed up your natural healing abilities. At the end of your turn, if your current hit point total is half or less of your hit point maximum, you regain hit points equal to half your mystic level.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="4">
         <feature>
             <name>Ability Score Improvement</name>
@@ -3007,7 +3007,7 @@
             <text>    If your DM uses the optional Feats, you can instead take a feat.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="5">
         <feature optional="YES">
             <name>Discipline: Conquering Mind</name>
@@ -3088,7 +3088,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
 </class>
 
 	<class>
@@ -3335,7 +3335,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Oathbreaker Channel Divinity: Control Undead</name>
-				<text>As an action, you can imbue one weapon that you are holding with positive energy, using your Channel Divinity. For 1 minute, you add your Charisma modifier to attack rolls made with that weapon (with a minimum bonus of +1). The weapon also emits bright light in a 20-foot radius and dim light 20 feet beyond that. If the weapon is not already magical, it becomes magical for the duration.</text>
+				<text>As an action, the paladin targets one undead creature he or she can see within 30 feet of him or her. The target must make a Wisdom saving throw. On a failed save, the target must obey the paladin's commands for the next 24 hours, or until the paladin uses this Channel Divinity option again. An undead whose challenge rating is equal to or greater than the paladin's level is immune to this effect.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Oathbreaker Channel Divinity: Dreadful Aspect</name>
@@ -3426,7 +3426,7 @@
 			<feature optional="YES">
 				<name>Oath of the Crown: Divine Allegiance</name>
 				<text>Starting at 7th level, when a creature within 5 feet of you takes damage, you can use your reaction to magically substitute your own health for that of the target creature, causing that creature not to take the damage. Instead, you take the damage. This damage to you can't be reduced or prevented in any way.</text>
-			</feature>	
+			</feature>
 		</autolevel>
 
 		<autolevel level="8">

--- a/Compendiums/Character Compendium
+++ b/Compendiums/Character Compendium
@@ -77,7 +77,7 @@
 			<text>One type of artisan's tools</text>
 		</trait>
 		<trait>
-			<name>Languages</name>			
+			<name>Languages</name>
 			<text>Dwarvish or one of your choice if you already speak Dwarvish</text>
 		</trait>
 		<trait>
@@ -2775,7 +2775,7 @@
 			<feature optional="YES">
 				<name>Arcana Domain: Arcane Initiate</name>
 				<text>When you choose this domain at 1st level, you gain proficiency in the Arcana skill, and you gain two cantrips of your choice from the wizard spell list. For you, these cantrips count as cleric cantrips.</text>
-			</feature>	
+			</feature>
 			<feature optional="YES">
 				<name>Death Domain: Bonus Proficiency</name>
 				<text>When the cleric chooses this domain at 1st level, he or she gains proficiency with martial weapons.</text>
@@ -2851,7 +2851,7 @@
 				<text>    A turned creature must spend its turns trying to move as far away from you as it can, and it can't willingly move to a space within 30 feet of you. It also can't take reactions. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If there's nowhere to move, the creature can use the Dodge action.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Arcana Domain Channel Divinity: Arcane Abjuration</name>	
+				<name>Arcana Domain Channel Divinity: Arcane Abjuration</name>
 				<text>Starting at 2nd level, you can use your Channel Divinity to abjure otherworldly creatures</text>
 				<text></text>
 				<text>As an action, you present your holy symbol, and one celestial, elemental, fey, or fiend of your choice that is within 30 feet of you must make a Wisdom saving throw, provided that the creature can see or hear you. IF the creature fails its saving throw, it is turned for 1 minute or until it takes any damage.</text>
@@ -4158,7 +4158,7 @@
 				<name>Way of the Sun Soul: Searing Arc Strike</name>
 				<text>At 6th level, you gain the ability to channel your ki into searing waves of energy. Immediately after you take the Attack action on your turn, you can spend 2 ki points to cast the 1st-level spell burning hands as a bonus action.</text>
 				<text>	You can spend additional ki points to cast burning hands as a higher level spell. Each additional ki point you spend increases the spell's level by 1. The maximum number of ki points (2 plus any additional points) that you can spend on the spell equals half your monk level (round down).</text>
-			</feature>		
+			</feature>
 		</autolevel>
 
 		<autolevel level="7">
@@ -4665,7 +4665,7 @@
                 <text>Alternatively, you may start with gold and choose your own equipment. (Unearthed Arcana does not </text>-->
             </feature>
         </autolevel>
- 
+
     <autolevel level="1">
 		<feature>
 			<name>Note</name>
@@ -4812,7 +4812,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="2">
         <feature optional="YES">
             <name>Discipline: Conquering Mind</name>
@@ -4892,7 +4892,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="3">
         <feature optional="YES">
             <name>Object Reading (Order of the Awakened)</name>
@@ -4905,7 +4905,7 @@
             <text>At 3rd level, you learn to use psionic energy to augment and speed up your natural healing abilities. At the end of your turn, if your current hit point total is half or less of your hit point maximum, you regain hit points equal to half your mystic level.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="4">
         <feature>
             <name>Ability Score Improvement</name>
@@ -4913,7 +4913,7 @@
             <text>    If your DM uses the optional Feats, you can instead take a feat.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="5">
         <feature optional="YES">
             <name>Discipline: Conquering Mind</name>
@@ -4994,7 +4994,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
 </class>
 
 	<class>
@@ -5241,7 +5241,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Oathbreaker Channel Divinity: Control Undead</name>
-				<text>As an action, you can imbue one weapon that you are holding with positive energy, using your Channel Divinity. For 1 minute, you add your Charisma modifier to attack rolls made with that weapon (with a minimum bonus of +1). The weapon also emits bright light in a 20-foot radius and dim light 20 feet beyond that. If the weapon is not already magical, it becomes magical for the duration.</text>
+				<text>As an action, the paladin targets one undead creature he or she can see within 30 feet of him or her. The target must make a Wisdom saving throw. On a failed save, the target must obey the paladin's commands for the next 24 hours, or until the paladin uses this Channel Divinity option again. An undead whose challenge rating is equal to or greater than the paladin's level is immune to this effect.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Oathbreaker Channel Divinity: Dreadful Aspect</name>
@@ -5332,7 +5332,7 @@
 			<feature optional="YES">
 				<name>Oath of the Crown: Divine Allegiance</name>
 				<text>Starting at 7th level, when a creature within 5 feet of you takes damage, you can use your reaction to magically substitute your own health for that of the target creature, causing that creature not to take the damage. Instead, you take the damage. This damage to you can't be reduced or prevented in any way.</text>
-			</feature>	
+			</feature>
 		</autolevel>
 
 		<autolevel level="8">

--- a/Compendiums/Full Compendium
+++ b/Compendiums/Full Compendium
@@ -8027,7 +8027,7 @@
 		<ac>2</ac>
 		<strength></strength>
 		<stealth></stealth>
-  		<modifier category="bonus">passive wisdom +5</modifier>		
+  		<modifier category="bonus">passive wisdom +5</modifier>
 	</item>
 	<item>
 		<name>Shield of Missile Attraction</name>
@@ -12789,7 +12789,7 @@
 		<text>While you wear this cloak with its hood up, Wisdom (Perception) checks made to see you have disadvantage. and you have advantage on Dexterity (Stealth) checks made to hide, as the cloak's color shifts to camouflage you. Pulling the hood up or down requires an action.</text>
 		<text />
 		<text>Source: Out of the Abyss, page 222</text>
-	</item>	
+	</item>
 	<item>
 		<name>Piwafwi of Fire Resistance (Cloak of Elvenkind)</name>
 		<type>W</type>
@@ -17292,7 +17292,7 @@
 		<components>V</components>
 		<duration>Concentration, up to 10 minutes</duration>
 		<classes>Paladin, Paladin (Crown)</classes>
-		<text>Divine energy radiates from you, distorting and diffusing magical energy within 30 feet of you. Until the spell ends, the sphere moves with you, centered on you. For the duration, each friendly creature in the area (including you) has advantage on saving throws against spells and other magical effects. Additionally, when an affected creature succeeds on a saving throw made against a spell or magical effect that allows it to make a saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw.</text>	
+		<text>Divine energy radiates from you, distorting and diffusing magical energy within 30 feet of you. Until the spell ends, the sphere moves with you, centered on you. For the duration, each friendly creature in the area (including you) has advantage on saving throws against spells and other magical effects. Additionally, when an affected creature succeeds on a saving throw made against a spell or magical effect that allows it to make a saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw.</text>
 	</spell>
 	<spell>
 		<name>Clairvoyance</name>
@@ -23565,7 +23565,7 @@
 			<text>One type of artisan's tools</text>
 		</trait>
 		<trait>
-			<name>Languages</name>			
+			<name>Languages</name>
 			<text>Dwarvish or one of your choice if you already speak Dwarvish</text>
 		</trait>
 		<trait>
@@ -26263,7 +26263,7 @@
 			<feature optional="YES">
 				<name>Arcana Domain: Arcane Initiate</name>
 				<text>When you choose this domain at 1st level, you gain proficiency in the Arcana skill, and you gain two cantrips of your choice from the wizard spell list. For you, these cantrips count as cleric cantrips.</text>
-			</feature>	
+			</feature>
 			<feature optional="YES">
 				<name>Death Domain: Bonus Proficiency</name>
 				<text>When the cleric chooses this domain at 1st level, he or she gains proficiency with martial weapons.</text>
@@ -26339,7 +26339,7 @@
 				<text>    A turned creature must spend its turns trying to move as far away from you as it can, and it can't willingly move to a space within 30 feet of you. It also can't take reactions. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If there's nowhere to move, the creature can use the Dodge action.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Arcana Domain Channel Divinity: Arcane Abjuration</name>	
+				<name>Arcana Domain Channel Divinity: Arcane Abjuration</name>
 				<text>Starting at 2nd level, you can use your Channel Divinity to abjure otherworldly creatures</text>
 				<text></text>
 				<text>As an action, you present your holy symbol, and one celestial, elemental, fey, or fiend of your choice that is within 30 feet of you must make a Wisdom saving throw, provided that the creature can see or hear you. IF the creature fails its saving throw, it is turned for 1 minute or until it takes any damage.</text>
@@ -27646,7 +27646,7 @@
 				<name>Way of the Sun Soul: Searing Arc Strike</name>
 				<text>At 6th level, you gain the ability to channel your ki into searing waves of energy. Immediately after you take the Attack action on your turn, you can spend 2 ki points to cast the 1st-level spell burning hands as a bonus action.</text>
 				<text>	You can spend additional ki points to cast burning hands as a higher level spell. Each additional ki point you spend increases the spell's level by 1. The maximum number of ki points (2 plus any additional points) that you can spend on the spell equals half your monk level (round down).</text>
-			</feature>		
+			</feature>
 		</autolevel>
 
 		<autolevel level="7">
@@ -28153,7 +28153,7 @@
                 <text>Alternatively, you may start with gold and choose your own equipment. (Unearthed Arcana does not </text>-->
             </feature>
         </autolevel>
- 
+
     <autolevel level="1">
 		<feature>
 			<name>Note</name>
@@ -28300,7 +28300,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="2">
         <feature optional="YES">
             <name>Discipline: Conquering Mind</name>
@@ -28380,7 +28380,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="3">
         <feature optional="YES">
             <name>Object Reading (Order of the Awakened)</name>
@@ -28393,7 +28393,7 @@
             <text>At 3rd level, you learn to use psionic energy to augment and speed up your natural healing abilities. At the end of your turn, if your current hit point total is half or less of your hit point maximum, you regain hit points equal to half your mystic level.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="4">
         <feature>
             <name>Ability Score Improvement</name>
@@ -28401,7 +28401,7 @@
             <text>    If your DM uses the optional Feats, you can instead take a feat.</text>
         </feature>
     </autolevel>
- 
+
     <autolevel level="5">
         <feature optional="YES">
             <name>Discipline: Conquering Mind</name>
@@ -28482,7 +28482,7 @@
             <text>Augmented Weapon (5): You can strengthen the energy that you have infused into your psionic weapon, increasing its bonus to attack rolls and damage rolls to +3 for 1 minute.</text>
         </feature>
     </autolevel>
- 
+
 </class>
 
 	<class>
@@ -28729,7 +28729,7 @@
 			</feature>
 			<feature optional="YES">
 				<name>Oathbreaker Channel Divinity: Control Undead</name>
-				<text>As an action, you can imbue one weapon that you are holding with positive energy, using your Channel Divinity. For 1 minute, you add your Charisma modifier to attack rolls made with that weapon (with a minimum bonus of +1). The weapon also emits bright light in a 20-foot radius and dim light 20 feet beyond that. If the weapon is not already magical, it becomes magical for the duration.</text>
+				<text>As an action, the paladin targets one undead creature he or she can see within 30 feet of him or her. The target must make a Wisdom saving throw. On a failed save, the target must obey the paladin's commands for the next 24 hours, or until the paladin uses this Channel Divinity option again. An undead whose challenge rating is equal to or greater than the paladin's level is immune to this effect.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Oathbreaker Channel Divinity: Dreadful Aspect</name>
@@ -28820,7 +28820,7 @@
 			<feature optional="YES">
 				<name>Oath of the Crown: Divine Allegiance</name>
 				<text>Starting at 7th level, when a creature within 5 feet of you takes damage, you can use your reaction to magically substitute your own health for that of the target creature, causing that creature not to take the damage. Instead, you take the damage. This damage to you can't be reduced or prevented in any way.</text>
-			</feature>	
+			</feature>
 		</autolevel>
 
 		<autolevel level="8">


### PR DESCRIPTION
See #159 for requested text change.

Additionally, atom.io was kind enough to strip trailing whirespace on save.

@ceryliae Is there a way to rebuild the files? Currently just made the change manually across the three instances.
