### PR TITLE
Adding missing action data to the Monster Manual

### DIFF
--- a/Bestiary/Monster Manual Bestiary.xml
+++ b/Bestiary/Monster Manual Bestiary.xml
@@ -3175,23 +3175,9 @@
 			<text>The devil makes three attacks: two with its claws and one with its sting.</text>
 		</action>
 		<action>
-			<name>Multiattack</name>
-			<text>The devil makes three attacks: two with its claws and one with its sting.</text>
-		</action>
-		<action>
 			<name>Claw</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 8 (1d8 + 4) slashing damage.</text>
 			<attack>Claw|8|1d8+4</attack>
-		</action>
-		<action>
-			<name>Claw</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 8 (1d8 + 4) slashing damage.</text>
-			<attack>Claw|8|1d8+4</attack>
-		</action>
-		<action>
-			<name>Sting</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .</text>
-			<attack>Sting|8|2d8+4</attack>
 		</action>
 		<action>
 			<name>Sting</name>
@@ -3222,6 +3208,33 @@
 		<passive>9</passive>
 		<languages>Infernal, telepathy 120 ft.</languages>
 		<cr>12</cr>
+		<trait>
+			<name>Devil's Sight</name>
+			<text>Magical darkness doesn't impede the devil's darkvision.</text>
+		</trait>
+		<trait>
+			<name>Magic Resistance</name>
+			<text>The devil has advantage on saving throws against spells and other magical effects.</text>
+		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The devil makes three attacks: two with its hooked polearm and one with its sting.</text>
+		</action>
+		<action>
+			<name>Hooked Polearm</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 17 (2d12 + 4) piercing damage. If the target is a huge or smaller creature, it is grappled (escape DC 14). Until the grapple ends, the devil can't use its polearm on another target.</text>
+			<attack>|17|2d12+4</attack>
+		</action>
+		<action>
+			<name>Claw</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 8 (1d8 + 4) slashing damage.</text>
+			<attack>Claw|8|1d8+4</attack>
+		</action>
+		<action>
+			<name>Sting</name>
+			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .</text>
+			<attack>Sting|8|2d8+4</attack>
+		</action>
 	</monster>
 	<monster>
 		<name>Bone Naga (Guardian)</name>
@@ -5384,6 +5397,26 @@
 			<text>• 3rd level (3 slots): clairvoyance, dispel magic</text>
 			<text>• 4th level (2 slots): divination,freedom of movement</text>
 		</trait>
+		<action>
+			<name>Multiattack</name>
+			<text>The drider makes three attacks, either with its longsword or its longbow. It can replace one of those attacks with a bite attack.</text>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 2 (1d4) piercing damage plus 9 (2d8) poison damage.</text>
+			<attack>Bite|6|1d4+2d8</attack>
+		</action>
+		<action>
+			<name>Longsword</name>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands.</text>
+			<attack>One Handed|6|1d8+3</attack>
+			<attack>Two Handed|6|1d10+3</attack>
+		</action>
+		<action>
+			<name>Longbow</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) poison damage.</text>
+			<attack>Longbow|6|1d8+3</attack>
+		</action>
 		<spells>dancing lights, darkness, faerie fire, poison spray, thaumaturgy, bane, detect magic, sanctuary, hold person, silence, clairvoyance, dispel magic, divination, freedom of movement</spells>
 	</monster>
 	<monster>
@@ -19430,6 +19463,30 @@
 			<name>Magic Resistance</name>
 			<text>The yuan-ti has advantage on saving throws against spells and other magical effects.</text>
 		</trait>
+		<action>
+			<name>Multiattack (Abomination Form Only)</name>
+			<text>The yuan_ti makes two ranged attacks or three melee attacks, but can use its bite and constrict attacks only once each.</text>
+		</action>
+		<action>
+			<name>Bite</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage plus 10 (3d6) poison damage.</text>
+			<attack>|5|1d6+4+3d6</attack>
+		</action>
+		<action>
+			<name>Constrict</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the yuan_ti can't constrict another target.</text>
+			<attack>|5|2d6+4</attack>
+		</action>
+		<action>
+			<name>Scimitar (Abomination Form Only)</name>
+			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.</text>
+			<attack>|5|2d6+4</attack>
+		</action>
+		<action>
+			<name>Longbow (Abomination Form Only)</name>
+			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 12 (2d8 + 3) piercing damage plus 10 (3d6) poison damage.</text>
+			<attack>|4|2d8+3+3d6</attack>
+		</action>
 		<spells>animal friendship, suggestion, fear</spells>
 	</monster>
 	<monster>

--- a/Bestiary/Monster Manual Bestiary.xml
+++ b/Bestiary/Monster Manual Bestiary.xml
@@ -1272,7 +1272,7 @@
 		<action>
 			<name>Tail</name>
 			<text>Melee Weapon Attack: +16 to hit, reach 20 ft., one target. Hit: 18 (2d8 + 9) bludgeoning damage.</text>
-			<attack>Tail||2d8+9</attack>
+			<attack>Tail|16|2d8+9</attack>
 		</action>
 		<action>
 			<name>Frightful Presence</name>
@@ -1500,7 +1500,7 @@
 		<action>
 			<name>Tail</name>
 			<text>Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.</text>
-			<attack>Tail|16|2d8+8</attack>
+			<attack>Tail|15|2d8+8</attack>
 		</action>
 		<action>
 			<name>Frightful Presence</name>
@@ -1880,6 +1880,7 @@
 		<action>
 			<name>Tail</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 18 (4d6 + 4) bludgeoning damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone.</text>
+			<attack>Tail|7|4d6+4</attack>
 		</action>
 	</monster>
 	<monster>
@@ -3223,7 +3224,7 @@
 		<action>
 			<name>Hooked Polearm</name>
 			<text>Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 17 (2d12 + 4) piercing damage. If the target is a huge or smaller creature, it is grappled (escape DC 14). Until the grapple ends, the devil can't use its polearm on another target.</text>
-			<attack>|17|2d12+4</attack>
+			<attack>|8|2d12+4</attack>
 		</action>
 		<action>
 			<name>Claw</name>
@@ -5065,7 +5066,7 @@
 		<action>
 			<name>Tentacle</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage plus 3 (1d6) piercing damage.</text>
-			<attack>Tentacle|7|1d6+4</attack>
+			<attack>Tentacle|6|1d6+4</attack>
 		</action>
 	</monster>
 	<monster>
@@ -5664,7 +5665,7 @@
 			<name>Quarterstaff</name>
 			<text>Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 6 (1d8 + 2) bludgeoning damage with shillelagh or if wielded with two hands.</text>
 			<attack>Quarterstaff|2|1d6</attack>
-			<attack>Shillelagh|6|1d8+2</attack>
+			<attack>Shillelagh|4|1d8+2</attack>
 		</action>
 		<spells>druidcraft, produce flame, shillelagh, entangle, longstrider, speak with animals, thunderwave, animal messenger, barkskin</spells>
 	</monster>
@@ -5709,8 +5710,9 @@
 		</trait>
 		<action>
 			<name>Club</name>
-			<text>Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: 2 (1 d4) bludgeoning damage, or 8 (1d8 + 4) bludgeoning damage with shillelagh.</text>
+			<text>Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage, or 8 (1d8 + 4) bludgeoning damage with shillelagh.</text>
 			<attack>Club|2|1d4</attack>
+			<attack>Shillelagh|6|1d8+4</attack>
 		</action>
 		<action>
 			<name>Fey Charm</name>
@@ -5801,7 +5803,7 @@
 		<action>
 			<name>Fist</name>
 			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage.</text>
-			<attack>Fist|3|1d4</attack>
+			<attack>Fist|2|1d4</attack>
 		</action>
 		<action>
 			<name>Javelin</name>
@@ -6034,10 +6036,12 @@
 		<action>
 			<name>Ram</name>
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage.</text>
+			<attack>Ram|5|1d6+3</attack>
 		</action>
 		<action>
 			<name>Hooves</name>
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one prone creature. Hit: 8 (2d4 + 3) bludgeoning damage.</text>
+			<attack>Hooves|5|2d4+3</attack>
 		</action>
 	</monster>
 	<monster>
@@ -7399,6 +7403,7 @@
 		<action>
 			<name>Claws</name>
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
+			<attack>Claws|4|2d4+2</attack>
 		</action>
 	</monster>
 	<monster>
@@ -9548,7 +9553,7 @@
 			<name>Spear</name>
 			<text>Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack.</text>
 			<attack>One Handed|3|1d6+1</attack>
-			<attack>Two Handed|5|1d8+1</attack>
+			<attack>Two Handed|3|1d8+1</attack>
 		</action>
 	</monster>
 	<monster>
@@ -10858,6 +10863,7 @@
 		<action>
 			<name>Bite</name>
 			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 21 (5d6 + 4) piercing damage.</text>
+			<attack>Bite|6|5d6+4</attack>
 		</action>
 	</monster>
 	<monster>
@@ -12504,7 +12510,7 @@
 		<action>
 			<name>Hooves</name>
 			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage.</text>
-			<attack>Hooves|4|1d4+2</attack>
+			<attack>Hooves|2|1d4+2</attack>
 		</action>
 	</monster>
 	<monster>
@@ -14184,6 +14190,7 @@
 		<action>
 			<name>Bite</name>
 			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) piercing damage</text>
+			<attack>Bite|3|2d4+1</attack>
 		</action>
 	</monster>
 	<monster>
@@ -14549,6 +14556,7 @@
 		<action>
 			<name>Beak</name>
 			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1 piercing damage.</text>
+			<attack>Beak|4|1</attack>
 		</action>
 	</monster>
 	<monster>
@@ -14923,7 +14931,7 @@
 		<action>
 			<name>Smother</name>
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one Medium or smaller creature. Hit: The creature is grappled (escape DC 13). Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target. In addition, at the start of each of the target's turns, the target takes 10 (2d6 + 3) bludgeoning damage.</text>
-			<attack>||2d6+3</attack>
+			<attack>|5|2d6+3</attack>
 		</action>
 	</monster>
 	<monster>
@@ -17002,6 +17010,7 @@
 		<action>
 			<name>Claw</name>
 			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage.</text>
+			<attack>Claw|5|1d8+3</attack>
 		</action>
 	</monster>
 	<monster>
@@ -19470,22 +19479,22 @@
 		<action>
 			<name>Bite</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage plus 10 (3d6) poison damage.</text>
-			<attack>|5|1d6+4+3d6</attack>
+			<attack>|7|1d6+4+3d6</attack>
 		</action>
 		<action>
 			<name>Constrict</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the yuan_ti can't constrict another target.</text>
-			<attack>|5|2d6+4</attack>
+			<attack>|7|2d6+4</attack>
 		</action>
 		<action>
 			<name>Scimitar (Abomination Form Only)</name>
 			<text>Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.</text>
-			<attack>|5|2d6+4</attack>
+			<attack>|7|2d6+4</attack>
 		</action>
 		<action>
 			<name>Longbow (Abomination Form Only)</name>
 			<text>Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 12 (2d8 + 3) piercing damage plus 10 (3d6) poison damage.</text>
-			<attack>|4|2d8+3+3d6</attack>
+			<attack>|6|2d8+3+3d6</attack>
 		</action>
 		<spells>animal friendship, suggestion, fear</spells>
 	</monster>

--- a/Items/Mundane Items.xml
+++ b/Items/Mundane Items.xml
@@ -3,6 +3,7 @@
 	<item>
 		<name>Copper (cp)</name>
 		<type>$</type>
+		<value>1cp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
 		<text />
@@ -21,6 +22,7 @@
 	<item>
 		<name>Electrum (ep)</name>
 		<type>$</type>
+		<value>1ep</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
 		<text />
@@ -39,6 +41,7 @@
 	<item>
 		<name>Gold (gp)</name>
 		<type>$</type>
+		<value>1gp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
 		<text />
@@ -57,6 +60,7 @@
 	<item>
 		<name>Platinum (pp)</name>
 		<type>$</type>
+		<value>1pp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
 		<text />
@@ -75,6 +79,7 @@
 	<item>
 		<name>Silver (sp)</name>
 		<type>$</type>
+		<value>1sp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
 		<text />
@@ -93,7 +98,17 @@
 	<item>
 		<name>Arrows</name>
 		<type>A</type>
+		<value>5cp</value>
 		<weight>0.05</weight>
+		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
+		<text />
+		<text>Source: Player's Handbook, page 150</text>
+	</item>
+	<item>
+		<name>Arrows (20)</name>
+		<type>A</type>
+		<value>1gp</value>
+		<weight>1</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
 		<text />
 		<text>Source: Player's Handbook, page 150</text>
@@ -101,7 +116,17 @@
 	<item>
 		<name>Blowgun Needles</name>
 		<type>A</type>
+		<value>2cp</value>
 		<weight>0.02</weight>
+		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
+		<text />
+		<text>Source: Player's Handbook, page 150</text>
+	</item>
+	<item>
+		<name>Blowgun Needles (50)</name>
+		<type>A</type>
+		<value>1gp</value>
+		<weight>1</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
 		<text />
 		<text>Source: Player's Handbook, page 150</text>
@@ -109,7 +134,17 @@
 	<item>
 		<name>Crossbow Bolts</name>
 		<type>A</type>
+		<value>5cp</value>
 		<weight>0.075</weight>
+		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
+		<text />
+		<text>Source: Player's Handbook, page 150</text>
+	</item>
+	<item>
+		<name>Crossbow Bolts (20)</name>
+		<type>A</type>
+		<value>1gp</value>
+		<weight>1.5</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
 		<text />
 		<text>Source: Player's Handbook, page 150</text>
@@ -117,7 +152,17 @@
 	<item>
 		<name>Sling Bullets</name>
 		<type>A</type>
+		<value>0.2cp</value>
 		<weight>0.075</weight>
+		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
+		<text />
+		<text>Source: Player's Handbook, page 150</text>
+	</item>
+	<item>
+		<name>Sling Bullets (20)</name>
+		<type>A</type>
+		<value>4cp</value>
+		<weight>1.5</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
 		<text />
 		<text>Source: Player's Handbook, page 150</text>
@@ -125,12 +170,14 @@
 	<item>
 		<name>Abacus</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>2</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Acid (vial)</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>1</weight>
 		<text>As an action, you can splash the contents of this vial onto a creature within 5 feet of you or throw the vial up to 20 feet, shattering it on impact. In either case, make a ranged attack against a creature or object, treating the acid as an improvised weapon. On a hit, the target takes 2d6 acid damage.</text>
 		<text />
@@ -139,6 +186,7 @@
 	<item>
 		<name>Alchemist's Fire (flask)</name>
 		<type>G</type>
+		<value>50gp</value>
 		<weight>1</weight>
 		<text>This sticky, adhesive fluid ignites when exposed to air. As an action, you can throw this flask up to 20 feet, shattering it on impact. Make a ranged attack against a creature or object, treating the alchemist's fire as an improvised weapon. On a hit, the target takes 1d4 fire damage at the start of each of its turns. A creature can end this damage by using its action to make a DC 10 Dexterity check to extinguish the flames.</text>
 		<text />
@@ -155,6 +203,7 @@
 	<item>
 		<name>Antitoxin</name>
 		<type>G</type>
+		<value>50gp</value>
 		<text>A creature that drinks this vial of liquid gains advantage on saving throws against poison for 1 hour. It confers no benefit to undead or constructs.</text>
 		<text />
 		<text>Source: Player's Handbook, page 151</text>
@@ -162,6 +211,7 @@
 	<item>
 		<name>Backpack</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>5</weight>
 		<text>A backpack can hold one cubic foot or 30 pounds of gear. You can also strap items, such as a bedroll or a coil of rope, to the outside of a backpack.</text>
 		<text />
@@ -182,6 +232,7 @@
 	<item>
 		<name>Ball Bearings</name>
 		<type>G</type>
+		<value>0.1cp</value>
 		<weight>0.002</weight>
 		<text>As an action, you can spill these tiny metal balls from their pouch to cover a level area 10 feet square. A creature moving across the covered area must succeed on a DC 10 Dexterity saving throw or fall prone. A creature moving through the area at half speed doesn't need to make the saving throw.</text>
 		<text />
@@ -190,6 +241,7 @@
 	<item>
 		<name>Barrel</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>70</weight>
 		<text>A barrel can hold 40 gallons of liquid or 4 cubic feet of solids.</text>
 		<text />
@@ -205,6 +257,7 @@
 	<item>
 		<name>Basket</name>
 		<type>G</type>
+		<value>4sp</value>
 		<weight>2</weight>
 		<text>A basket holds 2 cubic feet or 40 pounds of gear.</text>
 		<text />
@@ -213,23 +266,27 @@
 	<item>
 		<name>Bedroll</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>7</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Bell</name>
 		<type>G</type>
+		<value>1gp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Blanket</name>
 		<type>G</type>
+		<value>5sp</value>
 		<weight>3</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Block and Tackle</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>5</weight>
 		<text>A set of pulleys with a cable threaded through them and a hook to attach to objects, a block and tackle allows you to hoist up to four times the weight you can normally lift.</text>
 		<text />
@@ -238,6 +295,7 @@
 	<item>
 		<name>Book</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>5</weight>
 		<text>A book might contain poetry, historical accounts, information pertaining to a particular field of lore, diagrams and notes on gnomish contraptions, or just about anything else that can be represented using text or pictures. A book of spells is a spellbook (described later in this section).</text>
 		<text />
@@ -246,6 +304,7 @@
 	<item>
 		<name>Brewer's Supplies</name>
 		<type>G</type>
+		<value>20gp</value>
 		<weight>9</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -254,6 +313,7 @@
 	<item>
 		<name>Bucket</name>
 		<type>G</type>
+		<value>5cp</value>
 		<weight>2</weight>
 		<text>A bucket holds 3 gallons of liquid or 1/2 cubic foot of solids.</text>
 		<text />
@@ -262,6 +322,7 @@
 	<item>
 		<name>Bullseye Lantern</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>2</weight>
 		<text>A bullseye lantern casts bright light in a 60-foot cone and dim light for an additional 60 feet. Once lit, it burns for 6 hours on a flask (1 pint) of oil.</text>
 		<text />
@@ -270,6 +331,7 @@
 	<item>
 		<name>Burglar's Pack</name>
 		<type>G</type>
+		<value>16gp</value>
 		<weight>44.5</weight>
 		<text>Includes:</text>
 		<text />
@@ -306,6 +368,7 @@
 	<item>
 		<name>Calligrapher's Supplies</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -314,7 +377,17 @@
 	<item>
 		<name>Caltrops</name>
 		<type>G</type>
+		<value>5cp</value>
 		<weight>0.1</weight>
+		<text>As an action, you can spread a single bag of caltrops to cover a 5-foot-square area. Any creature that enters the area must succeed on a DC 15 Dexterity saving throw or stop moving and take 1 piercing damage. Until the creature regains at least 1 hit point, its walking speed is reduced by 10 feet. A creature moving through the area at half speed doesn't need to make the saving throw.</text>
+		<text />
+		<text>Source: Player's Handbook, page 151</text>
+	</item>
+	<item>
+		<name>Caltrops (20)</name>
+		<type>G</type>
+		<value>1gp</value>
+		<weight>2</weight>
 		<text>As an action, you can spread a single bag of caltrops to cover a 5-foot-square area. Any creature that enters the area must succeed on a DC 15 Dexterity saving throw or stop moving and take 1 piercing damage. Until the creature regains at least 1 hit point, its walking speed is reduced by 10 feet. A creature moving through the area at half speed doesn't need to make the saving throw.</text>
 		<text />
 		<text>Source: Player's Handbook, page 151</text>
@@ -322,6 +395,7 @@
 	<item>
 		<name>Candle</name>
 		<type>G</type>
+		<value>1cp</value>
 		<text>For 1 hour, a candle sheds bright light in a 5-foot radius and dim light for an additional 5 feet.</text>
 		<text />
 		<text>Source: Player's Handbook, page 151</text>
@@ -329,6 +403,7 @@
 	<item>
 		<name>Carpenter's Tools</name>
 		<type>G</type>
+		<value>8gp</value>
 		<weight>6</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -337,6 +412,7 @@
 	<item>
 		<name>Cartographer's Tools</name>
 		<type>G</type>
+		<value>15gp</value>
 		<weight>6</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -345,6 +421,7 @@
 	<item>
 		<name>Chain (10 feet)</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>10</weight>
 		<text>A chain has 10 hit points. It can be burst with a successful DC 20 Strength check.</text>
 		<text />
@@ -353,11 +430,13 @@
 	<item>
 		<name>Chalk (1 piece)</name>
 		<type>G</type>
+		<value>1cp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Chest</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>25</weight>
 		<text>A chest holds 12 cubic feet or 300 pounds of gear.</text>
 		<text />
@@ -366,6 +445,7 @@
 	<item>
 		<name>Climber's Kit</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>12</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -374,6 +454,7 @@
 	<item>
 		<name>Cobbler's Tools</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -382,12 +463,14 @@
 	<item>
 		<name>Common Clothes</name>
 		<type>G</type>
+		<value>5sp</value>
 		<weight>3</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Component Pouch</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>2</weight>
 		<text>A component pouch is a small, watertight leather belt pouch that has compartments to hold all the material components and other special items you need to cast your spells, except for those components that have a specific cost (as indicated in a spell's description).</text>
 		<text />
@@ -396,6 +479,7 @@
 	<item>
 		<name>Cook's Utensils</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -404,12 +488,14 @@
 	<item>
 		<name>Costume Clothes</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Crossbow Bolt Case</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>1</weight>
 		<text>This wooden case can hold up to twenty crossbow bolts.</text>
 		<text />
@@ -418,6 +504,7 @@
 	<item>
 		<name>Crowbar</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>5</weight>
 		<text>Using a crowbar grants advantage to Strength checks where the crowbar's leverage can be applied.</text>
 		<text />
@@ -426,6 +513,7 @@
 	<item>
 		<name>Crystal</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>1</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
 		<text />
@@ -434,6 +522,7 @@
 	<item>
 		<name>Dice Set</name>
 		<type>G</type>
+		<value>1sp</value>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
 		<text />
 		<text>Source: Player's Handbook, page 154</text>
@@ -441,6 +530,7 @@
 	<item>
 		<name>Diplomat's Pack</name>
 		<type>G</type>
+		<value>39gp</value>
 		<weight>36</weight>
 		<text>Includes:</text>
 		<text />
@@ -471,6 +561,7 @@
 	<item>
 		<name>Disguise Kit</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>3</weight>
 		<text>This pouch of cosmetics, hair dye, and small props lets you create disguises that change your physical appearance. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to create a visual disguise.</text>
 		<text />
@@ -479,6 +570,7 @@
 	<item>
 		<name>Dragonchess Set</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>0.5</weight>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
 		<text />
@@ -487,6 +579,7 @@
 	<item>
 		<name>Drum</name>
 		<type>G</type>
+		<value>6gp</value>
 		<weight>3</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -499,6 +592,7 @@
 	<item>
 		<name>Dulcimer</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>10</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -511,6 +605,7 @@
 	<item>
 		<name>Dungeoneer's Pack</name>
 		<type>G</type>
+		<value>12gp</value>
 		<weight>61.5</weight>
 		<text>Includes:</text>
 		<text />
@@ -537,6 +632,7 @@
 	<item>
 		<name>Entertainer's Pack</name>
 		<type>G</type>
+		<value>40gp</value>
 		<weight>38</weight>
 		<text>Includes:</text>
 		<text />
@@ -559,6 +655,7 @@
 	<item>
 		<name>Explorer's Pack</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>59</weight>
 		<text>Includes:</text>
 		<text />
@@ -583,12 +680,14 @@
 	<item>
 		<name>Fine Clothes</name>
 		<type>G</type>
+		<value>15gp</value>
 		<weight>6</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Fishing Tackle</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>4</weight>
 		<text>This kit includes a wooden rod, silken line, corkwood bobbers, steel hooks, lead sinkers, velvet lures, and narrow netting.</text>
 		<text />
@@ -597,6 +696,7 @@
 	<item>
 		<name>Flask</name>
 		<type>G</type>
+		<value>1cp</value>
 		<weight>1</weight>
 		<text>A flask holds 1 pint of liquid.</text>
 		<text />
@@ -605,6 +705,7 @@
 	<item>
 		<name>Flute</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>1</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -617,6 +718,7 @@
 	<item>
 		<name>Forgery Kit</name>
 		<type>G</type>
+		<value>15gp</value>
 		<weight>5</weight>
 		<text>This small box contains a variety of papers and parchments, pens and inks, seals and sealing wax, gold and silver leaf, and other supplies necessary to create convincing forgeries of physical documents. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to create a physical forgery of a document.</text>
 		<text />
@@ -625,6 +727,7 @@
 	<item>
 		<name>Glass Bottle</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>2</weight>
 		<text>A bottle holds 1 1/2 pints of liquid.</text>
 		<text />
@@ -633,6 +736,7 @@
 	<item>
 		<name>Glassblower's Tools</name>
 		<type>G</type>
+		<value>30gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -641,18 +745,21 @@
 	<item>
 		<name>Grappling Hook</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Hammer</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>3</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Healer's Kit</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>3</weight>
 		<text>This kit is a leather pouch containing bandages, salves, and splints. The kit has ten uses. As an action, you can expend one use of the kit to stabilize a creature that has 0 hit points, without needing to make a Wisdom (Medicine) check.</text>
 		<text />
@@ -661,6 +768,7 @@
 	<item>
 		<name>Hempen Rope (50 feet)</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>10</weight>
 		<text>Rope, whether made of hemp or silk, has 2 hit points and can be burst with a DC 17 Strength check.</text>
 		<text />
@@ -669,6 +777,7 @@
 	<item>
 		<name>Herbalism Kit</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>3</weight>
 		<text>This kit contains a variety of instruments such as clippers, mortar and pestle, and pouches and vials used by herbalists to create remedies and potions. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to identify or apply herbs. Also, proficiency with this kit is required to create antitoxin and potions of healing.</text>
 		<text />
@@ -677,6 +786,7 @@
 	<item>
 		<name>Holy Symbol (Amulet)</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>1</weight>
 		<text>A holy symbol is a representation of a god or pantheon</text>
 		<text />
@@ -687,6 +797,7 @@
 	<item>
 		<name>Holy Symbol (Emblem)</name>
 		<type>G</type>
+		<value>5gp</value>
 		<text>A holy symbol is a representation of a god or pantheon</text>
 		<text />
 		<text>A cleric or paladin can use a holy symbol as a spellcasting focus, using it in place of any material components which do not list a cost. To use the symbol in this way, the caster must hold it in hand, wear it visibly, or bear it on a shield.</text>
@@ -696,6 +807,7 @@
 	<item>
 		<name>Holy Symbol (Reliquary)</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>2</weight>
 		<text>A holy symbol is a representation of a god or pantheon</text>
 		<text />
@@ -706,6 +818,7 @@
 	<item>
 		<name>Holy Water (flask)</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>1</weight>
 		<text>As an action, you can splash the contents of this flask onto a creature within 5 feet of you or throw it up to 20 feet, shattering it on impact. In either case, make a ranged attack against a target creature, treating the holy water as an improvised weapon. If the target is a fiend or undead, it takes 2d6 radiant damage.\n\tA cleric or paladin may create holy water by performing a special ritual. The ritual takes 1 hour to perform, uses 25 gp worth of powdered silver, and requires the caster to expend a 1st-level spell slot.</text>
 		<text />
@@ -714,6 +827,7 @@
 	<item>
 		<name>Hooded Lantern</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>2</weight>
 		<text>A hooded lantern casts bright light in a 30-foot radius and dim light for an additional 30 feet. Once lit, it burns for 6 hours on a flask (1 pint) of oil. As an action, you can lower the hood, reducing the light to dim light in a 5-foot radius.</text>
 		<text />
@@ -722,6 +836,7 @@
 	<item>
 		<name>Horn</name>
 		<type>G</type>
+		<value>3gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -734,12 +849,14 @@
 	<item>
 		<name>Hourglass</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>1</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Hunting Trap</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>25</weight>
 		<text>When you use your action to set it, this trap forms a saw-toothed steel ring that snaps shut when a creature steps on a pressure plate in the center. The trap is affixed by a heavy chain to an immobile object, such as a tree or a spike driven into the ground. A creature that steps on the plate must succeed on a DC 13 Dexterity saving throw or take 1d4 piercing damage and stop moving. Thereafter, until the creature breaks free of the trap, its movement is limited by the length of the chain (typically 3 feet long). A creature can use its action to make a DC 13 Strength check, freeing itself or another creature within its reach on a success. Each failed check deals 1 piercing damage to the trapped creature.</text>
 		<text />
@@ -747,17 +864,20 @@
 	</item>
 	<item>
 		<name>Ink (1 ounce bottle)</name>
+		<value>10gp</value>
 		<type>G</type>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Ink Pen</name>
+		<value>2cp</value>
 		<type>G</type>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Iron Pot</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>10</weight>
 		<text>An iron pot holds 1 gallon of liquid.</text>
 		<text />
@@ -766,12 +886,21 @@
 	<item>
 		<name>Iron Spikes</name>
 		<type>G</type>
+		<value>1sp</value>
 		<weight>0.5</weight>
+		<text>Source: Player's Handbook, page 150</text>
+	</item>
+	<item>
+		<name>Iron Spikes (10)</name>
+		<type>G</type>
+		<value>1gp</value>
+		<weight>5</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Jeweler's Tools</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>2</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -780,6 +909,7 @@
 	<item>
 		<name>Jug</name>
 		<type>G</type>
+		<value>2cp</value>
 		<weight>4</weight>
 		<text>A jug holds 1 gallon of liquid.</text>
 		<text />
@@ -788,12 +918,14 @@
 	<item>
 		<name>Ladder (10-foot)</name>
 		<type>G</type>
+		<value>1sp</value>
 		<weight>25</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Lamp</name>
 		<type>G</type>
+		<value>5sp</value>
 		<weight>1</weight>
 		<text>A lamp casts bright light in a 15-foot radius and dim light for an additional 30 feet. Once lit, it burns for 6 hours on a flask (1 pint) of oil.</text>
 		<text />
@@ -802,6 +934,7 @@
 	<item>
 		<name>Leatherworker's Tools</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -810,6 +943,7 @@
 	<item>
 		<name>Lock</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>1</weight>
 		<text>A key is provided with the lock. Without the key, a creature proficient with thieves' tools can pick this lock with a successful DC 15 Dexterity check. Your DM may decide that better locks are available for higher prices.</text>
 		<text />
@@ -818,6 +952,7 @@
 	<item>
 		<name>Lute</name>
 		<type>G</type>
+		<value>35gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -830,6 +965,7 @@
 	<item>
 		<name>Lyre</name>
 		<type>G</type>
+		<value>30gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -842,6 +978,7 @@
 	<item>
 		<name>Magnifying Glass</name>
 		<type>G</type>
+		<value>100gp</value>
 		<text>This lens allows a closer look at small objects. It is also useful as a substitute for flint and steel when starting fires. Lighting a fire with a magnifying glass requires light as bright as sunlight to focus, tinder to ignite, and about 5 minutes for the fire to ignite. A magnifying glass grants advantage on any ability check made to appraise or inspect an item that is small or highly detailed.</text>
 		<text />
 		<text>Source: Player's Handbook, page 152</text>
@@ -849,6 +986,7 @@
 	<item>
 		<name>Manacles</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>6</weight>
 		<text>These metal restraints can bind a Small or Medium creature. Escaping the manacles requires a successful DC 20 Dexterity check. Breaking them requires a successful DC 20 Strength check. Each set of manacles comes with one key. Without the key, a creature proficient with thieves' tools can pick the manacles' lock with a successful DC 15 Dexterity check. Manacles have 15 hit points.</text>
 		<text />
@@ -857,6 +995,7 @@
 	<item>
 		<name>Map or Scroll Case</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>1</weight>
 		<text>This cylindrical leather case can hold up to ten rolled-up sheets of paper or five rolled-up sheets of parchment.</text>
 		<text />
@@ -865,6 +1004,7 @@
 	<item>
 		<name>Mason's Tools</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -873,6 +1013,7 @@
 	<item>
 		<name>Merchant's Scale</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>3</weight>
 		<text>A scale includes a small balance, pans, and a suitable assortment of weights up to 2 pounds. With it, you can measure the exact weight of small objects, such as raw precious metals or trade goods, to help determine their worth.</text>
 		<text />
@@ -881,6 +1022,7 @@
 	<item>
 		<name>Mess Kit</name>
 		<type>G</type>
+		<value>2sp</value>
 		<weight>1</weight>
 		<text>This tin box contains a cup and simple cutlery. The box clamps together, and one side can be used as a cooking pan and the other as a plate or shallow bowl.</text>
 		<text />
@@ -889,12 +1031,14 @@
 	<item>
 		<name>Miner's Pick</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>10</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Navigator's Tools</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>2</weight>
 		<text>This set of instruments is used for navigation at sea. Proficiency with navigator's tools lets you chart a ship's course and follow navigation charts. In addition, these tools allow you to add your proficiency bonus to any ability check you make to avoid getting lost at sea.</text>
 		<text />
@@ -903,6 +1047,7 @@
 	<item>
 		<name>Oil (flask)</name>
 		<type>G</type>
+		<value>1sp</value>
 		<weight>1</weight>
 		<text>Oil usually comes in a clay flask that holds 1 pint. As an action, you can splash the oil in this flask onto a creature within 5 feet of you or throw it up to 20 feet, shattering it on impact. Make a ranged attack against a target creature or object, treating the oil as an improvised weapon. On a hit, the target is covered in oil. If the target takes any fire damage before the oil dries (after 1 minute), the target takes an additional 5 fire damage from the burning oil. You can also pour a flask of oil on the ground to cover a 5-foot-square area, provided that the surface is level. If lit, the oil burns for 2 rounds and deals 5 fire damage to any creature that enters the area or ends its turn in the area. A creature can take this damage only once per turn.</text>
 		<text />
@@ -911,6 +1056,7 @@
 	<item>
 		<name>Orb</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>3</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
 		<text />
@@ -919,6 +1065,7 @@
 	<item>
 		<name>Painter's Supplies</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -927,6 +1074,7 @@
 	<item>
 		<name>Pan Flute</name>
 		<type>G</type>
+		<value>12gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -939,21 +1087,25 @@
 	<item>
 		<name>Paper (one sheet)</name>
 		<type>G</type>
+		<value>2sp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Parchment (one sheet)</name>
 		<type>G</type>
+		<value>1sp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Perfume (vial)</name>
 		<type>G</type>
+		<value>5gp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Pitcher</name>
 		<type>G</type>
+		<value>2cp</value>
 		<weight>4</weight>
 		<text>A pitcher holds 1 gallon of liquid.</text>
 		<text />
@@ -962,12 +1114,14 @@
 	<item>
 		<name>Piton</name>
 		<type>G</type>
+		<value>5cp</value>
 		<weight>0.25</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Playing Card Set</name>
 		<type>G</type>
+		<value>5sp</value>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
 		<text />
 		<text>Source: Player's Handbook, page 154</text>
@@ -975,6 +1129,7 @@
 	<item>
 		<name>Poisoner's Kit</name>
 		<type>G</type>
+		<value>50gp</value>
 		<weight>2</weight>
 		<text>A poisoner's kit includes the vials, chemicals, and other equipment necessary for the creation of poisons. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to craft or use poisons.</text>
 		<text />
@@ -983,12 +1138,14 @@
 	<item>
 		<name>Pole (10-foot)</name>
 		<type>G</type>
+		<value>5cp</value>
 		<weight>7</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Portable Ram</name>
 		<type>G</type>
+		<value>4gp</value>
 		<weight>35</weight>
 		<text>You can use a portable ram to break down doors. When doing so, you gain a +4 bonus on the Strength check. One other character can help you use the ram, giving you advantage on this check.</text>
 		<text />
@@ -997,6 +1154,7 @@
 	<item>
 		<name>Potter's Tools</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>3</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -1005,6 +1163,7 @@
 	<item>
 		<name>Pouch</name>
 		<type>G</type>
+		<value>5sp</value>
 		<weight>1</weight>
 		<text>A cloth or leather pouch can hold up to 20 sling bullets or 50 blowgun needles, among other things. A compartmentalized pouch for holding spell components is called a component pouch. A pouch can hold up to 1/5 cubic foot or 6 pounds of gear.</text>
 		<text />
@@ -1013,6 +1172,7 @@
 	<item>
 		<name>Priest's Pack</name>
 		<type>G</type>
+		<value>19gp</value>
 		<weight>24</weight>
 		<text>Includes:</text>
 		<text />
@@ -1041,6 +1201,7 @@
 	<item>
 		<name>Quiver</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>1</weight>
 		<text>A quiver can hold up to 20 arrows.</text>
 		<text />
@@ -1049,6 +1210,7 @@
 	<item>
 		<name>Rations (1 day)</name>
 		<type>G</type>
+		<value>5sp</value>
 		<weight>2</weight>
 		<text>Rations consist of dry foods suitable for extended travel, including jerky, dried fruit, hardtack, and nuts.</text>
 		<text />
@@ -1057,12 +1219,14 @@
 	<item>
 		<name>Robes</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Rod</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>2</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
 		<text />
@@ -1071,6 +1235,7 @@
 	<item>
 		<name>Sack</name>
 		<type>G</type>
+		<value>1cp</value>
 		<weight>0.5</weight>
 		<text>A sack can hold up to 1 cubic foot or 30 pounds of gear.</text>
 		<text />
@@ -1079,6 +1244,7 @@
 	<item>
 		<name>Scholar's Pack</name>
 		<type>G</type>
+		<value>40gp</value>
 		<weight>10</weight>
 		<text>Includes:</text>
 		<text />
@@ -1100,12 +1266,14 @@
 	</item>
 	<item>
 		<name>Sealing Wax</name>
+		<value>5sp</value>
 		<type>G</type>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Shawm</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>1</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -1118,16 +1286,19 @@
 	<item>
 		<name>Shovel</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>5</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Signal Whistle</name>
+		<value>5cp</value>
 		<type>G</type>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Signet Ring</name>
+		<value>5gp</value>
 		<type>G</type>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
@@ -1141,6 +1312,7 @@
 	</item>
 	<item>
 		<name>Sledge Hammer</name>
+		<value>2gp</value>
 		<type>G</type>
 		<weight>10</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1148,6 +1320,7 @@
 	<item>
 		<name>Smith's Tools</name>
 		<type>G</type>
+		<value>20gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -1156,11 +1329,13 @@
 	<item>
 		<name>Soap</name>
 		<type>G</type>
+		<value>2cp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Spellbook</name>
 		<type>G</type>
+		<value>50gp</value>
 		<weight>3</weight>
 		<text>Essential for wizards, a spellbook is a leather-bound tome with 100 blank vellum pages suitable for recording spells.</text>
 		<text />
@@ -1176,6 +1351,7 @@
 	<item>
 		<name>Spyglass</name>
 		<type>G</type>
+		<value>1000gp</value>
 		<weight>1</weight>
 		<text>Objects viewed through a spyglass are magnified to twice their size.</text>
 		<text />
@@ -1184,6 +1360,7 @@
 	<item>
 		<name>Staff</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>4</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
 		<text />
@@ -1192,12 +1369,14 @@
 	<item>
 		<name>Steel Mirror</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>0.5</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Tankard</name>
 		<type>G</type>
+		<value>1cp</value>
 		<text>A tankard holds 1 pint of liquid.</text>
 		<text />
 		<text>Source: Player's Handbook, page 153</text>
@@ -1205,6 +1384,7 @@
 	<item>
 		<name>Thieves' Tools</name>
 		<type>G</type>
+		<value>25gp</value>
 		<weight>1</weight>
 		<text>This set of tools includes a small file, a set of lock picks, a small mirror mounted on a metal handle, a set of narrow-bladed scissors, and a pair of pliers. Proficiency with these tools lets you add your proficiency bonus to any ability checks you make to disarm traps or open locks.</text>
 		<text />
@@ -1213,6 +1393,7 @@
 	<item>
 		<name>Three-Dragon Ante Set</name>
 		<type>G</type>
+		<value>1gp</value>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
 		<text />
 		<text>Source: Player's Handbook, page 154</text>
@@ -1220,6 +1401,7 @@
 	<item>
 		<name>Tinderbox</name>
 		<type>G</type>
+		<value>5sp</value>
 		<weight>1</weight>
 		<text>This small container holds flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a torch - or anything else with abundant, exposed fuel - takes an action. Lighting any other fire takes 1 minute.</text>
 		<text />
@@ -1228,6 +1410,7 @@
 	<item>
 		<name>Tinker's Tools</name>
 		<type>G</type>
+		<value>50gp</value>
 		<weight>10</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -1236,6 +1419,7 @@
 	<item>
 		<name>Torch</name>
 		<type>G</type>
+		<value>1cp</value>
 		<weight>1</weight>
 		<text>A torch burns for 1 hour, providing bright light in a 20-foot radius and dim light for an additional 20 feet. If you make a melee attack with a burning torch and hit, it deals 1 fire damage.</text>
 		<text />
@@ -1244,6 +1428,7 @@
 	<item>
 		<name>Totem</name>
 		<type>G</type>
+		<value>1gp</value>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
 		<text />
 		<text>Source: Player's Handbook, page 151</text>
@@ -1251,12 +1436,14 @@
 	<item>
 		<name>Traveler's Clothes</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Two-Person Tent</name>
 		<type>G</type>
+		<value>2gp</value>
 		<weight>20</weight>
 		<text>A simple and portable canvas shelter, a tent sleeps two.</text>
 		<text />
@@ -1265,6 +1452,7 @@
 	<item>
 		<name>Vial</name>
 		<type>G</type>
+		<value>1gp</value>
 		<text>A vial can hold up to 4 ounces of liquid.</text>
 		<text />
 		<text>Source: Player's Handbook, page 153</text>
@@ -1272,6 +1460,7 @@
 	<item>
 		<name>Viol</name>
 		<type>G</type>
+		<value>30gp</value>
 		<weight>1</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -1284,6 +1473,7 @@
 	<item>
 		<name>Wand</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>1</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
 		<text />
@@ -1292,6 +1482,7 @@
 	<item>
 		<name>Waterskin</name>
 		<type>G</type>
+		<value>2sp</value>
 		<weight>5</weight>
 		<text>A waterskin can hold up to 4 pints of liquid.</text>
 		<text />
@@ -1300,6 +1491,7 @@
 	<item>
 		<name>Weaver's Tools</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -1308,12 +1500,14 @@
 	<item>
 		<name>Whetstone</name>
 		<type>G</type>
+		<value>1cp</value>
 		<weight>1</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Woodcarver's Tools</name>
 		<type>G</type>
+		<value>1gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -1322,6 +1516,7 @@
 	<item>
 		<name>Wooden Staff</name>
 		<type>G</type>
+		<value>5gp</value>
 		<weight>4</weight>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
 		<text />
@@ -1330,6 +1525,7 @@
 	<item>
 		<name>Yew Wand</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>1</weight>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
 		<text />
@@ -1338,6 +1534,7 @@
 	<item>
 		<name>Chain Mail</name>
 		<type>HA</type>
+		<value>75gp</value>
 		<weight>55</weight>
 		<ac>16</ac>
 		<strength>13</strength>
@@ -1349,6 +1546,7 @@
 	<item>
 		<name>Plate Armor</name>
 		<type>HA</type>
+		<value>1500gp</value>
 		<weight>65</weight>
 		<ac>18</ac>
 		<strength>15</strength>
@@ -1360,6 +1558,7 @@
 	<item>
 		<name>Ring Mail</name>
 		<type>HA</type>
+		<value>30gp</value>
 		<weight>40</weight>
 		<ac>14</ac>
 		<stealth>YES</stealth>
@@ -1370,6 +1569,7 @@
 	<item>
 		<name>Splint Armor</name>
 		<type>HA</type>
+		<value>200gp</value>
 		<weight>60</weight>
 		<ac>17</ac>
 		<strength>15</strength>
@@ -1381,6 +1581,7 @@
 	<item>
 		<name>Leather Armor</name>
 		<type>LA</type>
+		<value>10gp</value>
 		<weight>10</weight>
 		<ac>11</ac>
 		<text>The breastplate and shoulder protectors of this armor are made of leather that has been stiffened by being boiled in oil. The rest of the armor is made of softer and more flexible materials.</text>
@@ -1390,6 +1591,7 @@
 	<item>
 		<name>Padded Armor</name>
 		<type>LA</type>
+		<value>5gp</value>
 		<weight>8</weight>
 		<ac>11</ac>
 		<stealth>YES</stealth>
@@ -1400,6 +1602,7 @@
 	<item>
 		<name>Studded Leather Armor</name>
 		<type>LA</type>
+		<value>45gp</value>
 		<weight>13</weight>
 		<ac>12</ac>
 		<text>Made from tough but flexible leather, studded leather is reinforced with close-set rivets or spikes.</text>
@@ -1409,6 +1612,7 @@
 	<item>
 		<name>Battleaxe</name>
 		<type>M</type>
+		<value>10gp</value>
 		<weight>4</weight>
 		<dmg1>1d8</dmg1>
 		<dmg2>1d10</dmg2>
@@ -1421,6 +1625,7 @@
 	<item>
 		<name>Club</name>
 		<type>M</type>
+		<value>1sp</value>
 		<weight>2</weight>
 		<dmg1>1d4</dmg1>
 		<dmgType>B</dmgType>
@@ -1432,6 +1637,7 @@
 	<item>
 		<name>Dagger</name>
 		<type>M</type>
+		<value>2gp</value>
 		<weight>1</weight>
 		<dmg1>1d4</dmg1>
 		<dmgType>P</dmgType>
@@ -1450,6 +1656,7 @@
 	<item>
 		<name>Flail</name>
 		<type>M</type>
+		<value>10gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
 		<dmgType>B</dmgType>
@@ -1458,6 +1665,7 @@
 	<item>
 		<name>Glaive</name>
 		<type>M</type>
+		<value>20gp</value>
 		<weight>6</weight>
 		<dmg1>1d10</dmg1>
 		<dmgType>S</dmgType>
@@ -1473,6 +1681,7 @@
 	<item>
 		<name>Greataxe</name>
 		<type>M</type>
+		<value>30gp</value>
 		<weight>7</weight>
 		<dmg1>1d12</dmg1>
 		<dmgType>S</dmgType>
@@ -1486,6 +1695,7 @@
 	<item>
 		<name>Greatclub</name>
 		<type>M</type>
+		<value>2sp</value>
 		<weight>10</weight>
 		<dmg1>1d8</dmg1>
 		<dmgType>B</dmgType>
@@ -1497,6 +1707,7 @@
 	<item>
 		<name>Greatsword</name>
 		<type>M</type>
+		<value>50gp</value>
 		<weight>6</weight>
 		<dmg1>2d6</dmg1>
 		<dmgType>S</dmgType>
@@ -1510,6 +1721,7 @@
 	<item>
 		<name>Halberd</name>
 		<type>M</type>
+		<value>20gp</value>
 		<weight>6</weight>
 		<dmg1>1d10</dmg1>
 		<dmgType>S</dmgType>
@@ -1523,6 +1735,7 @@
 	<item>
 		<name>Handaxe</name>
 		<type>M</type>
+		<value>5gp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
 		<dmgType>S</dmgType>
@@ -1539,6 +1752,7 @@
 	<item>
 		<name>Javelin</name>
 		<type>M</type>
+		<value>2sp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
 		<dmgType>P</dmgType>
@@ -1553,6 +1767,7 @@
 	<item>
 		<name>Lance</name>
 		<type>M</type>
+		<value>10gp</value>
 		<weight>6</weight>
 		<dmg1>1d12</dmg1>
 		<dmgType>P</dmgType>
@@ -1566,6 +1781,7 @@
 	<item>
 		<name>Light Hammer</name>
 		<type>M</type>
+		<value>2gp</value>
 		<weight>2</weight>
 		<dmg1>1d4</dmg1>
 		<dmgType>B</dmgType>
@@ -1582,6 +1798,7 @@
 	<item>
 		<name>Longsword</name>
 		<type>M</type>
+		<value>15gp</value>
 		<weight>3</weight>
 		<dmg1>1d8</dmg1>
 		<dmg2>1d10</dmg2>
@@ -1594,6 +1811,7 @@
 	<item>
 		<name>Mace</name>
 		<type>M</type>
+		<value>5gp</value>
 		<weight>4</weight>
 		<dmg1>1d6</dmg1>
 		<dmgType>B</dmgType>
@@ -1602,6 +1820,7 @@
 	<item>
 		<name>Maul</name>
 		<type>M</type>
+		<value>10gp</value>
 		<weight>10</weight>
 		<dmg1>2d6</dmg1>
 		<dmgType>B</dmgType>
@@ -1615,6 +1834,7 @@
 	<item>
 		<name>Morningstar</name>
 		<type>M</type>
+		<value>15gp</value>
 		<weight>4</weight>
 		<dmg1>1d8</dmg1>
 		<dmgType>P</dmgType>
@@ -1623,6 +1843,7 @@
 	<item>
 		<name>Pike</name>
 		<type>M</type>
+		<value>5gp</value>
 		<weight>18</weight>
 		<dmg1>1d10</dmg1>
 		<dmgType>P</dmgType>
@@ -1638,6 +1859,7 @@
 	<item>
 		<name>Quarterstaff</name>
 		<type>M</type>
+		<value>2sp</value>
 		<weight>4</weight>
 		<dmg1>1d6</dmg1>
 		<dmg2>1d8</dmg2>
@@ -1650,6 +1872,7 @@
 	<item>
 		<name>Rapier</name>
 		<type>M</type>
+		<value>25gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
 		<dmgType>P</dmgType>
@@ -1661,6 +1884,7 @@
 	<item>
 		<name>Scimitar</name>
 		<type>M</type>
+		<value>25gp</value>
 		<weight>3</weight>
 		<dmg1>1d6</dmg1>
 		<dmgType>S</dmgType>
@@ -1674,6 +1898,7 @@
 	<item>
 		<name>Shortsword</name>
 		<type>M</type>
+		<value>10gp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
 		<dmgType>P</dmgType>
@@ -1687,6 +1912,7 @@
 	<item>
 		<name>Sickle</name>
 		<type>M</type>
+		<value>1gp</value>
 		<weight>2</weight>
 		<dmg1>1d4</dmg1>
 		<dmgType>S</dmgType>
@@ -1698,6 +1924,7 @@
 	<item>
 		<name>Spear</name>
 		<type>M</type>
+		<value>1gp</value>
 		<weight>3</weight>
 		<dmg1>1d6</dmg1>
 		<dmg2>1d8</dmg2>
@@ -1715,6 +1942,7 @@
 	<item>
 		<name>Trident</name>
 		<type>M</type>
+		<value>5gp</value>
 		<weight>4</weight>
 		<dmg1>1d6</dmg1>
 		<dmg2>1d8</dmg2>
@@ -1732,6 +1960,7 @@
 	<item>
 		<name>War Pick</name>
 		<type>M</type>
+		<value>5gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
 		<dmgType>P</dmgType>
@@ -1740,6 +1969,7 @@
 	<item>
 		<name>Warhammer</name>
 		<type>M</type>
+		<value>15gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
 		<dmg2>1d10</dmg2>
@@ -1752,6 +1982,7 @@
 	<item>
 		<name>Whip</name>
 		<type>M</type>
+		<value>2gp</value>
 		<weight>3</weight>
 		<dmg1>1d4</dmg1>
 		<dmgType>S</dmgType>
@@ -1765,6 +1996,7 @@
 	<item>
 		<name>Breastplate</name>
 		<type>MA</type>
+		<value>400gp</value>
 		<weight>20</weight>
 		<ac>14</ac>
 		<text>This armor consists of a fitted metal chest piece worn with supple leather. Although it leaves the legs and arms relatively unprotected, this armor provides good protection for the wearer's vital organs while leaving the wearer relatively unencumbered.</text>
@@ -1774,6 +2006,7 @@
 	<item>
 		<name>Chain Shirt</name>
 		<type>MA</type>
+		<value>50gp</value>
 		<weight>20</weight>
 		<ac>13</ac>
 		<text>Made of interlocking metal rings, a chain shirt is worn between layers of clothing or leather. This armor offers modest protection to the wearer's upper body and allows the sound of the rings rubbing against one another to be muffled by outer layers.</text>
@@ -1783,6 +2016,7 @@
 	<item>
 		<name>Half Plate</name>
 		<type>MA</type>
+		<value>750gp</value>
 		<weight>40</weight>
 		<ac>15</ac>
 		<stealth>YES</stealth>
@@ -1793,6 +2027,7 @@
 	<item>
 		<name>Hide Armor</name>
 		<type>MA</type>
+		<value>10gp</value>
 		<weight>12</weight>
 		<ac>12</ac>
 		<text>This crude armor consists of thick furs and pelts. It is commonly worn by barbarian tribes, evil humanoids, and other folk who lack access to the tools and materials needed to create better armor.</text>
@@ -1802,6 +2037,7 @@
 	<item>
 		<name>Scale Mail</name>
 		<type>MA</type>
+		<value>50gp</value>
 		<weight>45</weight>
 		<ac>14</ac>
 		<stealth>YES</stealth>
@@ -1812,6 +2048,7 @@
 	<item>
 		<name>Blowgun</name>
 		<type>R</type>
+		<value>10gp</value>
 		<weight>1</weight>
 		<dmg1>1</dmg1>
 		<dmgType>P</dmgType>
@@ -1830,6 +2067,7 @@
 	<item>
 		<name>Dart</name>
 		<type>R</type>
+		<value>5cp</value>
 		<weight>0.25</weight>
 		<dmg1>1d4</dmg1>
 		<dmgType>P</dmgType>
@@ -1846,6 +2084,7 @@
 	<item>
 		<name>Hand Crossbow</name>
 		<type>R</type>
+		<value>75gp</value>
 		<weight>3</weight>
 		<dmg1>1d6</dmg1>
 		<dmgType>P</dmgType>
@@ -1866,6 +2105,7 @@
 	<item>
 		<name>Heavy Crossbow</name>
 		<type>R</type>
+		<value>50gp</value>
 		<weight>18</weight>
 		<dmg1>1d10</dmg1>
 		<dmgType>P</dmgType>
@@ -1888,6 +2128,7 @@
 	<item>
 		<name>Light Crossbow</name>
 		<type>R</type>
+		<value>25gp</value>
 		<weight>5</weight>
 		<dmg1>1d8</dmg1>
 		<dmgType>P</dmgType>
@@ -1908,6 +2149,7 @@
 	<item>
 		<name>Longbow</name>
 		<type>R</type>
+		<value>50gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
 		<dmgType>P</dmgType>
@@ -1928,6 +2170,7 @@
 	<item>
 		<name>Net</name>
 		<type>R</type>
+		<value>1gp</value>
 		<weight>3</weight>
 		<property>S,T</property>
 		<range>5/15</range>
@@ -1942,6 +2185,7 @@
 	<item>
 		<name>Shortbow</name>
 		<type>R</type>
+		<value>25gp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
 		<dmgType>P</dmgType>
@@ -1960,6 +2204,7 @@
 	<item>
 		<name>Sling</name>
 		<type>R</type>
+		<value>1sp</value>
 		<dmg1>1d4</dmg1>
 		<dmgType>B</dmgType>
 		<property>A</property>
@@ -1975,6 +2220,7 @@
 	<item>
 		<name>Shield</name>
 		<type>S</type>
+		<value>10gp</value>
 		<weight>6</weight>
 		<ac>2</ac>
 		<text>A shield is made from wood or metal and is carried in one hand. Wielding a shield increases your Armor Class by 2. You can benefit from only one shield at a time.</text>
@@ -1984,6 +2230,7 @@
 	<item>
 		<name>Assassin's Blood (Ingested)</name>
 		<type>G</type>
+		<value>150gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must make a DC 10 Constitution saving throw. On a failed save, it takes 6 (1d12) poison damage and is poisoned for 24 hours. On a successful save, the creature takes half damage and isn't poisoned.</text>
 		<text />
@@ -1993,6 +2240,7 @@
 	<item>
 		<name>Burnt Othur Fumes (Inhaled)</name>
 		<type>G</type>
+		<value>500gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or take 10 (3d6) poison damage, and must repeat the saving throw at the start of each of its turns. On each successive failed save, the character takes 3 (1d6) poison damage. After three successful saves, the poison ends.</text>
 		<text />
@@ -2003,6 +2251,7 @@
 	<item>
 		<name>Carrion Crawler Mucus (Contact)</name>
 		<type>G</type>
+		<value>200gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated carrion crawler. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. The poisoned creature is paralyzed. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
 		<text />
@@ -2011,6 +2260,7 @@
 	<item>
 		<name>Drow Poison (Injury)</name>
 		<type>G</type>
+		<value>200gp</value>
 		<weight>0</weight>
 		<text>This poison is typically made only by the draw, and only in a place far removed from sunlight. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the creature is also unconscious while poisoned in this way. The creature wakes up if it takes damage or if another creature takes an action to shake it awake.</text>
 		<text />
@@ -2019,6 +2269,7 @@
 	<item>
 		<name>Essence of Ether (Inhaled)</name>
 		<type>G</type>
+		<value>300gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 15 Constitution saving throw or become poisoned for 8 hours. The poisoned creature is unconscious. The creature wakes up if it takes damage or if another creature takes an action to shake it awake.</text>
 		<text />
@@ -2027,6 +2278,7 @@
 	<item>
 		<name>Malice (Inhaled)</name>
 		<type>G</type>
+		<value>250gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 15 Constitution saving throw or become poisoned for 1 hour. The poisoned creature is blinded.</text>
 		<text />
@@ -2035,6 +2287,7 @@
 	<item>
 		<name>Midnight Tears (Ingested)</name>
 		<type>G</type>
+		<value>1500gp</value>
 		<weight>0</weight>
 		<text>A creature that ingests this poison suffers no effect until the stroke of midnight. If the poison has not been neutralized before then, the creature must succeed on a DC 17 Constitution saving throw, taking 31 (9d6) poison damage on a failed save, or half as much damage on a successful one.</text>
 		<text />
@@ -2044,6 +2297,7 @@
 	<item>
 		<name>Oil of Taggit (Contact)</name>
 		<type>G</type>
+		<value>400gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or become poisoned for 24 hours. The poisoned creature is unconscious. The creature wakes up if it takes damage.</text>
 		<text />
@@ -2052,6 +2306,7 @@
 	<item>
 		<name>Pale Tincture (Ingested)</name>
 		<type>G</type>
+		<value>250gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 16 Constitution saving throw or take 3 (1d6) poison damage and become poisoned. The poisoned creature must repeat the saving throw every 24 hours, taking 3 (1d6) poison damage on a failed save. Until this poison ends, the damage the poison deals can't be healed by any means. After seven successful saving throws, the effect ends and the creature can heal normally.</text>
 		<text />
@@ -2061,6 +2316,7 @@
 	<item>
 		<name>Purple Worm Poison (Injury)</name>
 		<type>G</type>
+		<value>2000gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated purple worm. A creature subjected to this poison must make a DC 19 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one.</text>
 		<text />
@@ -2070,6 +2326,7 @@
 	<item>
 		<name>Serpent Venom (Injury)</name>
 		<type>G</type>
+		<value>200gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated giant poisonous snake. A creature subjected to this poison must succeed on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one.</text>
 		<text />
@@ -2079,6 +2336,7 @@
 	<item>
 		<name>Torpor (Ingested)</name>
 		<type>G</type>
+		<value>600gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 15 Constitution saving throw or become poisoned for 4d6 hours. The poisoned creature is incapacitated.</text>
 		<text />
@@ -2088,6 +2346,7 @@
 	<item>
 		<name>Truth Serum (Ingested)</name>
 		<type>G</type>
+		<value>150gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to thi poison must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. The poisoned creature can't knowingly speak a lie, as if under the effect of a zone of truth spell.</text>
 		<text />
@@ -2096,6 +2355,7 @@
 	<item>
 		<name>Wyvern Poison (Injury)</name>
 		<type>G</type>
+		<value>1200gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated wyvern. A creature subjected to this poison must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one.</text>
 		<text />
@@ -2324,6 +2584,7 @@
 	<item>
 		<name>Spiked Armor</name>
 		<type>MA</type>
+		<value>75gp</value>
 		<weight>45</weight>
 		<ac>14</ac>
 		<stealth>YES</stealth>
@@ -2336,7 +2597,8 @@
     <item>
         <name>Monster Hunter's Pack</name>
         <type>G</type>
-        <weight>48.5</weight>
+        <value>33gp</value>
+		<weight>48.5</weight>
         <text>Includes:</text>
         <text>   • a chest</text>
         <text>   • a crowbar</text>

--- a/Items/Mundane Items.xml
+++ b/Items/Mundane Items.xml
@@ -195,6 +195,7 @@
 	<item>
 		<name>Alchemist's Supplies</name>
 		<type>G</type>
+		<value>50gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
 		<text />
@@ -220,6 +221,7 @@
 	<item>
 		<name>Bagpipes</name>
 		<type>G</type>
+		<value>30gp</value>
 		<weight>6</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
 		<text />
@@ -250,6 +252,7 @@
 	<item>
 		<name>Basic Poison (vial)</name>
 		<type>G</type>
+		<value>100gp</value>
 		<text>You can use the poison in this vial to coat one slashing or piercing weapon or up to three pieces of ammunition. Applying the poison takes an action. A creature hit by the poisoned weapon or ammunition must make a DC 10 Constitution saving throw or take 1d4 poison damage. Once applied, the poison retains potency for 1 minute before drying.</text>
 		<text />
 		<text>Source: Player's Handbook, page 153</text>
@@ -1305,6 +1308,7 @@
 	<item>
 		<name>Silk Rope (50 feet)</name>
 		<type>G</type>
+		<value>10gp</value>
 		<weight>5</weight>
 		<text>Rope, whether made of hemp or silk, has 2 hit points and can be burst with a DC 17 Strength check.</text>
 		<text />
@@ -1344,6 +1348,7 @@
 	<item>
 		<name>Sprig of Mistletoe</name>
 		<type>G</type>
+		<value>1gp</value>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
 		<text />
 		<text>Source: Player's Handbook, page 151</text>


### PR DESCRIPTION
I noticed there were missing actions for the Yuan-Ti Abomination. I scanned for missing actions in the other Monster Manual entries and found that the Bone Devil Polearm and Drider Spellcaster were also missing their actions.
I don't understand what the first number represents in the <action><attack> data, so I simply duplicated the value from similar attacks.
Also, the Bone Devil had duplicate actions, so I removed them.
