### PR TITLE
update phb spells to add material component to spell

### DIFF
--- a/Spells/PHB Spells.xml
+++ b/Spells/PHB Spells.xml
@@ -3641,7 +3641,7 @@
 		<school>I</school>
 		<time>1 action</time>
 		<range>30 feet</range>
-		<components>S, M</components>
+		<components>S, M (a bit of fleece)</components>
 		<duration>1 minute</duration>
 		<classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
 		<text>You create a sound or an image of an object within range that lasts for the duration. The illusion also ends if you dismiss it as an action or cast this spell again.</text>


### PR DESCRIPTION
Minor Illusion was missing what the component was.   I can not figure out how to edit the full compendium.
