### PR TITLE
Fix missing end tag for 'Trinkets' header.

### DIFF
--- a/DM Screen/DM Screen.html
+++ b/DM Screen/DM Screen.html
@@ -7158,7 +7158,7 @@ Use <a href="#traps">these charts</a> to determine attack bonus, save DC, and da
 		
 		   <br />
 	<br />
-	<h2 id="trinkets">Trinkets
+	<h2 id="trinkets">Trinkets</h2>
 		<table>
 		<tr>
 			<th align="left" width="5%">d100</th>


### PR DESCRIPTION
Added `</h2>`, without it the entire table was seen as a header.
