### PR TITLE
Magic Items.xml - Empty tags (multiple)

### DIFF
--- a/Items/Magic Items.xml
+++ b/Items/Magic Items.xml
@@ -30,7 +30,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -194,7 +193,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -216,7 +214,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>16</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -227,7 +224,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>18</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -238,7 +234,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -249,7 +244,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>17</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -381,7 +375,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -393,7 +386,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -405,7 +397,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -417,7 +408,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -429,7 +419,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -441,7 +430,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -453,7 +441,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -465,7 +452,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -477,7 +463,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -489,7 +474,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -621,7 +605,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -633,7 +616,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -645,7 +627,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -657,7 +638,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -669,7 +649,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -681,7 +660,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -693,7 +671,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -705,7 +682,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -717,7 +693,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -729,7 +704,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -740,7 +714,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -751,7 +724,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -762,7 +734,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -774,7 +745,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -786,7 +756,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -798,7 +767,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -810,7 +778,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -822,7 +789,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -834,7 +800,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -846,7 +811,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -858,7 +822,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -870,7 +833,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -882,7 +844,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -894,7 +855,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -906,7 +866,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -918,7 +877,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -930,7 +888,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -942,7 +899,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -954,7 +910,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -966,7 +921,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -978,7 +932,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -990,7 +943,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -1002,7 +954,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -1961,7 +1912,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -1972,7 +1922,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -1983,7 +1932,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -1994,7 +1942,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2008,7 +1955,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2022,7 +1968,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2036,7 +1981,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2048,7 +1992,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2060,7 +2003,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2072,7 +2014,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2084,7 +2025,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2096,7 +2036,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2108,7 +2047,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2120,7 +2058,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2132,7 +2069,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2144,7 +2080,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2156,7 +2091,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2170,7 +2104,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2182,7 +2115,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2194,7 +2126,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2206,7 +2137,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2218,7 +2148,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2230,7 +2159,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2242,7 +2170,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2254,7 +2181,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2266,7 +2192,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2278,7 +2203,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2290,7 +2214,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2304,7 +2227,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2318,7 +2240,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2332,7 +2253,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2344,7 +2264,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2356,7 +2275,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2368,7 +2286,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2380,7 +2297,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2392,7 +2308,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2404,7 +2319,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2416,7 +2330,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2428,7 +2341,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2440,7 +2352,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2452,7 +2363,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2464,7 +2374,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2476,7 +2385,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2488,7 +2396,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2500,7 +2407,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2512,7 +2418,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2524,7 +2429,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2536,7 +2440,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2548,7 +2451,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2560,7 +2462,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2572,7 +2473,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2583,7 +2483,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2594,7 +2493,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2605,7 +2503,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2616,7 +2513,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2627,7 +2523,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2638,7 +2533,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2649,7 +2543,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2660,7 +2553,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2671,7 +2563,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -2685,7 +2576,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2697,7 +2587,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2709,7 +2598,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2721,7 +2609,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2733,7 +2620,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2745,7 +2631,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2757,7 +2642,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2769,7 +2653,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2781,7 +2664,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2793,7 +2675,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2805,7 +2686,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2819,7 +2699,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -2833,7 +2712,6 @@
 		<text>Source: Dungeon Master's Guide, page 165</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -3397,7 +3275,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -3409,7 +3286,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -3421,7 +3297,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -3469,7 +3344,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -3481,7 +3355,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -3493,7 +3366,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -3505,7 +3377,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -3517,7 +3388,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -3529,7 +3399,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>11</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -3541,7 +3410,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -3553,7 +3421,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -3565,7 +3432,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5125,7 +4991,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5137,7 +5002,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5149,7 +5013,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5161,7 +5024,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5173,7 +5035,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5185,7 +5046,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5197,7 +5057,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -5209,7 +5068,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -5221,7 +5079,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>15</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -5233,7 +5090,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5245,7 +5101,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5257,7 +5112,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>12</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5269,7 +5123,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -5281,7 +5134,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -5293,7 +5145,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -5917,7 +5768,6 @@
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5929,7 +5779,6 @@
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -5941,7 +5790,6 @@
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -6099,7 +5947,6 @@
 		<text>Source: Dungeon Master's Guide, page 172</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -7962,7 +7809,6 @@
 		<text>Source: Dungeon Master's Guide, page 209</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>13</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -8000,7 +7846,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 183</text>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -8012,7 +7857,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -8023,7 +7867,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 199</text>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
   		<modifier category="bonus">passive wisdom +5</modifier>		
 	</item>
@@ -8038,7 +7881,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -8050,7 +7892,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 201</text>
 		<ac>2</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 	<item>
@@ -12973,7 +12814,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -12985,7 +12825,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -12997,7 +12836,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13009,7 +12847,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13021,7 +12858,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13033,7 +12869,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13045,7 +12880,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13057,7 +12891,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13069,7 +12902,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13081,7 +12913,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13093,7 +12924,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13105,7 +12935,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13117,7 +12946,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13129,7 +12957,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13140,7 +12967,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth>YES</stealth>
 	</item>
 	<item>
@@ -13151,7 +12977,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<strength></strength>
 		<stealth></stealth>
 	</item>
 </compendium>

--- a/Items/Magic Items.xml
+++ b/Items/Magic Items.xml
@@ -214,7 +214,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>16</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mithral Plate Armor</name>
@@ -224,7 +223,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>18</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mithral Ring Mail</name>
@@ -234,7 +232,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mithral Splint Armor</name>
@@ -244,7 +241,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>17</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Plate Armor of Acid Resistance</name>
@@ -605,7 +601,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Cold Resistance</name>
@@ -616,7 +611,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Fire Resistance</name>
@@ -627,7 +621,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Force Resistance</name>
@@ -638,7 +631,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Lightning Resistance</name>
@@ -649,7 +641,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Necrotic Resistance</name>
@@ -660,7 +651,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Poison Resistance</name>
@@ -671,7 +661,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Psychic Resistance</name>
@@ -682,7 +671,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Radiant Resistance</name>
@@ -693,7 +681,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor of Thunder Resistance</name>
@@ -704,7 +691,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mariner's Leather Armor</name>
@@ -714,7 +700,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mariner's Padded Armor</name>
@@ -734,7 +719,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Padded Armor of Acid Resistance</name>
@@ -855,7 +839,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Cold Resistance</name>
@@ -866,7 +849,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Fire Resistance</name>
@@ -877,7 +859,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Force Resistance</name>
@@ -888,7 +869,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Lightning Resistance</name>
@@ -899,7 +879,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Necrotic Resistance</name>
@@ -910,7 +889,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Poison Resistance</name>
@@ -921,7 +899,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Psychic Resistance</name>
@@ -932,7 +909,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Radiant Resistance</name>
@@ -943,7 +919,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor of Thunder Resistance</name>
@@ -954,7 +929,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Battleaxe of Warning</name>
@@ -1912,7 +1886,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Adamantine Chain Shirt</name>
@@ -1922,7 +1895,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 150</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Adamantine Half Plate Armor</name>
@@ -1992,7 +1964,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Cold Resistance</name>
@@ -2003,7 +1974,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Fire Resistance</name>
@@ -2014,7 +1984,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Force Resistance</name>
@@ -2025,7 +1994,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Lightning Resistance</name>
@@ -2036,7 +2004,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Necrotic Resistance</name>
@@ -2047,7 +2014,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Poison Resistance</name>
@@ -2058,7 +2024,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Psychic Resistance</name>
@@ -2069,7 +2034,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Radiant Resistance</name>
@@ -2080,7 +2044,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate of Thunder Resistance</name>
@@ -2091,7 +2054,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Bronze Dragon Scale Mail</name>
@@ -2115,7 +2077,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Cold Resistance</name>
@@ -2126,7 +2087,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Fire Resistance</name>
@@ -2137,7 +2097,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Force Resistance</name>
@@ -2148,7 +2107,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Lightning Resistance</name>
@@ -2159,7 +2117,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Necrotic Resistance</name>
@@ -2170,7 +2127,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Poison Resistance</name>
@@ -2181,7 +2137,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Psychic Resistance</name>
@@ -2192,7 +2147,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Radiant Resistance</name>
@@ -2203,7 +2157,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt of Thunder Resistance</name>
@@ -2214,7 +2167,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Copper Dragon Scale Mail</name>
@@ -2374,7 +2326,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Cold Resistance</name>
@@ -2385,7 +2336,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Fire Resistance</name>
@@ -2396,7 +2346,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Force Resistance</name>
@@ -2407,7 +2356,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Lightning Resistance</name>
@@ -2418,7 +2366,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Necrotic Resistance</name>
@@ -2429,7 +2376,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Poison Resistance</name>
@@ -2440,7 +2386,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Psychic Resistance</name>
@@ -2451,7 +2396,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Radiant Resistance</name>
@@ -2462,7 +2406,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor of Thunder Resistance</name>
@@ -2473,7 +2416,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mariner's Breastplate</name>
@@ -2483,7 +2425,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mariner's Chain Shirt</name>
@@ -2493,7 +2434,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mariner's Half Plate Armor</name>
@@ -2513,7 +2453,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 181</text>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mariner's Scale Mail</name>
@@ -2533,7 +2472,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mithral Chain Shirt</name>
@@ -2543,7 +2481,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mithral Half Plate Armor</name>
@@ -2553,7 +2490,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>15</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Mithral Scale Mail</name>
@@ -2563,7 +2499,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Red Dragon Scale Mail</name>
@@ -3344,7 +3279,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor +2</name>
@@ -3355,7 +3289,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Leather Armor +3</name>
@@ -3366,7 +3299,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>11</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Padded Armor +1</name>
@@ -3410,7 +3342,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor +2</name>
@@ -3421,7 +3352,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Studded Leather Armor +3</name>
@@ -3432,7 +3362,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Battleaxe +1</name>
@@ -4991,7 +4920,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate +2</name>
@@ -5002,7 +4930,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Breastplate +3</name>
@@ -5013,7 +4940,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt +1</name>
@@ -5024,7 +4950,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt +2</name>
@@ -5035,7 +4960,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Chain Shirt +3</name>
@@ -5046,7 +4970,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Half Plate Armor +1</name>
@@ -5090,7 +5013,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor +2</name>
@@ -5101,7 +5023,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Hide Armor +3</name>
@@ -5112,7 +5033,6 @@
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>12</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Scale Mail +1</name>
@@ -5768,7 +5688,6 @@
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>2</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Shield +2</name>
@@ -5779,7 +5698,6 @@
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<modifier category="bonus">ac +2</modifier>
 		<ac>2</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Shield +3</name>
@@ -5790,7 +5708,6 @@
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<modifier category="bonus">ac +3</modifier>
 		<ac>2</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Arrow of Slaying</name>
@@ -5947,7 +5864,6 @@
 		<text>Source: Dungeon Master's Guide, page 172</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Berserker Battleaxe</name>
@@ -7809,7 +7725,6 @@
 		<text>Source: Dungeon Master's Guide, page 209</text>
 		<modifier category="bonus">ac +1</modifier>
 		<ac>13</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Oathbow</name>
@@ -7846,7 +7761,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 183</text>
 		<ac>2</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Arrow-Catching Shield</name>
@@ -7857,7 +7771,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 152</text>
 		<ac>2</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Sentinel Shield</name>
@@ -7867,7 +7780,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 199</text>
 		<ac>2</ac>
-		<stealth></stealth>
   		<modifier category="bonus">passive wisdom +5</modifier>		
 	</item>
 	<item>
@@ -7881,7 +7793,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 200</text>
 		<ac>2</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Spellguard Shield</name>
@@ -7892,7 +7803,6 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 201</text>
 		<ac>2</ac>
-		<stealth></stealth>
 	</item>
 	<item>
 		<name>Elixir of Health</name>
@@ -12977,6 +12887,5 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 182</text>
 		<ac>14</ac>
-		<stealth></stealth>
 	</item>
 </compendium>


### PR DESCRIPTION
Empty optional tags break the schema/tutorial for importing displayed inside the app. It either needs a value or should be removed.
