### PR TITLE
Add MM changes to Player Beastiary and update Minor Illusion

### DIFF
--- a/Bestiary/Monster Manual Bestiary.xml
+++ b/Bestiary/Monster Manual Bestiary.xml
@@ -8002,7 +8002,7 @@
 		<cr>1/8</cr>
 		<action>
 			<name>Bite</name>
-			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
 			<attack>Bite|4|1d4+2</attack>
 		</action>
 	</monster>

--- a/Bestiary/Player Bestiary.xml
+++ b/Bestiary/Player Bestiary.xml
@@ -1057,13 +1057,13 @@
 		</trait>
 		<action>
 			<name>Gore</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 18 (3d8 + 5) piercing damage.</text>
-			<attack>Gore|8|3d8+5</attack>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) piercing damage.</text>
+			<attack>Gore|8|3d8+6</attack>
 		</action>
 		<action>
 			<name>Stomp</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 21 (3d10 + 5) bludgeoning damage.</text>
-			<attack>Stomp|8|3d10+5</attack>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage.</text>
+			<attack>Stomp|8|3d10+6</attack>
 		</action>
 	</monster>
 	<monster>
@@ -2034,8 +2034,8 @@
 		<cr>1/8</cr>
 		<action>
 			<name>Bite</name>
-			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
-			<attack>Bite|3|1d4+1</attack>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
+			<attack>Bite|4|1d4+2</attack>
 		</action>
 	</monster>
 	<monster>
@@ -3606,8 +3606,8 @@
 		<cr>1/4</cr>
 		<action>
 			<name>Hooves</name>
-			<text>Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage.</text>
-			<attack>Hooves|2|2d4+3</attack>
+			<text>Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage.</text>
+			<attack>Hooves|5|2d4+3</attack>
 		</action>
 	</monster>
 	<monster>
@@ -4255,8 +4255,8 @@
 		</trait>
 		<action>
 			<name>Hooves</name>
-			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.</text>
-			<attack>|4|2d6+4</attack>
+			<text>Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.</text>
+			<attack>|6|2d6+4</attack>
 		</action>
 	</monster>
 	<monster>

--- a/Compendiums/Bestiary Compendium.xml
+++ b/Compendiums/Bestiary Compendium.xml
@@ -1051,7 +1051,7 @@
 		<int>9</int>
 		<wis>10</wis>
 		<cha>10</cha>
-		<resist>lightning, thunder, bludgeoning, piercing, and slashing from nonmagical weapons</resist>
+		<resist>lightning, thunder; bludgeoning, piercing, and slashing from nonmagical weapons</resist>
 		<immune>poison</immune>
 		<conditionImmune>paralyzed, petrified, poisoned, prone</conditionImmune>
 		<senses>darkvision 60 ft.</senses>
@@ -7914,13 +7914,13 @@
 		</trait>
 		<action>
 			<name>Gore</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 18 (3d8 + 5) piercing damage.</text>
-			<attack>Gore|8|3d8+5</attack>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) piercing damage.</text>
+			<attack>Gore|8|3d8+6</attack>
 		</action>
 		<action>
 			<name>Stomp</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 21 (3d10 + 5) bludgeoning damage.</text>
-			<attack>Stomp|8|3d10+5</attack>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage.</text>
+			<attack>Stomp|8|3d10+6</attack>
 		</action>
 	</monster>
 	<monster>
@@ -10621,8 +10621,8 @@
 		<cr>1/8</cr>
 		<action>
 			<name>Bite</name>
-			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
-			<attack>Bite|3|1d4+1</attack>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
+			<attack>Bite|4|1d4+2</attack>
 		</action>
 	</monster>
 	<monster>

--- a/Compendiums/Bestiary Compendium.xml
+++ b/Compendiums/Bestiary Compendium.xml
@@ -10621,7 +10621,7 @@
 		<cr>1/8</cr>
 		<action>
 			<name>Bite</name>
-			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
 			<attack>Bite|4|1d4+2</attack>
 		</action>
 	</monster>

--- a/Compendiums/Full Compendium.xml
+++ b/Compendiums/Full Compendium.xml
@@ -30861,7 +30861,7 @@
 		<school>I</school>
 		<time>1 action</time>
 		<range>30 feet</range>
-		<components>S, M</components>
+		<components>S, M (a bit of fleece)</components>
 		<duration>1 minute</duration>
 		<classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
 		<text>You create a sound or an image of an object within range that lasts for the duration. The illusion also ends if you dismiss it as an action or cast this spell again.</text>
@@ -34385,7 +34385,7 @@
 		<int>9</int>
 		<wis>10</wis>
 		<cha>10</cha>
-		<resist>lightning, thunder, bludgeoning, piercing, and slashing from nonmagical weapons</resist>
+		<resist>lightning, thunder; bludgeoning, piercing, and slashing from nonmagical weapons</resist>
 		<immune>poison</immune>
 		<conditionImmune>paralyzed, petrified, poisoned, prone</conditionImmune>
 		<senses>darkvision 60 ft.</senses>
@@ -41248,13 +41248,13 @@
 		</trait>
 		<action>
 			<name>Gore</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 18 (3d8 + 5) piercing damage.</text>
-			<attack>Gore|8|3d8+5</attack>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) piercing damage.</text>
+			<attack>Gore|8|3d8+6</attack>
 		</action>
 		<action>
 			<name>Stomp</name>
-			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 21 (3d10 + 5) bludgeoning damage.</text>
-			<attack>Stomp|8|3d10+5</attack>
+			<text>Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage.</text>
+			<attack>Stomp|8|3d10+6</attack>
 		</action>
 	</monster>
 	<monster>
@@ -43955,8 +43955,8 @@
 		<cr>1/8</cr>
 		<action>
 			<name>Bite</name>
-			<text>Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
-			<attack>Bite|3|1d4+1</attack>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
+			<attack>Bite|4|1d4+2</attack>
 		</action>
 	</monster>
 	<monster>

--- a/Compendiums/Full Compendium.xml
+++ b/Compendiums/Full Compendium.xml
@@ -43955,7 +43955,7 @@
 		<cr>1/8</cr>
 		<action>
 			<name>Bite</name>
-			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
+			<text>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.</text>
 			<attack>Bite|4|1d4+2</attack>
 		</action>
 	</monster>

--- a/Compendiums/Spells Compendium.xml
+++ b/Compendiums/Spells Compendium.xml
@@ -4154,7 +4154,7 @@
 		<school>I</school>
 		<time>1 action</time>
 		<range>30 feet</range>
-		<components>S, M</components>
+		<components>S, M (a bit of fleece)</components>
 		<duration>1 minute</duration>
 		<classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
 		<text>You create a sound or an image of an object within range that lasts for the duration. The illusion also ends if you dismiss it as an action or cast this spell again.</text>

--- a/Spells/PHB Spells.xml
+++ b/Spells/PHB Spells.xml
@@ -3641,7 +3641,7 @@
 		<school>I</school>
 		<time>1 action</time>
 		<range>30 feet</range>
-		<components>S, M</components>
+		<components>S, M (a bit of fleece)</components>
 		<duration>1 minute</duration>
 		<classes>Bard, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</classes>
 		<text>You create a sound or an image of an object within range that lasts for the duration. The illusion also ends if you dismiss it as an action or cast this spell again.</text>


### PR DESCRIPTION
Per PHB errata, player bestiary stats should be based off of their MM entries if there is any discrepancy.  With the MM Errata changing a couple of the beasts, I made the changes to reflect them in the players bestiary.  They were the Elephant, WarHorse, Riding Horse, and Giant Rat Diseased.
Corrected the average damage for the giant rat diseased in the MM per the errata.
For Minor Illusion, the spell was missing the actual material used in the spell.
