### PR TITLE
Minor Reorganization of Character Class Archetypes

### DIFF
--- a/Character/Classes.xml
+++ b/Character/Classes.xml
@@ -1661,6 +1661,10 @@
 				<text>    A knight prefers to lead through deeds, not words. As a knight spearheads an attack, the knight's actions can awaken reserves of courage and conviction in allies that they never suspected they had.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Martial Archetype: Scout</name>
+				<text>The archetypal Scout excels at finding safe passage through dangerous regions. Scouts usually favor light armor and ranged weapons, but they are comfortable using heavier gear when faced with intense fighting.</text>
+			</feature>
+			<feature optional="YES">
 				<name>Purple Dragon Knight: Restriction: Knighthood</name>
 				<text>Purple Dragon Knights are tied to a specific order of Cormyrean knighthood.</text>
 				<text>    Banneret serves as the generic name for this archetype if you use it in other campaign settings or to model warlords other than the Purple Dragon Knights.</text>
@@ -1669,10 +1673,6 @@
 				<name>Purple Dragon Knight: Rallying Cry</name>
 				<text>When you choose this archetype at 3rd level, you learn how to inspire your allies to fight on past their injuries.</text>
 				<text>    When you use your Second Wind feature, you can choose up to three creatures within 60 feet of you that are allied with you. Each one regains hit points equal to your fighter level, provided that the creature can see or hear you.</text>
-			</feature>
-			<feature optional="YES">
-				<name>Martial Archetype: Scout</name>
-				<text>The archetypal Scout excels at finding safe passage through dangerous regions. Scouts usually favor light armor and ranged weapons, but they are comfortable using heavier gear when faced with intense fighting.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Battle Master: Combat Superiority</name>
@@ -2321,6 +2321,14 @@
 				<text>Many monks of this tradition tattoo their bodies with representations of their ki powers, commonly imagined as coiling dragons, but also as phoenixes, fish, plants, mountains, and cresting waves.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Monastic Tradition: Way of the Long Death</name>
+				<text>Monks of the Way of the Long Death are obsessed with the meaning and mechanics of dying. They capture creatures and prepare elaborate experiments to capture, record, and understand the moments of their demise. They use this knowledge to guide their understanding of martial arts, yielding a deadly fighting style.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Monastic Tradition: Way of the Sun Soul</name>
+				<text>Monks of the Way of the Sun Soul learn to channel their own life energy into searing bolts of light. They teach that meditation can unlock the ability to unleash the indomitable light shed by the soul of every living creature.</text>
+			</feature>
+			<feature optional="YES">
 				<name>Way of Shadow: Shadow Arts</name>
 				<text>You can use your ki to duplicate the effects of certain spells. As an action, you can spend 2 ki points to cast darkness, darkvision, pass without trace, or silence, without providing material components. Additionally, you gain the minor illusion cantrip if you don't already know it.</text>
 			</feature>
@@ -2354,16 +2362,8 @@
 				<text>    If you reduce the damage to 0, you can catch the missile if it is small enough for you to hold in one hand and you have at least one hand free. If you catch a missile in this way, you can spend 1 ki point to make a ranged attack (range 20 feet/60 feet) with the weapon or piece of ammunition you just caught, as part of the same reaction. You make this attack with proficiency, regardless of your weapon proficiencies, and the missile counts as a monk weapon for the attack.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Monastic Tradition: Way of the Long Death</name>
-				<text>Monks of the Way of the Long Death are obsessed with the meaning and mechanics of dying. They capture creatures and prepare elaborate experiments to capture, record, and understand the moments of their demise. They use this knowledge to guide their understanding of martial arts, yielding a deadly fighting style.</text>
-			</feature>
-			<feature optional="YES">
 				<name>Way of the Long Death: Touch of Death</name>
 				<text>Starting when you choose this tradition at 3rd level, your study of death allows you to extract vitality from another creature as it nears its demise. When you reduce a creature within 5 feet of you to 0 hit points, you gain temporary hit points equal to your Wisdom modifier + your monk level (minimum of 1 temporary hit point).</text>
-			</feature>
-			<feature optional="YES">
-				<name>Monastic Tradition: Way of the Sun Soul</name>
-				<text>Monks of the Way of the Sun Soul learn to channel their own life energy into searing bolts of light. They teach that meditation can unlock the ability to unleash the indomitable light shed by the soul of every living creature.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Way of the Sun Soul: Radiant Sun Bolt</name>
@@ -3396,6 +3396,61 @@
 				<text>    Your choice grants you features at 3rd level and again at 7th, 15th, and 20th level. Those features include oath spells and the Channel Divinity feature.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Sacred Oath: Oath of the Ancients</name>
+				<text>The Oath of the Ancients is as old as the race of elves and the rituals of the druids. Sometimes called fey knights, green knights, or horned knights, paladins who swear this oath cast their lot with the side of the light in the cosmic struggle against darkness because they love the beautiful and life-giving things of the world, not necessarily because they believe in principles of honor, courage, and justice. They adorn their armor and clothing with images of growing things - leaves, antlers, or flowers - to reflect their commitment to preserving life and light in the world.</text>
+				<text />
+				<text>Tenets of the Ancients</text>
+				<text />
+				<text>The tenets of the Oath of the Ancients have been preserved for uncounted centuries. This oath emphasizes the principles of good above any concerns of law or chaos. Its four central principles are simple.</text>
+				<text>    Kindle the Light. Through your acts of mercy, kindness, and forgiveness, kindle the light of hope in the world, beating back despair.</text>
+				<text>    Shelter the Light. Where there is good, beauty, love, and laughter in the world, stand against the wickedness that would swallow it. Where life flourishes, stand against the forces that would render it barren.</text>
+				<text>    Preserve Your Own Light. Delight in song and laughter, in beauty and art. If you allow the light to die in your own heart, you can't preserve it in the world.</text>
+				<text>    Be the Light. Be a glorious beacon for all who live in despair. Let the light of your joy and courage shine forth in all your deeds.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Sacred Oath: Oath of Devotion</name>
+				<text>The Oath of Devotion binds a paladin to the loftiest ideals of justice, virtue, and order. Sometimes called cavaliers, white knights, or holy warriors, these paladins meet the ideal of the knight in shining armor, acting with honor in pursuit of justice and the greater good. They hold themselves to the highest standards of conduct, and some, for better or worse, hold the rest of the world to the same standards. Many who swear this oath are devoted to gods of law and good and use their gods' tenets as the measure of their devotion. They hold angels - the perfect servants of good - as their ideals, and incorporate images of angelic wings into their helmets or coats of arms.</text>
+				<text />
+				<text>Tenets of Devotion</text>
+				<text />
+				<text>Though the exact words and strictures of the Oath of Devotion vary, paladins of this oath share these tenets.</text>
+				<text>    Honesty. Don't lie or cheat. Let your word be your promise.</text>
+				<text>    Courage. Never fear to act, though caution is wise.</text>
+				<text>    Compassion. Aid others, protect the weak, and punish those who threaten them. Show mercy to your foes, but temper it with wisdom.</text>
+				<text>    Honor. Treat others with fairness, and let your honorable deeds be an example to them. Do as much good as possible while causing the least amount of harm.</text>
+				<text>    Duty. Be responsible for your actions and their consequences, protect those entrusted to your care, and obey those who have just authority over you.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Sacred Oath: Oath of Vengeance</name>
+				<text>The Oath of Vengeance is a solemn commitment to punish those who have committed a grievous sin. When evil forces slaughter helpless villagers, when an entire people turns against the will of the gods, when a thieves' guild grows too violent and powerful, when a dragon rampages through the countryside - at times like these, paladins arise and swear an Oath of Vengeance to set right that which has gone wrong. To these paladins - sometimes called avengers or dark knights - their own purity is not as important as delivering justice.</text>
+				<text />
+				<text>Tenets of Vengeance: The tenets of the Oath of Vengeance vary by paladin, but all the tenets revolve around punishing wrongdoers by any means necessary. Paladins who uphold these tenets are willing to sacrifice even their own righteousness to mete out justice upon those who do evil, so the paladins are often neutral or lawful neutral in alignment. The core principles of the tenets are brutally simple.</text>
+				<text>    Fight the Greater Evil. Faced with a choice of fighting my sworn foes or combating a lesser evil. I choose the greater evil.</text>
+				<text>    No Mercy for the Wicked. Ordinary foes might win my mercy, but my sworn enemies do not.</text>
+				<text>    By Any Means Necessary. My qualms can't get in the way of exterminating my foes.</text>
+				<text>    Restitution. If my foes wreak ruin on the world, it is because I failed to stop them. I must help those harmed by their misdeeds.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Sacred Oath: Oathbreaker</name>
+				<text>An Oathbreaker is a paladin who breaks his or her sacred oaths to pursue some dark ambition or serve an evil power. Whatever light burned in the paladin's heart has been extinguished. Only darkness remains.</text>
+				<text>    A paladin must be evil and at least 3rd level to become an Oathbreaker. The paladin replaces the features specific to his or her Sacred Oath with Oathbreaker features.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Sacred Oath: Oath of the Crown</name>
+				<text>The Oath of the Crown is sworn to the ideals of civilization, be it the spirit of a nation, fealty to a sovereign, or service to a deity of law and rulership. The paladins who swear this oath dedicate themselves to serving society and, in particular, the laws that hold society together. These paladins are the watchful guardians on the walls, standing against the chaotic tides of barbarism that threaten to tear down all that civilization has built, and are commonly known as guardians, exemplars, or sentinels. Often, paladins who swear this oath are members of an order of knighthood in service to a nation or sovereign, and undergo their oath as part of their admission to the order's ranks.</text>
+				<text/>
+				<text>Tenets of the Crown:</text>
+				<text>    The tenets of the Oath of the Crown are often set by the sovereign to which their oath is sworn, but generally emphasize the following tenets.</text>
+				<text/>
+				<text>Law: The law is paramount. It is the mortar that holds the stones of civilization together, and it must be respected.</text>
+				<text/>
+				<text>Loyalty: Your word is your bond. Without loyalty, oaths and laws are meaningless.</text>
+				<text/>
+				<text>Courage: You must be willing to do what needs to be done for the sake of order, even in the face of overwhelming odds. If you don't act, then who will?</text>
+				<text/>
+				<text>Responsibility: You must deal with the consequences of your actions, and you are responsible for fulfilling your duties and obligations. </text>
+				</feature>
+			<feature optional="YES">
 				<name>Oath of the Ancients Channel Divinity: Nature's Wrath</name>
 				<text>You can use your Channel Divinity to invoke primeval forces to ensnare a foe. As an action, you can cause spectral vines to spring up and reach for a creature within 10 feet of you that you can see. The creature must succeed on a Strength or Dexterity saving throw (its choice) or be restrained. While restrained by the vines, the creature repeats the saving throw at the end of each of its turns. On a success, it frees itself and the vines vanish.</text>
 			</feature>
@@ -3418,18 +3473,6 @@
 				<text>13th - ice storm, stoneskin</text>
 				<text />
 				<text>17th - commune with nature, tree stride</text>
-			</feature>
-			<feature optional="YES">
-				<name>Sacred Oath: Oath of the Ancients</name>
-				<text>The Oath of the Ancients is as old as the race of elves and the rituals of the druids. Sometimes called fey knights, green knights, or horned knights, paladins who swear this oath cast their lot with the side of the light in the cosmic struggle against darkness because they love the beautiful and life-giving things of the world, not necessarily because they believe in principles of honor, courage, and justice. They adorn their armor and clothing with images of growing things - leaves, antlers, or flowers - to reflect their commitment to preserving life and light in the world.</text>
-				<text />
-				<text>Tenets of the Ancients</text>
-				<text />
-				<text>The tenets of the Oath of the Ancients have been preserved for uncounted centuries. This oath emphasizes the principles of good above any concerns of law or chaos. Its four central principles are simple.</text>
-				<text>    Kindle the Light. Through your acts of mercy, kindness, and forgiveness, kindle the light of hope in the world, beating back despair.</text>
-				<text>    Shelter the Light. Where there is good, beauty, love, and laughter in the world, stand against the wickedness that would swallow it. Where life flourishes, stand against the forces that would render it barren.</text>
-				<text>    Preserve Your Own Light. Delight in song and laughter, in beauty and art. If you allow the light to die in your own heart, you can't preserve it in the world.</text>
-				<text>    Be the Light. Be a glorious beacon for all who live in despair. Let the light of your joy and courage shine forth in all your deeds.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Oath of Devotion Channel Divinity: Sacred Weapon</name>
@@ -3456,19 +3499,6 @@
 				<text>17th - commune, flame strike</text>
 			</feature>
 			<feature optional="YES">
-				<name>Sacred Oath: Oath of Devotion</name>
-				<text>The Oath of Devotion binds a paladin to the loftiest ideals of justice, virtue, and order. Sometimes called cavaliers, white knights, or holy warriors, these paladins meet the ideal of the knight in shining armor, acting with honor in pursuit of justice and the greater good. They hold themselves to the highest standards of conduct, and some, for better or worse, hold the rest of the world to the same standards. Many who swear this oath are devoted to gods of law and good and use their gods' tenets as the measure of their devotion. They hold angels - the perfect servants of good - as their ideals, and incorporate images of angelic wings into their helmets or coats of arms.</text>
-				<text />
-				<text>Tenets of Devotion</text>
-				<text />
-				<text>Though the exact words and strictures of the Oath of Devotion vary, paladins of this oath share these tenets.</text>
-				<text>    Honesty. Don't lie or cheat. Let your word be your promise.</text>
-				<text>    Courage. Never fear to act, though caution is wise.</text>
-				<text>    Compassion. Aid others, protect the weak, and punish those who threaten them. Show mercy to your foes, but temper it with wisdom.</text>
-				<text>    Honor. Treat others with fairness, and let your honorable deeds be an example to them. Do as much good as possible while causing the least amount of harm.</text>
-				<text>    Duty. Be responsible for your actions and their consequences, protect those entrusted to your care, and obey those who have just authority over you.</text>
-			</feature>
-			<feature optional="YES">
 				<name>Oath of Vengeance Channel Divinity: Abjure Enemy</name>
 				<text>As an action, you present your holy symbol and speak a prayer of denunciation, using your Channel Divinity. Choose one creature within 60 feet of you that you can see. That creature must make a Wisdom saving throw, unless it is immune to being frightened. Fiends and undead have disadvantage on this saving throw.</text>
 				<text>    On a failed save, the creature is frightened for 1 minute or until it takes any damage. While frightened, the creature's speed is 0, and it can't benefit from any bonus to its speed.</text>
@@ -3493,21 +3523,6 @@
 				<text>17th - hold monster, scrying</text>
 			</feature>
 			<feature optional="YES">
-				<name>Sacred Oath: Oath of Vengeance</name>
-				<text>The Oath of Vengeance is a solemn commitment to punish those who have committed a grievous sin. When evil forces slaughter helpless villagers, when an entire people turns against the will of the gods, when a thieves' guild grows too violent and powerful, when a dragon rampages through the countryside - at times like these, paladins arise and swear an Oath of Vengeance to set right that which has gone wrong. To these paladins - sometimes called avengers or dark knights - their own purity is not as important as delivering justice.</text>
-				<text />
-				<text>Tenets of Vengeance: The tenets of the Oath of Vengeance vary by paladin, but all the tenets revolve around punishing wrongdoers by any means necessary. Paladins who uphold these tenets are willing to sacrifice even their own righteousness to mete out justice upon those who do evil, so the paladins are often neutral or lawful neutral in alignment. The core principles of the tenets are brutally simple.</text>
-				<text>    Fight the Greater Evil. Faced with a choice of fighting my sworn foes or combating a lesser evil. I choose the greater evil.</text>
-				<text>    No Mercy for the Wicked. Ordinary foes might win my mercy, but my sworn enemies do not.</text>
-				<text>    By Any Means Necessary. My qualms can't get in the way of exterminating my foes.</text>
-				<text>    Restitution. If my foes wreak ruin on the world, it is because I failed to stop them. I must help those harmed by their misdeeds.</text>
-			</feature>
-			<feature>
-				<name>Sacred Oath: Oathbreaker</name>
-				<text>An Oathbreaker is a paladin who breaks his or her sacred oaths to pursue some dark ambition or serve an evil power. Whatever light burned in the paladin's heart has been extinguished. Only darkness remains.</text>
-				<text>    A paladin must be evil and at least 3rd level to become an Oathbreaker. The paladin replaces the features specific to his or her Sacred Oath with Oathbreaker features.</text>
-			</feature>
-			<feature optional="YES">
 				<name>Oathbreaker: Oathbreaker Spells</name>
 				<text>You gain oathbreaker spells at the paladin levels listed.</text>
 				<text />
@@ -3529,21 +3544,6 @@
 				<name>Oathbreaker Channel Divinity: Dreadful Aspect</name>
 				<text>As an action, the paladin channels the darkest emotions and focuses them into a burst of magical menace. Each creature of the paladin's choice within 30 feet of the paladin must make a Wisdom saving throw if it can see the paladin. On a failed save, the target is frightened of the paladin for 1 minute. If a creature frightened by this effect ends its turn more than 30 feet away from the paladin, it can attempt another Wisdom saving throw to end the effect on it.</text>
 			</feature>
-			<feature optional="YES">
-				<name>Sacred Oath: Oath of the Crown</name>
-				<text>The Oath of the Crown is sworn to the ideals of civilization, be it the spirit of a nation, fealty to a sovereign, or service to a deity of law and rulership. The paladins who swear this oath dedicate themselves to serving society and, in particular, the laws that hold society together. These paladins are the watchful guardians on the walls, standing against the chaotic tides of barbarism that threaten to tear down all that civilization has built, and are commonly known as guardians, exemplars, or sentinels. Often, paladins who swear this oath are members of an order of knighthood in service to a nation or sovereign, and undergo their oath as part of their admission to the order's ranks.</text>
-				<text/>
-				<text>Tenets of the Crown:</text>
-				<text>    The tenets of the Oath of the Crown are often set by the sovereign to which their oath is sworn, but generally emphasize the following tenets.</text>
-				<text/>
-				<text>Law: The law is paramount. It is the mortar that holds the stones of civilization together, and it must be respected.</text>
-				<text/>
-				<text>Loyalty: Your word is your bond. Without loyalty, oaths and laws are meaningless.</text>
-				<text/>
-				<text>Courage: You must be willing to do what needs to be done for the sake of order, even in the face of overwhelming odds. If you don't act, then who will?</text>
-				<text/>
-				<text>Responsibility: You must deal with the consequences of your actions, and you are responsible for fulfilling your duties and obligations. </text>
-				</feature>
 			<feature optional="YES">
 				<name>Oath of the Crown: Oath Spells</name>
 				<text>    You gain oath spells at the paladin levels listed.</text>
@@ -4872,6 +4872,12 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>Your archetype grants you features at 3rd level and then again at 9th, 13th, and 17th level.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Roguish Archetype: Mastermind</name>
+				<text>Your focus is on people and on the influence and secrets they have. Many spies, courtiers, and schemers follow this archetype, leading lives of intrigue. Words are your weapons as often as knives or poison, and secrets and favors are some of your favorite treasures.</text>
+				<text/>
+				<text>Source: Sword Coast Adventurer's Guide, p. 135</text>
+			</feature>
+			<feature optional="YES">
 				<name>Roguish Archetype: Swashbuckler</name>
 				<text>You focus your training on the art of the blade, relying on speed, elegance, and charisma in equal parts. While other warriors are brutes clad in heavy armor, your method of fighting looks more like performance. Rakes, duelists, and pirates typically follow this archetype.</text>
 				<text />
@@ -4925,6 +4931,15 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>When you choose this archetype at 3rd level, you gain proficiency with the disguise kit and the poisoner's kit.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Mastermind: Master of Intrigue</name>
+				<text>When you choose this archetype at 3rd level, you gain proficiency with the disguise kit, the forgery kit, and one gaming set of your choice. You also learn two languages of your choice. </text>
+				<text>    Additionally, you can unerringly mimic the speech patterns and accent of a creature that you hear speak for at least 1 minute, allowing you to pass yourself off as a native speaker of a particular land, provided that you know the language.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Mastermind: Master of Tactics</name>
+				<text>Starting at 3rd level, you can use the Help action as a bonus action. Additionally, when you use the Help action to aid an ally in attacking a creature, the target of that attack can be within 30 feet of you, rather than 5 feet of you, if the target can see or hear you.</text>
+			</feature>
+			<feature optional="YES">
 				<name>Swashbuckler: Fancy Footwork</name>
 				<text>When you choose this archetype at 3rd level, you learn how to land a strike and then slip away without reprisal. During your turn, if you make a melee attack against a creature, that creature cannot make opportunity attacks against you for the rest of your turn.</text>
 			</feature>
@@ -4941,21 +4956,6 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<name>Thief: Second-Story Work</name>
 				<text>When you choose this archetype at 3rd level, you gain the ability to climb faster than normal; climbing no longer costs you extra movement.</text>
 				<text>    In addition, when you make a running jump, the distance you cover increases by a number of feet equal to your Dexterity modifier.</text>
-			</feature>
-			<feature optional="YES">
-				<name>Rougeish Archetype: Mastermind</name>
-				<text>Your focus is on people and on the influence and secrets they have. Many spies, courtiers, and schemers follow this archetype, leading lives of intrigue. Words are your weapons as often as knives or poison, and secrets and favors are some of your favorite treasures.</text>
-				<text/>
-				<text>Source: Sword Coast Adventurer's Guide, p. 135</text>
-			</feature>
-			<feature optional="YES">
-				<name>Mastermind: Master of Intrigue</name>
-				<text>When you choose this archetype at 3rd level, you gain proficiency with the disguise kit, the forgery kit, and one gaming set of your choice. You also learn two languages of your choice. </text>
-				<text>    Additionally, you can unerringly mimic the speech patterns and accent of a creature that you hear speak for at least 1 minute, allowing you to pass yourself off as a native speaker of a particular land, provided that you know the language.</text>
-			</feature>
-			<feature optional="YES">
-				<name>Mastermind: Master of Tactics</name>
-				<text>Starting at 3rd level, you can use the Help action as a bonus action. Additionally, when you use the Help action to aid an ally in attacking a creature, the target of that attack can be within 30 feet of you, rather than 5 feet of you, if the target can see or hear you.</text>
 			</feature>
 		</autolevel>
 
@@ -5000,16 +5000,6 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>    Thereafter, if you adopt the new identity as a disguise, other creatures believe you to be that person until given an obvious reason not to.</text>
 			</feature>
 			<feature optional="YES">
-				<name>Swashbuckler: Panache</name>
-				<text>At 9th level, your charm becomes extraordinarily beguiling. As an action, you can make a Charisma (Persuasion) check contested by a creature's Wisdom (Insight) check. The creature must be able to hear you, and the two of you must share a language.</text>
-				<text>    If you succeed on the check and the creature is hostile to you, it has disadvantage on attack rolls against targets other than you and can't make opportunity attacks against targets other than you. This effect lasts for 1 minute, until one of your companions attacks the target or affects it with a spell, or until you and the target are more than 60 feet apart.</text>
-				<text>    If you succeed on the check and the creature isn't hostile to you, it is charmed by you for 1 minute. While charmed, it regards you as a friendly aquaintance. This effect ends immediately if you or your companions do anything harmful to it.</text>
-			</feature>
-			<feature optional="YES">
-				<name>Thief: Supreme Sneak</name>
-				<text>Starting at 9th level, you have advantage on a Dexterity (Stealth) check if you move no more than half your speed on the same turn.</text>
-			</feature>
-			<feature optional="YES">
 				<name>Mastermind: Insightful Manipulator</name>
 				<text>Starting at 9th level, if you spend at least 1 minute observing or interacting with another creature outside combat, you can learn certain information about its capabilities compared to your own. The DM tells you if the creature is your equal, superior, or inferior in regard to two of the following characteristics of your choice: </text>
 				<text/>
@@ -5019,6 +5009,16 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>- Class levels (if any) </text>
 				<text/>
 				<text>    At the DM's option, you might also realize you know a piece of the creature's history or one of its personality traits, if it has any.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Swashbuckler: Panache</name>
+				<text>At 9th level, your charm becomes extraordinarily beguiling. As an action, you can make a Charisma (Persuasion) check contested by a creature's Wisdom (Insight) check. The creature must be able to hear you, and the two of you must share a language.</text>
+				<text>    If you succeed on the check and the creature is hostile to you, it has disadvantage on attack rolls against targets other than you and can't make opportunity attacks against targets other than you. This effect lasts for 1 minute, until one of your companions attacks the target or affects it with a spell, or until you and the target are more than 60 feet apart.</text>
+				<text>    If you succeed on the check and the creature isn't hostile to you, it is charmed by you for 1 minute. While charmed, it regards you as a friendly aquaintance. This effect ends immediately if you or your companions do anything harmful to it.</text>
+			</feature>
+			<feature optional="YES">
+				<name>Thief: Supreme Sneak</name>
+				<text>Starting at 9th level, you have advantage on a Dexterity (Stealth) check if you move no more than half your speed on the same turn.</text>
 			</feature>
 		</autolevel>
 
@@ -5056,16 +5056,16 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>    Your ruse is indiscernible to the casual observer. If a wary creature suspects something is amiss, you have advantage on any Charisma (Deception) check you make to avoid detection.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Mastermind: Misdirection</name>
+				<text>Beginning at 13th level, you can sometimes cause another creature to suffer an attack meant for you. When you are targeted by an attack while a creature within 5 feet of you is granting you cover against that attack, you can use your reaction to have the attack target that creature instead of you.</text>
+			</feature>
+			<feature optional="YES">
 				<name>Swashbuckler: Elegant Maneuver</name>
 				<text>Starting at 13th level, you can use a bonus action on your turn to gain advantage on the next Dexterity (Acrobatics) or Strength (Athletics) check you make during the same turn.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Thief: Use Magic Device</name>
 				<text>By 13th level, you have learned enough about the workings of magic that you can improvise the use of items even when they are not intended for you. You ignore all class, race, and level requirements on the use of magic items.</text>
-			</feature>
-			<feature optional="YES">
-				<name>Mastermind: Misdirection</name>
-				<text>Beginning at 13th level, you can sometimes cause another creature to suffer an attack meant for you. When you are targeted by an attack while a creature within 5 feet of you is granting you cover against that attack, you can use your reaction to have the attack target that creature instead of you.</text>
 			</feature>
 		</autolevel>
 
@@ -5103,17 +5103,17 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>Starting at 17th level, you become a master of instant death. When you attack and hit a creature that is surprised, it must make a Constitution saving throw (DC 8 + your Dexterity modifier + your proficiency bonus). On a failed save, double the damage of your attack against the creature.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Mastermind: Soul of Deceit</name>
+				<text>Starting at 17th level, your thoughts can&#8217;t be read by telepathy or other means, unless you allow it. You can present false thoughts by making a Charisma (Deception) check contested by the mind reader's Wisdom (Insight) check.</text>
+				<text>    Additionally, no matter what you say, magic that would determine if you are telling the truth indicates you are being truthful, if you so choose, and you can't be compelled to tell the truth by magic.</text>
+			</feature>
+			<feature optional="YES">
 				<name>Swashbuckler: Master Duelist</name>
 				<text>Beginning at 17th level, your mastery of the blade lets you turn failure to success in combat. If you miss with an attack roll, you can choose to roll it again with advantage. Once you do so, you can't use this feature again until you finish a short or long rest.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Thief: Thief's Reflexes</name>
 				<text>When you reach 17th level, you have become adept at laying ambushes and quickly escaping danger. You can take two turns during the first round of any combat. You take your first turn at your normal initiative and your second turn at your initiative minus 10. You can't use this feature when you are surprised.</text>
-			</feature>
-			<feature optional="YES">
-				<name>Mastermind: Soul of Deceit</name>
-				<text>Starting at 17th level, your thoughts can&#8217;t be read by telepathy or other means, unless you allow it. You can present false thoughts by making a Charisma (Deception) check contested by the mind reader's Wisdom (Insight) check.</text>
-				<text>    Additionally, no matter what you say, magic that would determine if you are telling the truth indicates you are being truthful, if you so choose, and you can't be compelled to tell the truth by magic.</text>
 			</feature>
 		</autolevel>
 
@@ -5817,19 +5817,6 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>5th - dominate person, telekinesis</text>
 			</feature>
 			<feature optional="YES">
-				<name>The Archfey: Fey Presence</name>
-				<text>Starting at 1st level, your patron bestows upon you the ability to project the beguiling and fearsome presence of the fey. As an action, you can cause each creature in a 10-foot cube originating from you to make a Wisdom saving throw against your warlock spell save DC. The creatures that fail their saving throws are all charmed or frightened by you (your choice) until the end of your next turn.</text>
-				<text>    Once you use this feature, you can't use it again until you finish a short or long rest.</text>
-			</feature>
-			<feature optional="YES">
-				<name>The Fiend: Dark One's Blessing</name>
-				<text>Starting at 1st level, when you reduce a hostile creature to 0 hit points, you gain temporary hit points equal to your Charisma modifier + your warlock level (minimum of 1).</text>
-			</feature>
-			<feature optional="YES">
-				<name>The Great Old One: Awakened Mind</name>
-				<text>Starting at 1st level, your alien knowledge gives you the ability to touch the minds of other creatures. You can communicate telepathically with any creature you can see within 30 feet of you. You don't need to share a language with the creature for it to understand your telepathic utterances, but the creature must be able to understand at least one language.</text>
-			</feature>
-			<feature optional="YES">
 				<name>Otherworldly Patron: The Undying</name>
 				<text>Death holds no sway over your patron, who has unlocked the secrets of everlasting life, although such a prize - like all power - comes at a price. Once mortal, the Undying has seen mortal lifetimes pass like the seasons, like the flicker of endless days and nights. It has the secrets of the ages to share, secrets of life and death. Beings of this sort include Vecna, Lord of the Hand and the Eye; the dread Iuz; the lich-queen Vol; the Undying Court of Aerenal; Vlaakith, lich-queen of the githyanki; and the deathless wizard Fistandantalus.</text>
 				<text>    In the Realms, Undying patrons include Larloch the Shadow King, legendary master of Warlock's Crypt, and Gilgeam, the God-King of Unther.</text>
@@ -5865,6 +5852,19 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>3rd - daylight</text>
 				<text>4th - fire shield</text>
 				<text>5th - flame strike</text>
+			</feature>
+			<feature optional="YES">
+				<name>The Archfey: Fey Presence</name>
+				<text>Starting at 1st level, your patron bestows upon you the ability to project the beguiling and fearsome presence of the fey. As an action, you can cause each creature in a 10-foot cube originating from you to make a Wisdom saving throw against your warlock spell save DC. The creatures that fail their saving throws are all charmed or frightened by you (your choice) until the end of your next turn.</text>
+				<text>    Once you use this feature, you can't use it again until you finish a short or long rest.</text>
+			</feature>
+			<feature optional="YES">
+				<name>The Fiend: Dark One's Blessing</name>
+				<text>Starting at 1st level, when you reduce a hostile creature to 0 hit points, you gain temporary hit points equal to your Charisma modifier + your warlock level (minimum of 1).</text>
+			</feature>
+			<feature optional="YES">
+				<name>The Great Old One: Awakened Mind</name>
+				<text>Starting at 1st level, your alien knowledge gives you the ability to touch the minds of other creatures. You can communicate telepathically with any creature you can see within 30 feet of you. You don't need to share a language with the creature for it to understand your telepathic utterances, but the creature must be able to understand at least one language.</text>
 			</feature>
 			<feature optional="YES">
 				<name>The Undying: Among the Dead</name>
@@ -7170,6 +7170,10 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>Called abjurers, members of this school are sought when baleful spirits require exorcism, when important locations must be guarded against magical spying, and when portals to other planes of existence must be closed.</text>
 			</feature>
 			<feature optional="YES">
+				<name>Arcane Tradition: Bladesinger</name>
+				<text>Bladesingers are elves who bravely defend their people and lands. They are elf wizards who master a school of sword fighting grounded in a tradition of arcane magic. In combat, a bladesinger uses a series of intricate, elegant maneuvers that fend off harm and allow the bladesinger to channel magic into devastating attacks and a cunning defense.</text>
+			</feature>
+			<feature optional="YES">
 				<name>Arcane Tradition: Conjuration</name>
 				<text>As a conjurer, you favor spells that produce objects and creatures out of thin air. You can conjure billowing clouds of killing fog or summon creatures from elsewhere to fight on your behalf. As your mastery grows, you learn spells of transportation and can teleport yourself across vast distances, even to other planes of existence, in an instant.</text>
 			</feature>
@@ -7291,10 +7295,6 @@ to ensure they remain watched at all times. They venture into the depths on long
 				<text>At 2nd level, you can also tap into your reserves of magical energy to create spell scrolls. You can use your Arcane Recovery ability to create a scroll instead of regaining expended spell slots.</text>
 				<text />
 				<text>You must finish a short rest, then spend 10 minutes with parchment, quill, and ink to create a spell scroll containing one spell chosen from those you know. Subtract the spell's level from the total levels worth of slots you regain using Arcane Recovery. This reduction to your Arcane Recovery applies until you use the scroll and then finish a long rest.</text>
-			</feature>
-			<feature optional="YES">
-				<name>Arcane Tradition: Bladesinger</name>
-				<text>Bladesingers are elves who bravely defend their people and lands. They are elf wizards who master a school of sword fighting grounded in a tradition of arcane magic. In combat, a bladesinger uses a series of intricate, elegant maneuvers that fend off harm and allow the bladesinger to channel magic into devastating attacks and a cunning defense.</text>
 			</feature>
 			<feature optional="YES">
 				<name>Bladesinger: Restriction: Elves Only</name>


### PR DESCRIPTION
2 bigger fixes:
- Roguish Archetype Mastermind had misspellings in it. (Rougeish)
- Paladin oath: Oathbreaker was not marked optional.

Minor fixes:
Reorganized Archetypes/orders/etc so that all the available options are together in the list. Some of the files had newer archetypes further down the list along with the archetype features which I felt could be confusing.

The re-org should merge into Fight Club 5 without any issues. My test showed no duplication within any of the classes.
