### PR TITLE
Added rarity property to magic items

### DIFF
--- a/Compendiums/Full Compendium.xml
+++ b/Compendiums/Full Compendium.xml
@@ -821,6 +821,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -833,6 +834,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -843,6 +845,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -854,6 +857,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -866,6 +870,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -877,6 +882,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -888,6 +894,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -910,6 +917,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -937,6 +945,7 @@
     <name>Alchemy Jug</name>
     <type>W</type>
     <weight>12</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ceramic jug appears to be able to hold a gallon of liquid and weighs 12 pounds whether full or empty. Sloshing sounds can be heard from within the jug when it is shaken, even if the jug is empty.</text>
     <text>You can use an action and name one liquid from the table below to cause the jug to produce the chosen liquid. Afterward, you can uncork the jug as an action and pour that liquid out, up to 2 gallons per minute. The maximum amount of liquid the jug can produce depends on the liquid you named.</text>
@@ -960,6 +969,7 @@
     <name>Amulet of Health</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -971,6 +981,7 @@
     <name>Amulet of Proof Against Detection and Location</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -982,6 +993,7 @@
     <name>Amulet of the Planes</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -994,6 +1006,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you can speak its command word as a bonus action to cause it to animate. The shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The shield remains animated for 1 minute, until you use a bonus action to end this effect, or until you are incapacitated or die, at which point the shield falls to the ground or into your hand if you have one free.</text>
@@ -1012,6 +1025,7 @@
     <name>Apparatus of Kwalish</name>
     <type>W</type>
     <weight>500</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This item first appears to be a Large sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move either up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.</text>
     <text>The apparatus of Kwalish is a Large object with the following statistics:</text>
@@ -1057,6 +1071,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to nonmagical damage while you wear this armor. Additionally, you can use an action to make yourself immune to nonmagical damage for 10 minutes or until you are no longer wearing the armor. Once this special action is used, it can't be used again until the next dawn.</text>
@@ -1070,6 +1085,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to bludgeoning damage.</text>
@@ -1085,6 +1101,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to piercing damage.</text>
@@ -1100,6 +1117,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to slashing damage.</text>
@@ -1112,6 +1130,7 @@
     <name>Arrow of Slaying</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	An arrow of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both arrows of dragon slaying and arrows of blue dragon slaying. If a creature belonging to the type, race, or group associated with an arrow of slaying takes damage from the arrow, the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once an arrow of slaying deals its extra damage to a creature, it becomes a nonmagical arrow.</text>
@@ -1124,6 +1143,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to AC against ranged attacks while you wield this shield. This bonus is in addition to the shield's normal bonus to AC. In addition, whenever an attacker makes a ranged attack against a target within 5 feet of you, you can use your reaction to become the target of the attack instead.</text>
@@ -1152,6 +1172,7 @@
     <name>Arrows +1</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1163,6 +1184,7 @@
     <name>Arrows +2</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1174,6 +1196,7 @@
     <name>Arrows +3</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1200,6 +1223,7 @@
     <dmgType>S</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -1238,6 +1262,7 @@
     <name>Bag of Beans</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Inside this heavy cloth bag are 3d4 dry beans. The bag weighs 1/2 pound plus 1/4 pound for each bean it contains.</text>
     <text>If you dump the bag's contents out on the ground, they explode in a 10-foot radius, extending from the beans. Each creature in the area, including you, must make a DC 15 Dexterity saving throw, taking 5d4 fire damage on a failed save, or half as much damage on a successful one. The fire ignites flammable objects in the area that aren't being worn or carried.</text>
@@ -1265,6 +1290,7 @@
     <name>Bag of Devouring</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This bag superficially resembles a bag of holding but is a feeding orifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.</text>
     <text>The extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can use its action to try to escape with a successful DC 15 Strength check. Another creature can use its action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength check (provided it isn't pulled inside the bag first). Any creature that starts its turn inside the bag is devoured, its body destroyed.</text>
@@ -1277,6 +1303,7 @@
     <name>Bag of Holding</name>
     <type>W</type>
     <weight>15</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This bag has an interior space considerably larger than its outside dimensions, roughly 2 feet in diameter at the mouth and 4 feet deep. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 15 pounds, regardless of its contents. Retrieving an item from the bag requires an action.</text>
     <text>If the bag is overloaded, pierced, or torn, it ruptures and is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth, unharmed, but the bag must be put right before it can be used again. Breathing creatures inside the bag can survive up to a number of minutes equal to 10 divided by the number of creatures (minimum 1 minute), after which time they begin to suffocate.</text>
@@ -1288,6 +1315,7 @@
     <name>Bag of Tricks, Gray</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from gray cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics. The creature vanishes at the next dawn or when it is reduced to 0 hit points.</text>
@@ -1311,6 +1339,7 @@
     <name>Bag of Tricks, Rust</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from rust cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics.</text>
@@ -1335,6 +1364,7 @@
     <name>Bag of Tricks, Tan</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from tan cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics.</text>
@@ -1389,6 +1419,7 @@
         <name>Banner of the Krig Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>Crafted from a thick, red fabric, this banner measures 5 feet high and 3 feet wide. The krig (war) rune is displayed on the fabric with round, metal plates sewn into it. It can be attached to a 10-foot pole to serve as a standard. Furling or unfurling the banner requires an action. The banner has the following properties.</text>
@@ -1447,6 +1478,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1464,6 +1496,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1481,6 +1514,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1498,6 +1532,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1510,6 +1545,7 @@
     <name>Bead of Force</name>
     <type>W</type>
     <weight>0.0625</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 beads of force are found together.</text>
     <text>You can use an action to throw the bead up to 60 feet. The bead explodes on impact and is destroyed. Each creature within a 10-foot radius of where the bead landed must succeed on a DC 15 Dexterity saving throw or take 5d4 force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save, or are partially within the area, are pushed away from the center of the sphere until they are no longer inside it. Only breathable air can pass through the sphere's wall. No attack or other effect can.</text>
@@ -1534,6 +1570,7 @@
 	<item>
     <name>Belt of Cloud Giant Strength</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -1544,6 +1581,7 @@
   <item>
     <name>Belt of Dwarvenkind</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1562,6 +1600,7 @@
   <item>
     <name>Belt of Fire Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1572,6 +1611,7 @@
   <item>
     <name>Belt of Frost Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1582,6 +1622,7 @@
   <item>
     <name>Belt of Hill Giant Strength</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1592,6 +1633,7 @@
   <item>
     <name>Belt of Stone Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1602,6 +1644,7 @@
   <item>
     <name>Belt of Storm Giant Strength</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -1617,6 +1660,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -1637,6 +1681,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -1660,6 +1705,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -1706,6 +1752,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.</text>
@@ -1721,6 +1768,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a creature of non-lawful alignment</text>
     <text />
@@ -1763,6 +1811,7 @@
         <name>Blod Stone</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This diamond contains the blood of a creature—b1ood that appears in the form of the blod (blood) rune. While the item is on your person, you can use your action to divine the location of the creature nearest to you that is related to the blood in the item and that isn’t undead. You sense the distance and direction of the creature relative to your location. The creature is either the one whose blood is in the item or a blood relative.</text>
@@ -1813,6 +1862,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1835,6 +1885,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1857,6 +1908,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1875,6 +1927,7 @@
     <name>Blowgun Needle of Slaying</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A blowgun needle of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both needles of dragon slaying and needles of blue dragon slaying. If a creature belonging to the type, race, or group associated with a needle of slaying takes damage from the needle the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a needle of slaying deals its extra damage to a creature, it becomes a nonmagical blowgun needle.</text>
@@ -1904,6 +1957,7 @@
     <name>Blowgun Needles +1</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1915,6 +1969,7 @@
     <name>Blowgun Needles +2</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1926,6 +1981,7 @@
     <name>Blowgun Needles +3</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1941,6 +1997,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1983,6 +2040,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.</text>
@@ -2004,6 +2062,7 @@
     <name>Book of Exalted Deeds</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement by a creature of good alignment</text>
     <text />
@@ -2026,6 +2085,7 @@
     <name>Book of Vile Darkness</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -2056,6 +2116,7 @@
   <item>
     <name>Boots of Elvenkind</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have advantage on Dexterity (Stealth) checks that rely on moving silently.</text>
     <text />
@@ -2064,6 +2125,7 @@
   <item>
     <name>Boots of Levitation</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2074,6 +2136,7 @@
   <item>
     <name>Boots of Speed</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2085,6 +2148,7 @@
   <item>
     <name>Boots of Striding and Springing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2095,6 +2159,7 @@
   <item>
     <name>Boots of the Winterlands</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2118,6 +2183,7 @@
     <name>Bowl of Commanding Water Elementals</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While this bowl is filled with water, you can use an action to speak the bowl's command word and summon a water elemental, as if you had cast the conjure elemental spell. The bowl can't be used this way again until the next dawn.</text>
     <text>The bowl is about 1 foot in diameter and half as deep. It weighs 3 pounds and holds about 3 gallons.</text>
@@ -2127,6 +2193,7 @@
   <item>
     <name>Bracers of Archery</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2137,6 +2204,7 @@
   <item>
     <name>Bracers of Defense</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2151,6 +2219,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -2163,6 +2232,7 @@
     <name>Brazier of Commanding Fire Elementals</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While a fire burns in this brass brazier, you can use an action to speak the brazier's command word and summon a fire elemental, as if you had cast the conjure elemental spell. The brazier can't be used this way again until the next dawn.</text>
     <text>The brazier weighs 5 pounds.</text>
@@ -2184,6 +2254,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -2195,6 +2266,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -2206,6 +2278,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -2217,6 +2290,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2228,6 +2302,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2239,6 +2314,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2250,6 +2326,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2261,6 +2338,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2272,6 +2350,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2283,6 +2362,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2294,6 +2374,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2305,6 +2386,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2316,6 +2398,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2337,6 +2420,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.</text>
@@ -2348,6 +2432,7 @@
   <item>
     <name>Brooch of Shielding</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2359,6 +2444,7 @@
     <name>Broom of Flying</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wooden broom, which weighs 3 pounds, functions like a mundane broom until you stand astride it and speak its command word. It then hovers beneath you and can be ridden in the air. It has a flying speed of 50 feet. It can carry up to 400 pounds, but its flying speed becomes 30 feet while carrying over 200 pounds. The broom stops hovering when you land.</text>
     <text>You can send the broom to travel alone to a destination within 1 mile of you if you speak the command word, name the location, and are familiar with that place. The broom comes back to you when you speak another command word, provided that the broom is still within 1 mile of you.</text>
@@ -2469,6 +2555,7 @@
 	<item>
     <name>Candle of Invocation</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2494,6 +2581,7 @@
   <item>
     <name>Cap of Water Breathing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cap underwater, you can speak its command word as an action to create a bubble of air around your head. It allows you to breathe normally underwater. This bubble stays with you until you speak the command word again, the cap is removed, or you are no longer underwater.</text>
     <text />
@@ -2502,6 +2590,7 @@
   <item>
     <name>Cape of the Mountebank</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This cape smells faintly of brimstone. While wearing it, you can use it to cast the dimension door spell as an action. This property of the cape can't be used again until the next dawn.</text>
     <text>When you disappear, you leave behind a cloud of smoke, and you appear in a similar cloud of smoke at your destination. The smoke lightly obscures the space you left and the space you appear in, and it dissipates at the end of your next turn. A light or stronger wind disperses the smoke.</text>
@@ -2520,6 +2609,7 @@
 	<item>
     <name>Carpet of Flying, 3 ft. x 5 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 3 ft. x 5 ft. carpet can carry up to 200 lb. at a fly speed of 80 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2529,6 +2619,7 @@
   <item>
     <name>Carpet of Flying, 4 ft. x 6 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 4 ft. x 6 ft. carpet can carry up to 400 lb. at a fly speed of 60 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2538,6 +2629,7 @@
   <item>
     <name>Carpet of Flying, 5 ft. x 7 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 5 ft. x 7 ft. carpet can carry up to 600 lb. at a fly speed of 40 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2547,6 +2639,7 @@
   <item>
     <name>Carpet of Flying, 6 ft. x 9 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 6 ft. x 9 ft. carpet can carry up to 800 lb. at a fly speed of 30 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2575,6 +2668,7 @@
     <name>Censer of Controlling Air Elementals</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While incense is burning in this censer, you can use an action to speak the censer's command word and summon an air elemental, as if you had cast the conjure elemental spell. The censer can't be used this way again until the next dawn.</text>
     <text>This 6-inch-wide, 1-foot-high vessel resembles a chalice with a decorated lid. It weighs 1 pound.</text>
@@ -2609,6 +2703,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -2622,6 +2717,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -2635,6 +2731,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -2648,6 +2745,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2661,6 +2759,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2674,6 +2773,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2687,6 +2787,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2700,6 +2801,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2713,6 +2815,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2726,6 +2829,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2739,6 +2843,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2752,6 +2857,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2765,6 +2871,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2786,6 +2893,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -2797,6 +2905,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -2808,6 +2917,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -2819,6 +2929,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2830,6 +2941,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2841,6 +2953,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2852,6 +2965,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2863,6 +2977,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2874,6 +2989,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2885,6 +3001,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2896,6 +3013,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2907,6 +3025,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2918,6 +3037,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2943,6 +3063,7 @@
     <name>Chime of Opening</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This hollow metal tube measures about 1 foot long and weighs 1 pound. You can strike it as an action, pointing it at an object within 120 feet of you that can be opened, such as a door, lid, or lock. The chime issues a clear tone, and one lock or latch on the object opens unless the sound can't reach the object. If no locks or latches remain, the object itself opens.</text>
     <text>The chime can be used ten times. After the tenth time it cracks and becomes useless.</text>
@@ -2952,6 +3073,7 @@
   <item>
     <name>Circlet of Blasting</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this circlet, you can use an action to cast the scorching ray spell with it. When you make the spell's attacks, you do so with an attack bonus of +5. The circlet can't be used this way again until the next dawn.</text>
     <text />
@@ -2962,6 +3084,7 @@
         <name>Claw of the Wyrm Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This dragon's claw has been covered with a coat of molten silver, upon which has been inscribed the wyrm (dragon) rune. The claw has the following properties.</text>
@@ -2993,6 +3116,7 @@
 	<item>
     <name>Cloak of Arachnida</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3008,6 +3132,7 @@
   <item>
     <name>Cloak of Displacement</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3018,6 +3143,7 @@
   <item>
     <name>Cloak of Elvenkind</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -3028,6 +3154,7 @@
   <item>
     <name>Cloak of Invisibility</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3038,6 +3165,7 @@
   <item>
     <name>Cloak of Protection</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -3050,6 +3178,7 @@
   <item>
     <name>Cloak of the Bat</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3061,6 +3190,7 @@
   <item>
     <name>Cloak of the Manta Ray</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cloak with its hood up, you can breathe underwater, and you have a swimming speed of 60 feet. Pulling the hood up or down requires an action.</text>
     <text />
@@ -3085,6 +3215,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3101,6 +3232,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3117,6 +3249,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3133,6 +3266,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -3170,6 +3304,7 @@
         <name>Conch of Teleportation</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This item is an ordinary, albeit rather large, conch shell that has been inscribed with the uvar rune. The conch measures 2 1/2 feet long and weighs 20 pounds.</text>
@@ -3211,6 +3346,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.</text>
@@ -3239,6 +3375,7 @@
     <name>Crossbow Bolt of Slaying</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A crossbow bolt of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both bolts of dragon slaying and bolts of blue dragon slaying. If a creature belonging to the type, race, or group associated with a bolt of slaying takes damage from the bolt the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a bolt of slaying deals its extra damage to a creature, it becomes a nonmagical crossbow bolt.</text>
@@ -3268,6 +3405,7 @@
     <name>Crossbow Bolts +1</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3279,6 +3417,7 @@
     <name>Crossbow Bolts +2</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3290,6 +3429,7 @@
     <name>Crossbow Bolts +3</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3319,6 +3459,7 @@
     <name>Crystal Ball</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3330,6 +3471,7 @@
     <name>Crystal Ball of Mind Reading</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3342,6 +3484,7 @@
     <name>Crystal Ball of Telepathy</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3354,6 +3497,7 @@
     <name>Crystal Ball of True Seeing</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3365,6 +3509,7 @@
   <item>
     <name>Cube of Force</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3395,6 +3540,7 @@
   <item>
     <name>Cubic Gate</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the DM.</text>
     <text>You can use an action to press one side of the cube to cast the gate spell with it, opening a portal to the plane keyed to that side. Alternatively, if you use an action to press one side twice, you can cast the plane shift spell (save DC 17) with the cube and transport the targets to the plane keyed to that side.</text>
@@ -3406,6 +3552,7 @@
   <item>
     <name>Daern's Instant Fortress</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place this 1-inch metal cube on the ground and speak its command word. The cube rapidly grows into a fortress that remains until you use an action to speak the command word that dismisses it, which works only if the fortress is empty.</text>
     <text>The fortress is a square tower, 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors. with a ladder running along one wall to connect them. The ladder ends at a trapdoor leading to the roof. When activated, the tower has a small door on the side facing you. The door opens only at your command, which you can speak as a bonus action. It is immune to the knock spell and similar magic, such as that of a chime of opening.</text>
@@ -3442,6 +3589,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3465,6 +3613,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3488,6 +3637,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3511,6 +3661,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>You can use an action to cause thick, black poison to coat the blade. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 poison damage and become poisoned for 1 minute. The dagger can't be used this way again until the next dawn.</text>
@@ -3536,6 +3687,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -3557,6 +3709,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3577,6 +3730,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3594,6 +3748,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3611,6 +3766,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3630,6 +3786,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3667,6 +3824,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3688,6 +3846,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3709,6 +3868,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3730,6 +3890,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -3777,6 +3938,7 @@
     <name>Decanter of Endless Water</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This stoppered flask sloshes when shaken, as if it contains water. The decanter weighs 2 pounds.</text>
     <text>You can use an action to remove the stopper and speak one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following options:</text>
@@ -3790,6 +3952,7 @@
   <item>
     <name>Deck of Illusions</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This box contains a set of parchment cards. A full deck has 34 cards. A deck found as treasure is usually missing 1d20 - 1 cards.</text>
     <text>The magic of the deck functions only if cards are drawn at random (you can use an altered deck of playing cards to simulate the deck). You can use an action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of you.</text>
@@ -3836,6 +3999,7 @@
   <item>
     <name>Deck of Many Things</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have only thirteen cards, but the rest have twenty-two.</text>
     <text>Before you draw a card, you must declare how many cards you intend to draw and then draw them randomly (you can use an altered deck of playing cards to simulate the deck). Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.</text>
@@ -3898,6 +4062,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3919,6 +4084,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3937,6 +4103,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3955,6 +4122,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3975,6 +4143,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3995,6 +4164,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you gain a +1 bonus to AC, and you can understand and speak Abyssal. In addition, the armor's clawed gauntlets turn unarmed strikes with your hands into magic weapons that deal slashing damage, with a +1 bonus to attack rolls and damage rolls and a damage die of 1d8.</text>
@@ -4061,6 +4231,7 @@
 	<item>
     <name>Dimensional Shackles</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place these shackles on an incapacitated creature. The shackles adjust to fit a creature of Small to Large size. In addition to serving as mundane manacles, the shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing-through an interdimensional portal.</text>
     <text>You and any creature you designate when you use the shackles can use an action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength Athletics) check. On a success, the creature breaks free and destroys the shackles.</text>
@@ -4127,6 +4298,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4148,6 +4320,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4166,6 +4339,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4184,6 +4358,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4204,6 +4379,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4255,6 +4431,7 @@
     <name>Driftglobe</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small sphere of thick glass weighs 1 pound. If you are within 60 feet of it, you can speak its command word and cause it to emanate the light or daylight spell. Once used, the daylight effect can't be used again until the next dawn.</text>
     <text>You can speak another command word as an action to make the illuminated globe rise into the air and float no more than 5 feet off the ground. The globe hovers in this way until you or another creature grasps it. If you move more than 60 feet from the hovering globe, it follows you until it is within 60 feet of you. It takes the shortest route to do so. If prevented from moving, the globe sinks gently to the ground and becomes inactive, and its light winks out.</text>
@@ -4357,6 +4534,7 @@
 	<item>
     <name>Dust of Disappearance</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small packet, this powder resembles very fine sand. There is enough of it for one use. When you use an action to throw the dust into the air, you and each creature and object within 10 feet of you become invisible for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. If a creature affected by the dust attacks or casts a spell, the invisibility ends for that creature.</text>
     <text />
@@ -4365,6 +4543,7 @@
   <item>
     <name>Dust of Dryness</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small packet contains 1d6 + 4 pinches of dust. You can use an action to sprinkle a pinch of it over water. The dust turns a cube of water 15 feet on a side into one marble-sized pellet, which floats or rests near where the dust was sprinkled. The pellet's weight is negligible.</text>
     <text>Someone can use an action to smash the pellet against a hard surface, causing the pellet to shatter and release the water the dust absorbed. Doing so ends that pellet's magic.</text>
@@ -4376,6 +4555,7 @@
   <item>
     <name>Dust of Sneezing and Choking</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small container, this powder resembles very fine sand. It appears to be dust of disappearance, and an identify spell reveals it to be such. There is enough of it for one use.</text>
     <text>When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The lesser restoration spell can also end the effect on a creature.</text>
@@ -4389,6 +4569,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	While wearing this armor, you gain a +2 bonus to AC. In addition, if an effect moves you against your will along the ground, you can use your reaction to reduce the distance you are moved by up to 10 feet.</text>
     <text />
@@ -4404,6 +4585,7 @@
     <dmgType>B</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Dwarf</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. It has the thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 damage or, if the target is a giant, 2d8 damage. Immediately after the attack, the weapon flies back to your hand.</text>
@@ -4424,6 +4606,7 @@
     <name>Efreeti Bottle</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This painted brass bottle weighs 1 pound. When you use an action to remove the stopper, a cloud of thick smoke flows out of the bottle. At the end of your turn, the smoke disappears with a flash of harmless fire, and an efreeti appears in an unoccupied space within 30 feet of you. See the Monster Manual for the efreeti's statistics.</text>
     <text>The first time the bottle is opened, the DM rolls to determine what happens.</text>
@@ -4442,6 +4625,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you gain a +3 bonus to AC, you are immune to fire damage, and you can understand and speak Primordial. In addition, you can stand on and walk across molten rock as if it were solid ground.</text>
@@ -4471,6 +4655,7 @@
 	<item>
     <name>Elemental Gem, Blue Sapphire</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, an air elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
@@ -4501,6 +4686,7 @@
     <name>Elixir of Health</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, it cures any disease afflicting you, and it removes the blinded, deafened, paralyzed, and poisoned conditions. The clear red liquid has tiny bubbles of light in it.</text>
     <text />
@@ -4511,6 +4697,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to AC while you wear this armor. You are considered proficient with this armor even if you lack proficiency with medium armor.</text>
     <text />
@@ -4553,6 +4740,7 @@
     <name>Eversmoking Bottle</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Smoke leaks from the lead-stoppered mouth of this brass bottle, which weighs 1 pound. When you use an action to remove the stopper, a cloud of thick smoke pours out in a 60-foot radius from the bottle. The cloud's area is heavily obscured. Each minute the bottle remains open and within the cloud, the radius increases by 10 feet until it reaches its maximum radius of 120 feet.</text>
     <text>The cloud persists as long as the bottle is open. Closing the bottle requires you to speak its command word as an action. Once the bottle is closed, the cloud disperses after 10 minutes. A moderate wind (11 to 20 miles per hour) can also disperse the smoke after 1 minute, and a strong wind (21 or more miles per hour) can do so after 1 round.</text>
@@ -4587,6 +4775,7 @@
 	<item>
     <name>Eye of Vecna</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -4618,6 +4807,7 @@
   <item>
     <name>Eyes of Charming</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -4628,6 +4818,7 @@
   <item>
     <name>Eyes of Minute Seeing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These crystal lenses fit over the eyes. While wearing them, you can see much better than normal out to a range of 1 foot. You have advantage on Intelligence (Investigation) checks that rely on sight while searching an area or studying an object within that range.</text>
     <text />
@@ -4636,6 +4827,7 @@
   <item>
     <name>Eyes of the Eagle</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -4646,6 +4838,7 @@
   <item>
     <name>Figurine of Wondrous Power, Bronze Griffon</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics.</text>
@@ -4659,6 +4852,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ebony Fly</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4672,6 +4866,7 @@
   <item>
     <name>Figurine of Wondrous Power, Golden Lions</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics.</text>
@@ -4685,6 +4880,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ivory Goats</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4701,6 +4897,7 @@
   <item>
     <name>Figurine of Wondrous Power, Marble Elephant</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4714,6 +4911,7 @@
   <item>
     <name>Figurine of Wondrous Power, Obsidian Steed</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4728,6 +4926,7 @@
   <item>
     <name>Figurine of Wondrous Power, Onyx Dog</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4741,6 +4940,7 @@
   <item>
     <name>Figurine of Wondrous Power, Serpentine Owl</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4754,6 +4954,7 @@
   <item>
     <name>Figurine of Wondrous Power, Silver Raven</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4795,6 +4996,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4808,6 +5010,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4821,6 +5024,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4834,6 +5038,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -4847,6 +5052,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4866,6 +5072,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4882,6 +5089,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4898,6 +5106,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4916,6 +5125,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4953,6 +5163,7 @@
     <name>Folding Boat</name>
     <type>W</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep. It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring you to use an action to speak it.</text>
     <text>One command word causes the box to unfold into a boat 10 feet long, 4 feet wide, and 2 feet deep. The boat has one pair of oars, an anchor, a mast, and a lateen sail. The boat can hold up to four Medium creatures comfortably.</text>
@@ -4978,6 +5189,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -4999,6 +5211,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5017,6 +5230,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5035,6 +5249,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5055,6 +5270,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5071,6 +5287,7 @@
   <item>
     <name>Gauntlets of Ogre Power</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -5082,6 +5299,7 @@
         <name>Gavel of the Venn Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This wooden gavel is small by giant reckoning but nearly the size of a warhammcr in human hands. The venn (friend) rune is inscribed in mithral in the base of the haft. Among giants, this item is used as part of rituals to resolve disputes. The gavel has the following properties.</text>
@@ -5096,6 +5314,7 @@
     <name>Gem of Brightness</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This prism has 50 charges. While you are holding it, you can use an action to speak one of three command words to cause one of the following effects:</text>
     <text>• The first command word causes the gem to shed bright light in a 30-foot radius and dim light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you use a bonus action to repeat the command word or until you use another function of the gem.</text>
@@ -5109,6 +5328,7 @@
     <name>Gem of Seeing</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -5126,6 +5346,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5144,6 +5365,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5164,6 +5386,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5185,6 +5408,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5208,6 +5432,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5226,6 +5451,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5244,6 +5470,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5264,6 +5491,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5298,6 +5526,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5318,6 +5547,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5338,6 +5568,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5358,6 +5589,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5375,6 +5607,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	While wearing this armor, you gain a +1 bonus to AC. You can also use a bonus action to speak the armor's command word and cause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like, including color, style, and accessories, but the armor retains its normal bulk and weight. The illusory appearance last until you use this property again or remove the armor.</text>
     <text />
@@ -5402,6 +5635,7 @@
 	<item>
     <name>Gloves of Missile Snaring</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -5413,6 +5647,7 @@
   <item>
     <name>Gloves of Swimming and Climbing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -5423,6 +5658,7 @@
   <item>
     <name>Gloves of Thievery</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These gloves are invisible while worn. While wearing them, you gain a +5 bonus to Dexterity (Sleight of Hand) checks and Dexterity checks made to pick locks.</text>
     <text />
@@ -5431,6 +5667,7 @@
   <item>
     <name>Goggles of Night</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing these dark lenses, you have darkvision out to a range of 60 feet. If you already have darkvision. wearing the goggles increases its range by 60 feet.</text>
     <text />
@@ -5461,6 +5698,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -5497,6 +5735,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5515,6 +5754,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5533,6 +5773,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5551,6 +5792,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5580,6 +5822,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5596,6 +5839,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5612,6 +5856,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5628,6 +5873,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5657,6 +5903,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5675,6 +5922,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5693,6 +5941,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5711,6 +5960,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -5728,6 +5978,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -5747,6 +5998,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -5770,6 +6022,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5787,6 +6040,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -5828,6 +6082,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to poison damage.</text>
@@ -5864,6 +6119,7 @@
         <dmgType>S</dmgType>
         <property>H,2H</property>
         <text>This item requires attunement</text>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text>In the Year of the Icy Axe (123 DR), the frost giant lord Gurt fell to Uthgar Gardolfsson—leader of the folk who would become the Uthgardt barbarians—in a battle that marked the ascendance of humankind over the giants in the Dessarin Valley. Gurt’s greataxe was buried in Morgur’s Mound until it was unearthed and brought back to Waterdeep. After laying in the city’s vaults for decades, the axe was given to Harshnag, a frost giant adventurer, in recognition of his service to Waterdeep. Uthgardt barbarians recognize the weapon on sight and attack any giant that wields it.</text>
         <text>You gain a +1 bonus to attack and damage rolls made with this magic weapon. It is sized for a giant, weighs 325 pounds, and deals 3dl2 slashing damage on a hit, plus an extra 2d12 slashing damage if the target is human.</text>
@@ -5895,6 +6151,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5915,6 +6172,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5935,6 +6193,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5955,6 +6214,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5984,6 +6244,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -5996,6 +6257,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -6008,6 +6270,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -6020,6 +6283,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -6032,6 +6296,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -6044,6 +6309,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -6056,6 +6322,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -6068,6 +6335,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -6080,6 +6348,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -6092,6 +6361,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -6104,6 +6374,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -6116,6 +6387,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -6128,6 +6400,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -6149,6 +6422,7 @@
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text />
@@ -6194,6 +6468,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6218,6 +6493,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6242,6 +6518,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6266,6 +6543,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -6284,6 +6562,7 @@
   <item>
     <name>Hand of Vecna</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -6337,6 +6616,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6358,6 +6638,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6379,6 +6660,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6400,6 +6682,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -6415,6 +6698,7 @@
   <item>
     <name>Hat of Disguise</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -6453,6 +6737,7 @@
   <item>
     <name>Headband of Intellect</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -6500,6 +6785,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6526,6 +6812,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6552,6 +6839,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6578,6 +6866,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -6598,6 +6887,7 @@
   <item>
     <name>Helm of Brilliance</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -6615,6 +6905,7 @@
   <item>
     <name>Helm of Comprehending Languages</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this helm, you can use an action to cast the comprehend languages spell from it at will.</text>
     <text />
@@ -6623,6 +6914,7 @@
   <item>
     <name>Helm of Telepathy</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -6634,6 +6926,7 @@
   <item>
     <name>Helm of Teleportation</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -6664,6 +6957,7 @@
     <name>Heward's Handy Haversack</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 20 pounds of material, not exceeding a volume of 2 cubic feet. The large central pouch can hold up to 8 cubic feet or 80 pounds of material. The backpack always weighs 5 pounds, regardless of its contents.</text>
     <text>Placing an object in the haversack follows the normal rules for interacting with objects. Retrieving an item from the haversack requires you to use an action. When you reach into the haversack for a specific item, the item is always magically on top.</text>
@@ -6687,6 +6981,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -6698,6 +6993,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -6709,6 +7005,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -6720,6 +7017,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -6731,6 +7029,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -6742,6 +7041,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -6753,6 +7053,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -6764,6 +7065,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -6775,6 +7077,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -6786,6 +7089,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -6797,6 +7101,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -6808,6 +7113,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -6819,6 +7125,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -6832,6 +7139,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6854,6 +7162,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6873,6 +7182,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6892,6 +7202,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6913,6 +7224,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -7012,6 +7324,7 @@
     <name>Horn of Blasting</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to speak the horn's command word and then blow the horn, which emits a thunderous blast in a 30-foot cone that is audible 600 feet away. Each creature in the cone must make a DC 15 Constitution saving throw. On a failed save, a creature takes 5d6 thunder damage and is deafened for 1 minute. On a successful save, a creature takes half as much damage and isn't deafened. Creatures and objects made of glass or crystal have disadvantage on the saving throw and take 10d6 thunder damage instead of 5d6.</text>
     <text>Each use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 fire damage to the blower and destroys the horn.</text>
@@ -7023,6 +7336,7 @@
     <name>Horn of Valhalla, Brass</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>A brass horn summons 3d4 + 3 berserkers.  To use the brass horn, you must be proficient with all simple weapons.</text>
@@ -7035,6 +7349,7 @@
     <name>Horn of Valhalla, Bronze</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>A bronze horn summons 4d4 + 4 berserkers.  To use the bronze horn, you must be proficient with medium armor.</text>
@@ -7047,6 +7362,7 @@
     <name>Horn of Valhalla, Iron</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>The iron horn summons 5d4 + 5 berserkers.  To use the iron horn, you must be proficient with all martial weapons.</text>
@@ -7059,6 +7375,7 @@
     <name>Horn of Valhalla, Silver</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>The silver horn summons 2d4 + 2 berserkers.</text>
@@ -7070,6 +7387,7 @@
   <item>
     <name>Horseshoes of Speed</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they increase the creature's walking speed by 30 feet.</text>
     <text />
@@ -7078,6 +7396,7 @@
   <item>
     <name>Horseshoes of a Zephyr</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above the ground. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores difficult terrain. In addition, the creature can move at normal speed for up to 12 hours a day without suffering exhaustion from a forced march.</text>
     <text />
@@ -7122,6 +7441,7 @@
     <name>Immovable Rod</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This flat iron rod has a button on one end. You can use an action to press the button, which causes the rod to become magically fixed in place. Until you or another creature uses an action to push the button again, the rod doesn't move, even if it is defying gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can use an action to make a DC 30 Strength check, moving the fixed rod up to 10 feet on a success</text>
     <text />
@@ -7131,6 +7451,7 @@
         <name>Ingot of the Skold Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This appears to be a simple ingot of iron ore, about a foot long and a few inches across. Inspection of its surface reveals the faint, silvery outline ofthe skold (shield) rune. The ingot has the following properties, which work only while it's on your person.</text>
@@ -7169,6 +7490,7 @@
     <name>Instrument of the Bards, Anstruth Harp</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7184,6 +7506,7 @@
     <name>Instrument of the Bards, Canaith Mandolin</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7199,6 +7522,7 @@
     <name>Instrument of the Bards, Cli Lyre</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7214,6 +7538,7 @@
     <name>Instrument of the Bards, Doss Lute</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7229,6 +7554,7 @@
     <name>Instrument of the Bards, Fochlucan Bandore</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7244,6 +7570,7 @@
     <name>Instrument of the Bards, Mac-Fuirmidh Cittern</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7259,6 +7586,7 @@
     <name>Instrument of the Bards, Ollamh Harp</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7273,6 +7601,7 @@
   <item>
     <name>Ioun Stone, Absorption</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7289,6 +7618,7 @@
   <item>
     <name>Ioun Stone, Agility</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7305,6 +7635,7 @@
   <item>
     <name>Ioun Stone, Awareness</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7320,6 +7651,7 @@
   <item>
     <name>Ioun Stone, Fortitude</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7336,6 +7668,7 @@
   <item>
     <name>Ioun Stone, Greater Absorption</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -7351,6 +7684,7 @@
   <item>
     <name>Ioun Stone, Insight</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7367,6 +7701,7 @@
   <item>
     <name>Ioun Stone, Intellect</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7383,6 +7718,7 @@
   <item>
     <name>Ioun Stone, Leadership</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7399,6 +7735,7 @@
   <item>
     <name>Ioun Stone, Mastery</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -7415,6 +7752,7 @@
   <item>
     <name>Ioun Stone, Protection</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7431,6 +7769,7 @@
   <item>
     <name>Ioun Stone, Regeneration</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -7446,6 +7785,7 @@
   <item>
     <name>Ioun Stone, Reserve</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7463,6 +7803,7 @@
   <item>
     <name>Ioun Stone, Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7479,6 +7820,7 @@
   <item>
     <name>Ioun Stone, Sustenance</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7495,6 +7837,7 @@
     <name>Iron Bands of Bilarro</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can use an action to speak the command word and throw the sphere at a Huge or smaller creature you can see within 60 feet of you. As the sphere moves through the air, it opens into a tangle of metal bands.</text>
     <text>Make a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your proficiency bonus. On a hit, the target is restrained until you take a bonus action to speak the command word again to release it. Doing so, or missing with the attack, causes the bands to contract and become a sphere once more.</text>
@@ -7507,6 +7850,7 @@
     <name>Iron Flask</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This iron bottle has a brass stopper. You can use an action to speak the flask's command word, targeting a creature that you can see within 60 feet of you. If the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has advantage on the saving throw. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at a time. A creature trapped in the flask doesn't need to breathe, eat, or drink and doesn't age.</text>
     <text>You can use an action to remove the flask's stopper and release the creature the flask contains. The creature is friendly to you and your companions for 1 hour and obeys your commands for that duration. If you give no commands or give it a command that is likely to result in its death, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.</text>
@@ -7618,6 +7962,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7637,6 +7982,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7656,6 +8002,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7675,6 +8022,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This javelin is a magic weapon. When you hurl it and speak its command word, it transforms into a bolt of lightning, forming a line 5 feet wide that extends out from you to a target within 120 feet. Each creature in the line excluding you and the target must make a DC 13 Dexterity saving throw, taking 4d6 lightning damage on a failed save, and half as much damage on a successful one. The lightning bolt turns back into a javelin when it reaches the target. Make a ranged weapon attack against the target. On a hit, the target takes damage from the javelin plus 4d6 lightning damage.</text>
     <text>The javelin's property can't be used again until the next dawn. In the meantime, the javelin can still be used as a magic weapon.</text>
@@ -7694,6 +8042,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -7725,6 +8074,7 @@
 	<item>
     <name>Keoghtom's Ointment</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This glass jar, 3 inches in diameter, contains 1d4 + 1 doses of a thick mixture that smells faintly of aloe. The jar and its contents weigh 1/2 pound.</text>
     <text>As an action, one dose of the ointment can be swallowed or applied to the skin. The creature that receives it regains 2d8 + 2 hit points, ceases to be poisoned, and is cured of any disease.</text>
@@ -7740,6 +8090,7 @@
         <dmgType>B</dmgType>
         <property>L</property>
         <text>This item requires attunement</text>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
         <text>The Korolnor Scepter is one of ten Ruling Scepters of Shanatar, forged by the dwarven gods and given to the ruling houses of the ancient dwarven empire. The Korolnor Scepter’s location was unknown for the longest time until a storm giant queen, Neri, found it in a barnacle-covered shipwreck at the bottom of the Trackless Sea. The Ruling Scepters are all roughly the same size and shape, but their materials and properties vary.</text>
@@ -7792,6 +8143,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7808,6 +8160,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7824,6 +8177,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7840,6 +8194,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -7852,6 +8207,7 @@
     <name>Lantern of Revealing</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's bright light. You can use an action to lower the hood, reducing the light to dim light in a 5-foot radius.</text>
     <text />
@@ -7872,6 +8228,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -7883,6 +8240,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -7894,6 +8252,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -7905,6 +8264,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -7916,6 +8276,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -7927,6 +8288,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -7938,6 +8300,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -7949,6 +8312,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -7960,6 +8324,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -7971,6 +8336,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -7982,6 +8348,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -7993,6 +8360,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -8004,6 +8372,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -8048,6 +8417,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8072,6 +8442,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8096,6 +8467,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8120,6 +8492,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8160,6 +8533,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8181,6 +8555,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8202,6 +8577,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8223,6 +8599,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8273,6 +8650,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8297,6 +8675,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8321,6 +8700,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8345,6 +8725,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8381,6 +8762,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8398,6 +8780,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8415,6 +8798,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8432,6 +8816,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -8448,6 +8833,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -8466,6 +8852,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -8488,6 +8875,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8504,6 +8892,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -8534,6 +8923,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8559,6 +8949,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8581,6 +8972,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8603,6 +8995,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8627,6 +9020,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8685,6 +9079,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8698,6 +9093,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8711,6 +9107,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8724,6 +9121,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit a fiend or an undead with this magic weapon, that creature takes an extra 2d6 radiant damage. If the target has 25 hit points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature becomes frightened of you until the end of your next turn.</text>
@@ -8738,6 +9136,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. The bonus increases to +3 when you use the mace to attack a construct.</text>
     <text>When you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 bludgeoning damage, or an extra 14 bludgeoning damage if it's a construct. If a construct has 25 hit points or fewer after taking this damage, it is destroyed.</text>
@@ -8752,6 +9151,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon has 3 charges. While holding it, you can use an action and expend 1 charge to release a wave of terror. Each creature of your choice in a 30-foot radius extending from you must succeed on a DC 15 Wisdom saving throw or become frightened of you for 1 minute. While it is frightened in this way, a creature must spend its turns trying to move as far away from you as it can, and it can't willingly move to a space within 30 feet of you. It also can't take reactions. For its action it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can use the Dodge action. At the end of each of its turns, a creature can repeat the saving throw, ending the effect on itself on a success.</text>
@@ -8766,6 +9166,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8801,6 +9202,7 @@
 	<item>
     <name>Mantle of Spell Resistance</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8812,6 +9214,7 @@
     <name>Manual of Bodily Health</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains health and diet tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -8821,6 +9224,7 @@
     <name>Manual of Clay Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a clay golem, you must spend 30 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 65,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8831,6 +9235,7 @@
     <name>Manual of Flesh Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a flesh golem, you must spend 60 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 50,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8841,6 +9246,7 @@
     <name>Manual of Gainful Exercise</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strength score increase- by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -8850,6 +9256,7 @@
     <name>Manual of Iron Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create an iron golem, you must spend 120 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 100,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8860,6 +9267,7 @@
     <name>Manual of Quickness of Action</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains coordination and balance exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -8869,6 +9277,7 @@
     <name>Manual of Stone Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a golem, you must spend 90 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 80,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8889,6 +9298,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8901,6 +9311,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8911,6 +9322,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8922,6 +9334,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8932,6 +9345,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8942,6 +9356,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8953,6 +9368,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8965,6 +9381,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8976,6 +9393,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8987,6 +9405,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -9009,6 +9428,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -9019,6 +9439,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -9064,6 +9485,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9082,6 +9504,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9100,6 +9523,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9119,6 +9543,7 @@
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -9133,6 +9558,7 @@
     <name>Medallion of Thoughts</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9180,6 +9606,7 @@
     <name>Mirror of Life Trapping</name>
     <type>W</type>
     <weight>50</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When this 4-foot-tall mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, 10 hit points, and vulnerability to bludgeoning damage. It shatters and is destroyed when reduced to 0 hit points.</text>
     <text>If the mirror is hanging on a vertical surface and you are within 5 feet of it, you can use an action to speak its command word and activate it. It remains activated until you use an action to speak the command word again.</text>
@@ -9196,6 +9623,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9206,6 +9634,7 @@
     <type>HA</type>
     <weight>55</weight>
     <ac>16</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9216,6 +9645,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9226,6 +9656,7 @@
     <type>MA</type>
     <weight>40</weight>
     <ac>15</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9236,6 +9667,7 @@
     <type>HA</type>
     <weight>65</weight>
     <ac>18</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9246,6 +9678,7 @@
     <type>HA</type>
     <weight>40</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9256,6 +9689,7 @@
     <type>MA</type>
     <weight>45</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9275,6 +9709,7 @@
     <type>HA</type>
     <weight>60</weight>
     <ac>17</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9311,6 +9746,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by an elf or half-elf of neutral good alignment</text>
     <text />
@@ -9360,6 +9796,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9373,6 +9810,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9386,6 +9824,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9399,6 +9838,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -9409,6 +9849,7 @@
         <name>Navigation Orb</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>A navigation orb is a hollow, 7-foot-diameter sphere of thin, polished mithral with a large skye (cloud) rune embossed on its outer surface. The orb levitates 10 feet above the ground and is keyed to a particular cloud castle, allowing you to control that castle's altitude and movement while the orb is inside the castle. If the orb is destroyed or removed from its castle, the castle's altitude and location remain ﬁxed until the orb is returned or replaced.</text>
@@ -9433,6 +9874,7 @@
     <name>Necklace of Adaptation</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9444,6 +9886,7 @@
     <name>Necklace of Fireballs</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This necklace has 1d6 + 3 beads hanging from it. You can use an action to detach a bead and throw it up to 6 feet away. When it reaches the end of its trajectory, the bead detonates as a 3rd-level fireball spell (save DC 15).</text>
     <text>You can hurl multiple beads, or even the whole necklace, as one action. When you do so, increase the level of the fireball by 1 for each bead beyond the first.</text>
@@ -9455,6 +9898,7 @@
     <name>Necklace of Prayer Beads</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Cleric, Druid, or Paladin</text>
     <text />
@@ -9493,6 +9937,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -9513,6 +9958,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -9533,6 +9979,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -9553,6 +10000,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -9570,6 +10018,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9591,6 +10040,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9609,6 +10059,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9627,6 +10078,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9647,6 +10099,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9664,6 +10117,7 @@
     <name>Nolzur's Marvelous Pigments</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Typically found in 1d4 pots inside a fine wooden box with a brush (weighing 1 pound in total), these pigments allow you to create three-dimensional objects by painting them in two dimensions. The paint flows from the brush to form the desired object as you concentrate on its image.</text>
     <text>Each pot of paint is sufficient to cover 1,000 square feet of a surface, which lets you create inanimate objects or terrain features-such as a door, a pit, flowers, trees, cells, rooms, or weapons- that are up to 10,000 cubic feet. It takes 10 minutes to cover 100 square feet.</text>
@@ -9681,6 +10135,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you nock an arrow on this bow, it whispers in Elvish, "Swift defeat to my enemies." When you use this weapon to make a ranged attack, you can, as a command phrase, say, "Swift death to you who have wronged me." The target of your attack becomes your sworn enemy until it dies or until dawn seven days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.</text>
@@ -9712,6 +10167,7 @@
     <name>Oil of Etherealness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Beads of this cloudy gray oil form on the outside of its container and quickly evaporate. The oil can cover a Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the etherealness spell for 1 hour.</text>
     <text />
@@ -9721,6 +10177,7 @@
     <name>Oil of Sharpness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This clear, gelatinous oil sparkles with tiny, ultrathin silver shards. The oil can coat one slashing or piercing weapon or up to 5 pieces of slashing or piercing ammunition. Applying the oil takes 1 minute. For 1 hour, the coated item is magical and has a +3 bonus to attack and damage rolls.</text>
     <text />
@@ -9730,6 +10187,7 @@
     <name>Oil of Slipperiness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This sticky black unguent is thick and heavy in the container, but it flows quickly when poured. The oil can cover a Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of a freedom of movement spell for 8 hours.</text>
     <text>Alternatively, the oil can be poured on the ground as an action, where it covers a 10-foot square, duplicating the effect of the grease spell in that area for 8 hours.</text>
@@ -9749,6 +10207,7 @@
         <name>Opal of the Ild Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This triangular ﬁre opal measures about three inches on each side and is half an inch thick. The ild (ﬁre) rune shimmers within its core, causing it to be slightly warm to the touch. The opal has the following properties, which work only while it’s on your person.</text>
@@ -9773,6 +10232,7 @@
 	<item>
     <name>Orb of Dragonkind</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -9796,6 +10256,7 @@
         <name>Orb of the Stein Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This orb of granite is about the size of an adult human’s ﬁst. The stein (stone) rune appears on it in the form ofcrystalline veins that run across the surface. The orb has the following properties, which work only while it's on your person.</text>
@@ -9852,6 +10313,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -9864,6 +10326,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -9876,6 +10339,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -9888,6 +10352,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -9900,6 +10365,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -9912,6 +10378,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -9924,6 +10391,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -9936,6 +10404,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -9948,6 +10417,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -9960,6 +10430,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -9972,6 +10443,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -9984,6 +10456,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -9996,6 +10469,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -10049,6 +10523,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
 	<item>
     <name>Pearl of Power</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -10060,6 +10535,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
         <name>Pennant of the Vind Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This blue pennant is crafted from silk and is ﬁve feet long and whips about as if buffeted by a wind. The vind (wind) rune appears on its surface, looking almost like a cloud. The pennant has the following properties, which work only while it’s on your person.</text>
@@ -10084,6 +10560,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Periapt of Health</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You are immune to contracting any disease while you wear this pendant. If you are already infected with a disease, the effects of the disease are suppressed you while you wear the pendant.</text>
     <text />
@@ -10093,6 +10570,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Periapt of Proof Against Poison</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, poisons have no effect on you. You are immune to the poisoned condition and have immunity to poison damage.</text>
     <text />
@@ -10102,6 +10580,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Periapt of Wound Closure</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10113,6 +10592,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Philter of Love</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>The next time you see a creature within 10 minutes after drinking this philter, you become charmed by that creature for 1 hour. If the creature is of a species and gender you are normally attracted to, you regard it as your true love while you are charmed. This potion's rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart.</text>
     <text />
@@ -10141,6 +10621,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -10161,6 +10642,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -10181,6 +10663,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -10201,6 +10684,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -10217,6 +10701,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Pipes of Haunting</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You must be proficient with wind instruments to use these pipes. They have 3 charges. You can use an action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature within 30 feet of you that hears you play must succeed on a DC 15 Wisdom saving throw or become frightened of you for 1 minute. If you wish, all creatures in the area that aren't hostile toward you automatically succeed on the saving throw. A creature that fails the saving throw can repeat it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its saving throw is immune to the effect of these pipes for 24 hours. The pipes regain 1d3 expended charges daily at dawn.</text>
     <text />
@@ -10227,6 +10712,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Pipes of the Sewers</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10292,6 +10778,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -10305,6 +10792,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -10318,6 +10806,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -10331,6 +10820,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -10344,6 +10834,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -10357,6 +10848,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	While you're wearing this armor, you can speak its command word as an action to gain the effect of the etherealness spell, which last for 10 minutes or until you remove the armor or use an action to speak the command word again. This property of the armor can't be used again until the next dawn.</text>
@@ -10370,6 +10862,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -10383,6 +10876,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -10396,6 +10890,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -10409,6 +10904,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -10422,6 +10918,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -10435,6 +10932,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -10448,6 +10946,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -10461,6 +10960,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -10513,6 +11013,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Portable Hole</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
     <text>You can use an action to unfold a portable hole and place it on or against a solid surface, whereupon the portable hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane, so it can't be used to create open passages. Any creature inside an open portable hole can exit the hole by climbing out of it.</text>
@@ -10535,6 +11036,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Acid Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to acid damage for 1 hour.</text>
     <text />
@@ -10544,6 +11046,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Animal Friendship</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you can cast the animal friendship spell (save DC 13) for 1 hour at will. Agitating this muddy liquid brings little bits into view: a fish scale, a hummingbird tongue, a cat claw, or a squirrel hair.</text>
     <text />
@@ -10553,6 +11056,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Clairvoyance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the clairvoyance spell. An eyeball bobs in this yellowish liquid but vanishes when the potion is opened.</text>
     <text />
@@ -10562,6 +11066,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Climbing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>When you drink this potion, you gain a climbing speed equal to your walking speed for 1 hour. During this time, you have advantage on Strength (Athletics) checks you make to climb. The potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors.</text>
     <text />
@@ -10571,6 +11076,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Cloud Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, your Strength score changes to 27 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a cloud giant.</text>
@@ -10581,6 +11087,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Cold Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to cold damage for 1 hour.</text>
     <text />
@@ -10590,6 +11097,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Diminution</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the "reduce" effect of the enlarge/reduce spell for 1d4 hours (no concentration required). The red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process.</text>
     <text />
@@ -10600,6 +11108,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Fire Breath</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>After drinking this potion, you can use a bonus action to exhale fire at a target within 30 feet of you. The target must make a DC 13 Dexterity saving throw, taking 4d6 fire damage on a failed save, or half as much damage on a successful one. The effect ends after you exhale the fire three times or when 1 hour has passed. This potion's orange liquid flickers, and smoke fills the top of the container and wafts out whenever it is opened.</text>
     <text />
@@ -10610,6 +11119,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Fire Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 25 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a fire giant.</text>
@@ -10620,6 +11130,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Fire Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to fire damage for 1 hour.</text>
     <text />
@@ -10629,6 +11140,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Flying</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, you gain a flying speed equal to your walking speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft. This potion's clear liquid floats at the top of its container and has cloudy white impurities drifting in it.</text>
     <text />
@@ -10638,6 +11150,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Force Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to force damage for 1 hour.</text>
     <text />
@@ -10647,6 +11160,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Frost Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 23 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a frost giant.</text>
@@ -10657,6 +11171,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Gaseous Form</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the gaseous form spell for 1 hour (no concentration required) or until you end the effect as a bonus action. This potion's container seems to hold fog that moves and pours like water.</text>
     <text />
@@ -10665,6 +11180,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
         <name>Potion of Giant Size</name>
         <type>P</type>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
         <text>When you drink this potion, you become Huge for 24 hours if you are Medium or smaller, otherwise the potion does nothing. For that duration, your Strength becomes 25, if it isn't already higher, and your hit point maximum is doubled (your current hit points are doubled when you drink the potion). In addition, the reach of your melee attacks increases by 5 feet.</text>
@@ -10677,6 +11193,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Greater Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You regain 4d4 + 4 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10687,6 +11204,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Growth</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain the "enlarge" effect of the enlarge/reduce spell for 1d4 hours (no concentration required). The red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process.</text>
     <text />
@@ -10697,6 +11215,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>You regain 2d4 + 2 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10707,6 +11226,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Heroism</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>For 1 hour after drinking it, you gain 10 temporary hit points that last for 1 hour. For the same duration, you are under the effect of the bless spell (no concentration required). This blue potion bubbles and steams as if boiling.</text>
     <text />
@@ -10716,6 +11236,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Hill Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, your Strength score changes to 21 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a hill giant.</text>
@@ -10726,6 +11247,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Invisibility</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This potion's container looks empty but feels as though it holds liquid. When you drink it, you become invisible for 1 hour. Anything you wear or carry is invisible with you. The effect ends early if you attack or cast a spell.</text>
     <text />
@@ -10735,6 +11257,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Invulnerability</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>For 1 minute after you drink this potion, you have resistance to all damage. The potion's syrupy liquid looks like liquefied iron.</text>
     <text />
@@ -10744,6 +11267,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Lightning Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to lightning damage for 1 hour.</text>
     <text />
@@ -10753,6 +11277,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Longevity</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, your physical age is reduced by 1d6 + 6 years, to a minimum of 13 years. Each time you subsequently drink a potion of longevity, there is 10 percent cumulative chance that you instead age by 1d6 + 6 years. Suspended in this amber liquid are a scorpion's tail, an adder's fang, a dead spider, and a tiny heart that, against all reason, is still beating. These ingredients vanish when the potion is opened.</text>
     <text />
@@ -10763,6 +11288,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Mind Reading</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the detect thoughts spell (save DC 13). The potion's dense, purple liquid has an ovoid cloud of pink floating in it.</text>
     <text />
@@ -10772,6 +11298,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Necrotic Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to necrotic damage for 1 hour.</text>
     <text />
@@ -10781,6 +11308,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Poison</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This concoction looks, smells, and tastes like a potion of healing or other beneficial potion. However, it is actually poison masked by illusion magic. An identify spell reveals its true nature.</text>
     <text>If you drink it, you take 3d6 poison damage, and you must succeed on a DC 13 Constitution saving throw or be poisoned. At the start of each of your turns while you are poisoned in this way, you take 3d6 poison damage. At the end of each of your turns, you can repeat the saving throw. On a successful save, the poison damage you take on your subsequent turns decreases by 1d6. The poison ends when the damage decreases to 0.</text>
@@ -10794,6 +11322,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Poison Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to poison damage for 1 hour.</text>
     <text />
@@ -10803,6 +11332,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Psychic Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to psychic damage for 1 hour.</text>
     <text />
@@ -10812,6 +11342,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Radiant Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to radiant damage for 1 hour.</text>
     <text />
@@ -10821,6 +11352,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Speed</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, you gain resistance to acid damage for 1 hour.</text>
     <text />
@@ -10830,6 +11362,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Stone Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 23 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a stone giant.</text>
@@ -10840,6 +11373,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Storm Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>When you drink this potion, your Strength score changes to 29 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a storm giant.</text>
@@ -10850,6 +11384,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Superior Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You regain 8d4 + 8 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10860,6 +11395,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Supreme Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You regain 10d4 + 20 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10870,6 +11406,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Thunder Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to thunder damage for 1 hour.</text>
     <text />
@@ -10879,6 +11416,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Vitality</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, it removes any exhaustion you are suffering and cures any disease or poison affecting you. For the next 24 hours, you regain the maximum number of hit points for any Hit Die you spend. The potion's crimson liquid regularly pulses with dull light, calling to mind a heartbeat.</text>
     <text />
@@ -10888,6 +11426,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Water Breathing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You can breathe underwater for 1 hour after drinking this potion. Its cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it.</text>
     <text />
@@ -10953,6 +11492,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Quaal's Feather Token, Anchor</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10963,6 +11503,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Bird</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10973,6 +11514,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Fan</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10983,6 +11525,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Swan Boat</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10993,6 +11536,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Tree</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11003,6 +11547,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Whip</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11034,6 +11579,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11051,6 +11597,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11068,6 +11615,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11085,6 +11633,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -11106,6 +11655,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Quiver of Ehlonna</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to sixty arrows, bolts, or similar objects. The midsize compartment holds up to eighteen javelins or similar objects. The longest compartment holds up to six long objects, such as bows, quarterstaffs, or spears.</text>
     <text>You can draw any item the quiver contains as if doing so from a regular quiver or scabbard.</text>
@@ -11131,6 +11681,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11147,6 +11698,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11163,6 +11715,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11179,6 +11732,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -11194,6 +11748,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -11215,6 +11770,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -11230,6 +11786,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -11278,6 +11835,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -11303,6 +11861,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -11315,6 +11874,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -11327,6 +11887,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -11339,6 +11900,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -11351,6 +11913,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -11363,6 +11926,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -11375,6 +11939,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -11387,6 +11952,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -11399,6 +11965,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -11411,6 +11978,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -11423,6 +11991,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -11435,6 +12004,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -11447,6 +12017,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -11456,6 +12027,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Acid Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11466,6 +12038,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Air Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11483,6 +12056,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Animal Influence</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can use an action to expend 1 of its charges to cast one of the following spells:</text>
     <text>• Animal friendship (save DC 13)</text>
@@ -11495,6 +12069,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Cold Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11505,6 +12080,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Djinni Summoning</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11517,6 +12093,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Earth Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11534,6 +12111,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Evasion</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11545,6 +12123,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Feather Falling</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11555,6 +12134,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Fire Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11571,6 +12151,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Fire Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11581,6 +12162,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Force Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11591,6 +12173,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Free Action</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11601,6 +12184,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Invisibility</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11611,6 +12195,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Jumping</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11621,6 +12206,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Lightning Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11631,6 +12217,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Mind Shielding</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11643,6 +12230,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Necrotic Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11653,6 +12241,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Poison Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11663,6 +12252,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Protection</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11675,6 +12265,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Psychic Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11685,6 +12276,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Radiant Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11695,6 +12287,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Regeneration</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11706,6 +12299,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Shooting Stars</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement Outdoors at Night</text>
     <text />
@@ -11731,6 +12325,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Spell Storing</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11743,6 +12338,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Spell Turning</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11753,6 +12349,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Swimming</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You have a swimming speed of 40 feet while wearing this ring.</text>
     <text />
@@ -11761,6 +12358,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Telekinesis</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11771,6 +12369,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Three Wishes</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>While wearing this ring, you can use an action to expend 1 of its 3 charges to cast the wish spell from it. The ring becomes nonmagical when you use the last charge.</text>
     <text />
@@ -11779,6 +12378,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Thunder Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11789,6 +12389,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Warmth</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11799,6 +12400,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Water Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11815,6 +12417,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Water Walking</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this ring, you can stand on and move across any liquid surface as if it were solid ground.</text>
     <text />
@@ -11823,6 +12426,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of X-ray Vision</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11834,6 +12438,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of the Ram</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11851,6 +12456,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Eyes</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11866,6 +12472,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Scintillating Colors</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11878,6 +12485,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Robe of Serpants</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Uncommon</rarity>
         <text>Rarity: Uncommon</text>
         <text />
         <text>A robe of serpents is a stylish silk garment that is popular among wealthy nobles and retired assassins. The robe is emblazoned with 1d4 + 3 stylized serpents, all brightly colored.</text>
@@ -11888,6 +12496,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
     <name>Robe of Stars</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11902,6 +12511,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Useful Items</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This robe has cloth patches of various shapes and colors covering it. While wearing the robe. you can use an action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.</text>
     <text>The robe has two of each of the following patches:</text>
@@ -11933,6 +12543,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of the Archmagi</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -11968,6 +12579,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Absorption</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11982,6 +12594,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Alertness</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -12000,6 +12613,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Lordly Might</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -12026,6 +12640,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Resurrection</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Cleric, Druid, or Paladin</text>
     <text />
@@ -12038,6 +12653,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Rulership</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -12049,6 +12665,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Security</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>While holding this rod, you can use an action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a paradise that exists in an extraplanar space. You choose the form that the paradise takes. It could be a tranquil garden, lovely glade, cheery tavern, immense palace, tropical island, fantastic carnival, or whatever else you can imagine. Regardless of its nature, the paradise contains enough water and food to sustain its visitors. Everything else that can be interacted with inside the extraplanar space can exist only there. For example, a flower picked from a garden in the paradise disappears if it is taken outside the extraplanar space.</text>
     <text>For each hour spent in the paradise, a visitor regains hit points as if it had spent 1 Hit Die. Also, creatures don't age while in the paradise, although time passes normally. Visitors can remain in the paradise for up to 200 days divided by the number of creatures present (round down).</text>
@@ -12060,6 +12677,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of the Pact Keeper, +1</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -12074,6 +12692,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of the Pact Keeper, +2</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -12088,6 +12707,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of the Pact Keeper, +3</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -12102,6 +12722,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Rod of the Vonindod</name>
         <type>RD</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>The ﬁre giant duke Zalto hired a wizard to craft several of these adamantine rods. Each measures 4 feet long, weighs 100 pounds, and is sized to ﬁt comfortably in a ﬁre giant’s hand. The rod has two prongs at one end and a molded handle grip on the opposite end.</text>
@@ -12114,6 +12735,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rope of Climbing</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This 60-foot length of silk rope weighs 3 pounds and can hold up to 3,000 pounds. If you hold one end of the rope and use an action to speak the command word, the rope animates. As a bonus action, you can command the other end to move toward a destination you choose. That end moves 10 feet on your turn when you first command it and 10 feet on each of your turns until reaching its destination, up to its maximum length away, or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.</text>
     <text>If you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, the rope shortens to a 50-foot length and grants advantage on checks made to climb it.</text>
@@ -12125,6 +12747,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rope of Entanglement</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This rope is 30 feet long and weighs 3 pounds. If you hold one end of the rope and use an action to speak its command word, the other end darts forward to entangle a creature you can see within 20 feet of you. The target must succeed on a DC 15 Dexterity saving throw or become restrained.</text>
     <text>You can release the creature by using a bonus action to speak a second command word. A target restrained by the rope can use an action to make a DC 15 Strength or Dexterity check (target's choice). On a success, the creature is no longer restrained by the rope.</text>
@@ -12144,6 +12767,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Saddle of the Cavalier</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While in this saddle on a mount, you can't be dismounted against your will if you're conscious, and attack rolls against the mount have disadvantage.</text>
     <text />
@@ -12187,6 +12811,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -12199,6 +12824,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -12211,6 +12837,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -12223,6 +12850,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -12235,6 +12863,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -12247,6 +12876,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -12259,6 +12889,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -12271,6 +12902,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -12283,6 +12915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -12295,6 +12928,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -12307,6 +12941,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -12319,6 +12954,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -12331,6 +12967,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -12340,6 +12977,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scarab of Protection</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -12393,6 +13031,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12411,6 +13050,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12429,6 +13069,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12447,6 +13088,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -12464,6 +13106,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -12483,6 +13126,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon. In addition, you can make one attack with it as a bonus action on each of your turns.</text>
@@ -12502,6 +13146,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -12525,6 +13170,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -12542,6 +13188,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -12557,6 +13204,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Aberrations</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents aberrations from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an aberration would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12565,6 +13213,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Beasts</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents beasts from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a beast would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12573,6 +13222,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Celestials</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents celestials from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a celestial would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12581,6 +13231,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Elementals</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents elementals from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an elemental would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12589,6 +13240,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Fey</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fey from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fey would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12597,6 +13249,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Fiends</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fiends from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fiend would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12605,6 +13258,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Plants</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents plants from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a plant would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12613,6 +13267,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Undead</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents undead from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an undead would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12648,6 +13303,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sending Stones</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Sending stones come in pairs, with each smooth stone carved to match the other so the pairing is easily recognized. While you touch one stone, you can use an action to cast the sending spell from it. The target is the bearer of the other stone. If no creature bears the other stone, you know that fact as soon as you use the stone and don't cast the spell.</text>
     <text>Once sending is cast through the stones, they can't be used again until the next dawn. If one of the stones in a pair is destroyed, the other one becomes nonmagical.</text>
@@ -12659,6 +13315,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While holding this shield, you have advantage on initiative rolls and Wisdom (Perception) checks. The shield is emblazoned with a symbol of an eye.</text>
     <text />
@@ -12679,6 +13336,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Shard of the Ise Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This shard of ice is long and slender, roughly the size of a dagger. The ise (ice) rune glows within it. The shard has the following properties, which work only while it’s on your person.</text>
@@ -12720,6 +13378,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While holding this shield, you have a +1 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -12731,6 +13390,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	While holding this shield, you have a +2 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -12742,6 +13402,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	While holding this shield, you have a +3 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -12753,6 +13414,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you have resistance to damage from ranged weapon attacks.</text>
@@ -12788,6 +13450,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12810,6 +13473,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12832,6 +13496,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12854,6 +13519,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -12888,6 +13554,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12906,6 +13573,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12924,6 +13592,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12942,6 +13611,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -12959,6 +13629,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -12982,6 +13653,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -12999,6 +13671,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -13037,6 +13710,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13053,6 +13727,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13069,6 +13744,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13085,6 +13761,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -13139,6 +13816,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.</text>
@@ -13178,6 +13856,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13198,6 +13877,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13218,6 +13898,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13234,6 +13915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullet of Slaying</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A sling bullet of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both bullets of dragon slaying and bullets of blue dragon slaying. If a creature belonging to the type, race, or group associated with a bullet of slaying takes damage from the bullet the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a bullet of slaying deals its extra damage to a creature, it becomes a nonmagical sling bullet.</text>
@@ -13263,6 +13945,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullets +1</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -13274,6 +13957,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullets +2</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -13285,6 +13969,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullets +3</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -13300,6 +13985,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -13314,6 +14000,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Slippers of Spider Climbing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -13339,6 +14026,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Sovereign Glue</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with oil of slipperiness. When found, a container contains 1d6 + 1 ounces.</text>
     <text>One ounce of the glue can cover a 1-foot square surface. The glue takes 1 minute to set. Once it has done so, the bond it creates can be broken only by the application of universal solvent or oil of etherealness, or with a wish spell.</text>
@@ -13372,6 +14060,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13394,6 +14083,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13416,6 +14106,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13438,6 +14129,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -13583,6 +14275,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (1st Level)</name>
     <type>SC</type>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 11.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13597,6 +14290,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (2nd Level)</name>
     <type>SC</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 12.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13611,6 +14305,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (3rd Level)</name>
     <type>SC</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 13.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13625,6 +14320,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (4th Level)</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 14.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13639,6 +14335,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (5th Level)</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 15.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13653,6 +14350,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (6th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 16.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13667,6 +14365,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (7th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 17.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13681,6 +14380,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (8th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 18.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13695,6 +14395,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (9th Level)</name>
     <type>SC</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 19.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13709,6 +14410,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (Cantrip)</name>
     <type>SC</type>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC equals 10.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13734,6 +14436,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you have advantage on saving throws against spells and other magical effects, and spell attacks have disadvantage against you</text>
@@ -13743,6 +14446,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sphere of Annihilation</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.</text>
     <text>The sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an artifact is susceptible to damage from a sphere of annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 4d10 force damage.</text>
@@ -13946,6 +14650,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -13959,6 +14664,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -13972,6 +14678,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -13985,6 +14692,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -13998,6 +14706,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -14011,6 +14720,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -14024,6 +14734,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -14037,6 +14748,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -14050,6 +14762,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -14063,6 +14776,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -14076,6 +14790,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -14089,6 +14804,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -14102,6 +14818,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -14138,6 +14855,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Charming</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14167,6 +14885,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Fire</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14181,6 +14900,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Frost</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14195,6 +14915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Healing</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, or Druid</text>
     <text />
@@ -14208,6 +14929,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Power</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14237,6 +14959,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Striking</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -14253,6 +14976,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Swarming Insects</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14269,6 +14993,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Thunder and Lightning</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -14293,6 +15018,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Withering</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -14307,6 +15033,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Adder</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -14322,6 +15049,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Magi</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14349,6 +15077,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Python</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -14362,6 +15091,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Woodlands</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Druid</text>
     <text />
@@ -14388,6 +15118,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Stone of Controlling Earth Elementals</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>If the stone is touching the ground, you can use an action to speak its command word and summon an earth elemental, as if you had cast the conjure elemental spell. The stone can't be used this way again until the next dawn. The stone weighs 5 pounds.</text>
     <text />
@@ -14396,6 +15127,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Stone of Good Luck</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -14445,6 +15177,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -14456,6 +15189,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -14467,6 +15201,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -14478,6 +15213,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -14489,6 +15225,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -14500,6 +15237,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -14511,6 +15249,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -14522,6 +15261,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -14533,6 +15273,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -14544,6 +15285,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -14555,6 +15297,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -14566,6 +15309,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -14577,6 +15321,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -14591,6 +15336,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>F,V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	This item appears to be a longsword hilt. While grasping the hilt, you can use a bonus action to cause a blade of pure radiance to spring into existence, or make the blade disappear. While the blade exists, this magic longsword has the finesse property. If you are proficient with shortswords or longswords, you are proficient with the sun blade.</text>
     <text>You gain a +2 bonus to attack and damage rolls made with this weapon, which deals radiant damage instead of slashing damage. When you hit an undead with it, that target takes an extra 1d8 radiant damage.</text>
@@ -14639,6 +15385,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14659,6 +15406,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14679,6 +15427,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14699,6 +15448,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14719,6 +15469,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14739,6 +15490,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14759,6 +15511,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14779,6 +15532,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14799,6 +15553,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14819,6 +15574,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -14847,6 +15603,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Talisman of Pure Good</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Creature of Good Alignment</text>
     <text />
@@ -14862,6 +15619,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Talisman of Ultimate Evil</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Creature of Evil Alignment</text>
     <text />
@@ -14877,6 +15635,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Talisman of the Sphere</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -14896,6 +15655,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tentacle Rod</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -14976,6 +15736,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of Clear Thought</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -14985,6 +15746,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of Leadership and Influence</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -15002,6 +15764,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of Understanding</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -15011,6 +15774,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of the Stilled Tongue</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Wizard</text>
     <text />
@@ -15082,6 +15846,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -15104,6 +15869,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -15126,6 +15892,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -15148,6 +15915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This trident is a magic weapon. It has 3 charges. While you carry it, you can use an action and expend 1 charge to cast dominate beast (save DC 15) from it on a beast that has an innate swimming speed. The trident regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -15169,6 +15937,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -15421,6 +16190,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Universal Solvent</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This tube holds milky liquid with a strong alcohol smell. You can use an action to pour the contents of the tube onto a surface within reach. The liquid instantly dissolves up to 1 square foot of adhesive it touches, including sovereign glue.</text>
     <text />
@@ -15442,6 +16212,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15457,6 +16228,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15476,6 +16248,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15491,6 +16264,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15512,6 +16286,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15529,6 +16304,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15541,6 +16317,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15559,6 +16336,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15575,6 +16353,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15589,6 +16368,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15605,6 +16385,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15624,6 +16405,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15646,6 +16428,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15665,6 +16448,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15689,6 +16473,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15705,6 +16490,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15720,6 +16506,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15742,6 +16529,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15761,6 +16549,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15783,6 +16572,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15796,6 +16586,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15809,6 +16600,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15824,6 +16616,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15836,6 +16629,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15855,6 +16649,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15869,6 +16664,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15883,6 +16679,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15900,6 +16697,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15919,6 +16717,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15935,6 +16734,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15950,6 +16750,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15969,6 +16770,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15989,6 +16791,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -16006,6 +16809,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -16019,6 +16823,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -16033,6 +16838,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -16062,6 +16868,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -16084,6 +16891,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -16103,6 +16911,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -16130,6 +16939,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Binding</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16145,6 +16955,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Enemy Detection</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -16158,6 +16969,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Fear</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -16174,6 +16986,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Fireballs</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16194,6 +17007,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Lightning Bolts</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16214,6 +17028,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Magic Detection</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wand has 3 charges. While holding it, you can expend 1 charge as an action to cast the detect magic spell from it. The wand regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -16224,6 +17039,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Magic Missiles</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wand has 7 charges. While holding it, you can use an action to expend 1 or more of its charges to cast the magic missile spell from it. For 1 charge, you cast the 1st-level version of the spell. You can increase the spell slot level by one for each additional charge you expend.</text>
     <text>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed.</text>
@@ -16242,6 +17058,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Orcus</name>
     <type>WD</type>
     <weight>4</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -16275,6 +17092,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Paralysis</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16289,6 +17107,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Polymorph</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16302,6 +17121,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Secrets</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>The wand has 3 charges. While holding it. you can use an action to expend 1 of its charges, and if a secret door or trap is within 30 feet of you, the wand pulses and points at the one nearest to you. The wand regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -16325,6 +17145,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Web</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16348,6 +17169,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Wonder</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16387,6 +17209,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of the War Mage, +1</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16399,6 +17222,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of the War Mage, +2</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16411,6 +17235,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of the War Mage, +3</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16434,6 +17259,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16447,6 +17273,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16460,6 +17287,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16473,6 +17301,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -16500,6 +17329,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16517,6 +17347,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16534,6 +17365,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16551,6 +17383,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -16577,6 +17410,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a creature that worships a god of the sea</text>
     <text />
@@ -16618,6 +17452,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Well of Many Worlds</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
     <text>You can use an action to unfold and place the well of many worlds on a solid surface, whereupon it creates a two-way portal to another world or plane of existence. Each time the item opens a portal, the DM decides where it leads. You can use an action to close an open portal by taking hold of the edges of the cloth and folding it up. Once well of many worlds has opened a portal, it can't do so again for 1d8 hours.</text>
@@ -16634,6 +17469,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a dwarf</text>
     <text />
@@ -16678,6 +17514,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16696,6 +17533,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16714,6 +17552,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16732,6 +17571,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -16771,6 +17611,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.</text>
@@ -16782,6 +17623,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wind Fan</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While holding this fan, you can use an action to cast the gust of wind spell (save DC 13) from it. Once used, the fan shouldn't be used again until the next dawn. Each time it is used again before then, it has a cumulative 20 percent chance of not working and tearing into useless, nonmagical tatters.</text>
     <text />
@@ -16821,6 +17663,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Winged Boots</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -16832,6 +17675,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wings of Flying</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -16871,6 +17715,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
         <name>Wyrmskull Throne</name>
         <type>W</type>
+        <rarity>Artifact</rarity>
         <text>Rarity: Artifact</text>
         <text />
         <text>Built by dwarven gods and entrusted to the rulers of Shanatar, an ancient dwarven empire. the Wyrmskull Throne was a symbol of dwarven power and pride for ages untold. The throne hovers a foot off the ground and is a massive thing made of polished obsidian with oversized feet—the impaled skulls of four ancient blue dragons. Runes glisten in the carved obsidian winking to life with blue energy when the throne's powers are activated.</text>

--- a/Compendiums/Items Compendium.xml
+++ b/Compendiums/Items Compendium.xml
@@ -821,6 +821,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -833,6 +834,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -843,6 +845,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -854,6 +857,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -866,6 +870,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -877,6 +882,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -888,6 +894,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -910,6 +917,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -937,6 +945,7 @@
     <name>Alchemy Jug</name>
     <type>W</type>
     <weight>12</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ceramic jug appears to be able to hold a gallon of liquid and weighs 12 pounds whether full or empty. Sloshing sounds can be heard from within the jug when it is shaken, even if the jug is empty.</text>
     <text>You can use an action and name one liquid from the table below to cause the jug to produce the chosen liquid. Afterward, you can uncork the jug as an action and pour that liquid out, up to 2 gallons per minute. The maximum amount of liquid the jug can produce depends on the liquid you named.</text>
@@ -960,6 +969,7 @@
     <name>Amulet of Health</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -971,6 +981,7 @@
     <name>Amulet of Proof Against Detection and Location</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -982,6 +993,7 @@
     <name>Amulet of the Planes</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -994,6 +1006,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you can speak its command word as a bonus action to cause it to animate. The shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The shield remains animated for 1 minute, until you use a bonus action to end this effect, or until you are incapacitated or die, at which point the shield falls to the ground or into your hand if you have one free.</text>
@@ -1012,6 +1025,7 @@
     <name>Apparatus of Kwalish</name>
     <type>W</type>
     <weight>500</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This item first appears to be a Large sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move either up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.</text>
     <text>The apparatus of Kwalish is a Large object with the following statistics:</text>
@@ -1057,6 +1071,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to nonmagical damage while you wear this armor. Additionally, you can use an action to make yourself immune to nonmagical damage for 10 minutes or until you are no longer wearing the armor. Once this special action is used, it can't be used again until the next dawn.</text>
@@ -1070,6 +1085,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to bludgeoning damage.</text>
@@ -1085,6 +1101,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to piercing damage.</text>
@@ -1100,6 +1117,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to slashing damage.</text>
@@ -1112,6 +1130,7 @@
     <name>Arrow of Slaying</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	An arrow of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both arrows of dragon slaying and arrows of blue dragon slaying. If a creature belonging to the type, race, or group associated with an arrow of slaying takes damage from the arrow, the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once an arrow of slaying deals its extra damage to a creature, it becomes a nonmagical arrow.</text>
@@ -1124,6 +1143,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to AC against ranged attacks while you wield this shield. This bonus is in addition to the shield's normal bonus to AC. In addition, whenever an attacker makes a ranged attack against a target within 5 feet of you, you can use your reaction to become the target of the attack instead.</text>
@@ -1152,6 +1172,7 @@
     <name>Arrows +1</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1163,6 +1184,7 @@
     <name>Arrows +2</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1174,6 +1196,7 @@
     <name>Arrows +3</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1200,6 +1223,7 @@
     <dmgType>S</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -1238,6 +1262,7 @@
     <name>Bag of Beans</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Inside this heavy cloth bag are 3d4 dry beans. The bag weighs 1/2 pound plus 1/4 pound for each bean it contains.</text>
     <text>If you dump the bag's contents out on the ground, they explode in a 10-foot radius, extending from the beans. Each creature in the area, including you, must make a DC 15 Dexterity saving throw, taking 5d4 fire damage on a failed save, or half as much damage on a successful one. The fire ignites flammable objects in the area that aren't being worn or carried.</text>
@@ -1265,6 +1290,7 @@
     <name>Bag of Devouring</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This bag superficially resembles a bag of holding but is a feeding orifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.</text>
     <text>The extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can use its action to try to escape with a successful DC 15 Strength check. Another creature can use its action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength check (provided it isn't pulled inside the bag first). Any creature that starts its turn inside the bag is devoured, its body destroyed.</text>
@@ -1277,6 +1303,7 @@
     <name>Bag of Holding</name>
     <type>W</type>
     <weight>15</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This bag has an interior space considerably larger than its outside dimensions, roughly 2 feet in diameter at the mouth and 4 feet deep. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 15 pounds, regardless of its contents. Retrieving an item from the bag requires an action.</text>
     <text>If the bag is overloaded, pierced, or torn, it ruptures and is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth, unharmed, but the bag must be put right before it can be used again. Breathing creatures inside the bag can survive up to a number of minutes equal to 10 divided by the number of creatures (minimum 1 minute), after which time they begin to suffocate.</text>
@@ -1288,6 +1315,7 @@
     <name>Bag of Tricks, Gray</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from gray cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics. The creature vanishes at the next dawn or when it is reduced to 0 hit points.</text>
@@ -1311,6 +1339,7 @@
     <name>Bag of Tricks, Rust</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from rust cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics.</text>
@@ -1335,6 +1364,7 @@
     <name>Bag of Tricks, Tan</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from tan cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics.</text>
@@ -1389,6 +1419,7 @@
         <name>Banner of the Krig Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>Crafted from a thick, red fabric, this banner measures 5 feet high and 3 feet wide. The krig (war) rune is displayed on the fabric with round, metal plates sewn into it. It can be attached to a 10-foot pole to serve as a standard. Furling or unfurling the banner requires an action. The banner has the following properties.</text>
@@ -1447,6 +1478,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1464,6 +1496,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1481,6 +1514,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1498,6 +1532,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1510,6 +1545,7 @@
     <name>Bead of Force</name>
     <type>W</type>
     <weight>0.0625</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 beads of force are found together.</text>
     <text>You can use an action to throw the bead up to 60 feet. The bead explodes on impact and is destroyed. Each creature within a 10-foot radius of where the bead landed must succeed on a DC 15 Dexterity saving throw or take 5d4 force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save, or are partially within the area, are pushed away from the center of the sphere until they are no longer inside it. Only breathable air can pass through the sphere's wall. No attack or other effect can.</text>
@@ -1534,6 +1570,7 @@
 	<item>
     <name>Belt of Cloud Giant Strength</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -1544,6 +1581,7 @@
   <item>
     <name>Belt of Dwarvenkind</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1562,6 +1600,7 @@
   <item>
     <name>Belt of Fire Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1572,6 +1611,7 @@
   <item>
     <name>Belt of Frost Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1582,6 +1622,7 @@
   <item>
     <name>Belt of Hill Giant Strength</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1592,6 +1633,7 @@
   <item>
     <name>Belt of Stone Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -1602,6 +1644,7 @@
   <item>
     <name>Belt of Storm Giant Strength</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -1617,6 +1660,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -1637,6 +1681,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -1660,6 +1705,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -1706,6 +1752,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.</text>
@@ -1721,6 +1768,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a creature of non-lawful alignment</text>
     <text />
@@ -1763,6 +1811,7 @@
         <name>Blod Stone</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This diamond contains the blood of a creature—b1ood that appears in the form of the blod (blood) rune. While the item is on your person, you can use your action to divine the location of the creature nearest to you that is related to the blood in the item and that isn’t undead. You sense the distance and direction of the creature relative to your location. The creature is either the one whose blood is in the item or a blood relative.</text>
@@ -1813,6 +1862,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1835,6 +1885,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1857,6 +1908,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -1875,6 +1927,7 @@
     <name>Blowgun Needle of Slaying</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A blowgun needle of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both needles of dragon slaying and needles of blue dragon slaying. If a creature belonging to the type, race, or group associated with a needle of slaying takes damage from the needle the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a needle of slaying deals its extra damage to a creature, it becomes a nonmagical blowgun needle.</text>
@@ -1904,6 +1957,7 @@
     <name>Blowgun Needles +1</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1915,6 +1969,7 @@
     <name>Blowgun Needles +2</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1926,6 +1981,7 @@
     <name>Blowgun Needles +3</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -1941,6 +1997,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1983,6 +2040,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.</text>
@@ -2004,6 +2062,7 @@
     <name>Book of Exalted Deeds</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement by a creature of good alignment</text>
     <text />
@@ -2026,6 +2085,7 @@
     <name>Book of Vile Darkness</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -2056,6 +2116,7 @@
   <item>
     <name>Boots of Elvenkind</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have advantage on Dexterity (Stealth) checks that rely on moving silently.</text>
     <text />
@@ -2064,6 +2125,7 @@
   <item>
     <name>Boots of Levitation</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2074,6 +2136,7 @@
   <item>
     <name>Boots of Speed</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2085,6 +2148,7 @@
   <item>
     <name>Boots of Striding and Springing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2095,6 +2159,7 @@
   <item>
     <name>Boots of the Winterlands</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2118,6 +2183,7 @@
     <name>Bowl of Commanding Water Elementals</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While this bowl is filled with water, you can use an action to speak the bowl's command word and summon a water elemental, as if you had cast the conjure elemental spell. The bowl can't be used this way again until the next dawn.</text>
     <text>The bowl is about 1 foot in diameter and half as deep. It weighs 3 pounds and holds about 3 gallons.</text>
@@ -2127,6 +2193,7 @@
   <item>
     <name>Bracers of Archery</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2137,6 +2204,7 @@
   <item>
     <name>Bracers of Defense</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2151,6 +2219,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -2163,6 +2232,7 @@
     <name>Brazier of Commanding Fire Elementals</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While a fire burns in this brass brazier, you can use an action to speak the brazier's command word and summon a fire elemental, as if you had cast the conjure elemental spell. The brazier can't be used this way again until the next dawn.</text>
     <text>The brazier weighs 5 pounds.</text>
@@ -2184,6 +2254,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -2195,6 +2266,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -2206,6 +2278,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -2217,6 +2290,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2228,6 +2302,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2239,6 +2314,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2250,6 +2326,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2261,6 +2338,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2272,6 +2350,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2283,6 +2362,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2294,6 +2374,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2305,6 +2386,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2316,6 +2398,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2337,6 +2420,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.</text>
@@ -2348,6 +2432,7 @@
   <item>
     <name>Brooch of Shielding</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -2359,6 +2444,7 @@
     <name>Broom of Flying</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wooden broom, which weighs 3 pounds, functions like a mundane broom until you stand astride it and speak its command word. It then hovers beneath you and can be ridden in the air. It has a flying speed of 50 feet. It can carry up to 400 pounds, but its flying speed becomes 30 feet while carrying over 200 pounds. The broom stops hovering when you land.</text>
     <text>You can send the broom to travel alone to a destination within 1 mile of you if you speak the command word, name the location, and are familiar with that place. The broom comes back to you when you speak another command word, provided that the broom is still within 1 mile of you.</text>
@@ -2469,6 +2555,7 @@
 	<item>
     <name>Candle of Invocation</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -2494,6 +2581,7 @@
   <item>
     <name>Cap of Water Breathing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cap underwater, you can speak its command word as an action to create a bubble of air around your head. It allows you to breathe normally underwater. This bubble stays with you until you speak the command word again, the cap is removed, or you are no longer underwater.</text>
     <text />
@@ -2502,6 +2590,7 @@
   <item>
     <name>Cape of the Mountebank</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This cape smells faintly of brimstone. While wearing it, you can use it to cast the dimension door spell as an action. This property of the cape can't be used again until the next dawn.</text>
     <text>When you disappear, you leave behind a cloud of smoke, and you appear in a similar cloud of smoke at your destination. The smoke lightly obscures the space you left and the space you appear in, and it dissipates at the end of your next turn. A light or stronger wind disperses the smoke.</text>
@@ -2520,6 +2609,7 @@
 	<item>
     <name>Carpet of Flying, 3 ft. x 5 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 3 ft. x 5 ft. carpet can carry up to 200 lb. at a fly speed of 80 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2529,6 +2619,7 @@
   <item>
     <name>Carpet of Flying, 4 ft. x 6 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 4 ft. x 6 ft. carpet can carry up to 400 lb. at a fly speed of 60 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2538,6 +2629,7 @@
   <item>
     <name>Carpet of Flying, 5 ft. x 7 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 5 ft. x 7 ft. carpet can carry up to 600 lb. at a fly speed of 40 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2547,6 +2639,7 @@
   <item>
     <name>Carpet of Flying, 6 ft. x 9 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 6 ft. x 9 ft. carpet can carry up to 800 lb. at a fly speed of 30 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -2575,6 +2668,7 @@
     <name>Censer of Controlling Air Elementals</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While incense is burning in this censer, you can use an action to speak the censer's command word and summon an air elemental, as if you had cast the conjure elemental spell. The censer can't be used this way again until the next dawn.</text>
     <text>This 6-inch-wide, 1-foot-high vessel resembles a chalice with a decorated lid. It weighs 1 pound.</text>
@@ -2609,6 +2703,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -2622,6 +2717,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -2635,6 +2731,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -2648,6 +2745,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2661,6 +2759,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2674,6 +2773,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2687,6 +2787,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2700,6 +2801,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2713,6 +2815,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2726,6 +2829,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2739,6 +2843,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2752,6 +2857,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2765,6 +2871,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2786,6 +2893,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -2797,6 +2905,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -2808,6 +2917,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -2819,6 +2929,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2830,6 +2941,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2841,6 +2953,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2852,6 +2965,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2863,6 +2977,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2874,6 +2989,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2885,6 +3001,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2896,6 +3013,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2907,6 +3025,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2918,6 +3037,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2943,6 +3063,7 @@
     <name>Chime of Opening</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This hollow metal tube measures about 1 foot long and weighs 1 pound. You can strike it as an action, pointing it at an object within 120 feet of you that can be opened, such as a door, lid, or lock. The chime issues a clear tone, and one lock or latch on the object opens unless the sound can't reach the object. If no locks or latches remain, the object itself opens.</text>
     <text>The chime can be used ten times. After the tenth time it cracks and becomes useless.</text>
@@ -2952,6 +3073,7 @@
   <item>
     <name>Circlet of Blasting</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this circlet, you can use an action to cast the scorching ray spell with it. When you make the spell's attacks, you do so with an attack bonus of +5. The circlet can't be used this way again until the next dawn.</text>
     <text />
@@ -2962,6 +3084,7 @@
         <name>Claw of the Wyrm Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This dragon's claw has been covered with a coat of molten silver, upon which has been inscribed the wyrm (dragon) rune. The claw has the following properties.</text>
@@ -2993,6 +3116,7 @@
 	<item>
     <name>Cloak of Arachnida</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3008,6 +3132,7 @@
   <item>
     <name>Cloak of Displacement</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3018,6 +3143,7 @@
   <item>
     <name>Cloak of Elvenkind</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -3028,6 +3154,7 @@
   <item>
     <name>Cloak of Invisibility</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3038,6 +3165,7 @@
   <item>
     <name>Cloak of Protection</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -3050,6 +3178,7 @@
   <item>
     <name>Cloak of the Bat</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3061,6 +3190,7 @@
   <item>
     <name>Cloak of the Manta Ray</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cloak with its hood up, you can breathe underwater, and you have a swimming speed of 60 feet. Pulling the hood up or down requires an action.</text>
     <text />
@@ -3085,6 +3215,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3101,6 +3232,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3117,6 +3249,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3133,6 +3266,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -3170,6 +3304,7 @@
         <name>Conch of Teleportation</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This item is an ordinary, albeit rather large, conch shell that has been inscribed with the uvar rune. The conch measures 2 1/2 feet long and weighs 20 pounds.</text>
@@ -3211,6 +3346,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.</text>
@@ -3239,6 +3375,7 @@
     <name>Crossbow Bolt of Slaying</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A crossbow bolt of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both bolts of dragon slaying and bolts of blue dragon slaying. If a creature belonging to the type, race, or group associated with a bolt of slaying takes damage from the bolt the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a bolt of slaying deals its extra damage to a creature, it becomes a nonmagical crossbow bolt.</text>
@@ -3268,6 +3405,7 @@
     <name>Crossbow Bolts +1</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3279,6 +3417,7 @@
     <name>Crossbow Bolts +2</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3290,6 +3429,7 @@
     <name>Crossbow Bolts +3</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3319,6 +3459,7 @@
     <name>Crystal Ball</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3330,6 +3471,7 @@
     <name>Crystal Ball of Mind Reading</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3342,6 +3484,7 @@
     <name>Crystal Ball of Telepathy</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3354,6 +3497,7 @@
     <name>Crystal Ball of True Seeing</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -3365,6 +3509,7 @@
   <item>
     <name>Cube of Force</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -3395,6 +3540,7 @@
   <item>
     <name>Cubic Gate</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the DM.</text>
     <text>You can use an action to press one side of the cube to cast the gate spell with it, opening a portal to the plane keyed to that side. Alternatively, if you use an action to press one side twice, you can cast the plane shift spell (save DC 17) with the cube and transport the targets to the plane keyed to that side.</text>
@@ -3406,6 +3552,7 @@
   <item>
     <name>Daern's Instant Fortress</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place this 1-inch metal cube on the ground and speak its command word. The cube rapidly grows into a fortress that remains until you use an action to speak the command word that dismisses it, which works only if the fortress is empty.</text>
     <text>The fortress is a square tower, 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors. with a ladder running along one wall to connect them. The ladder ends at a trapdoor leading to the roof. When activated, the tower has a small door on the side facing you. The door opens only at your command, which you can speak as a bonus action. It is immune to the knock spell and similar magic, such as that of a chime of opening.</text>
@@ -3442,6 +3589,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3465,6 +3613,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3488,6 +3637,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3511,6 +3661,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>You can use an action to cause thick, black poison to coat the blade. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 poison damage and become poisoned for 1 minute. The dagger can't be used this way again until the next dawn.</text>
@@ -3536,6 +3687,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -3557,6 +3709,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3577,6 +3730,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3594,6 +3748,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3611,6 +3766,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3630,6 +3786,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -3667,6 +3824,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3688,6 +3846,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3709,6 +3868,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3730,6 +3890,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -3777,6 +3938,7 @@
     <name>Decanter of Endless Water</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This stoppered flask sloshes when shaken, as if it contains water. The decanter weighs 2 pounds.</text>
     <text>You can use an action to remove the stopper and speak one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following options:</text>
@@ -3790,6 +3952,7 @@
   <item>
     <name>Deck of Illusions</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This box contains a set of parchment cards. A full deck has 34 cards. A deck found as treasure is usually missing 1d20 - 1 cards.</text>
     <text>The magic of the deck functions only if cards are drawn at random (you can use an altered deck of playing cards to simulate the deck). You can use an action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of you.</text>
@@ -3836,6 +3999,7 @@
   <item>
     <name>Deck of Many Things</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have only thirteen cards, but the rest have twenty-two.</text>
     <text>Before you draw a card, you must declare how many cards you intend to draw and then draw them randomly (you can use an altered deck of playing cards to simulate the deck). Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.</text>
@@ -3898,6 +4062,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3919,6 +4084,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3937,6 +4103,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3955,6 +4122,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3975,6 +4143,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -3995,6 +4164,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you gain a +1 bonus to AC, and you can understand and speak Abyssal. In addition, the armor's clawed gauntlets turn unarmed strikes with your hands into magic weapons that deal slashing damage, with a +1 bonus to attack rolls and damage rolls and a damage die of 1d8.</text>
@@ -4061,6 +4231,7 @@
 	<item>
     <name>Dimensional Shackles</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place these shackles on an incapacitated creature. The shackles adjust to fit a creature of Small to Large size. In addition to serving as mundane manacles, the shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing-through an interdimensional portal.</text>
     <text>You and any creature you designate when you use the shackles can use an action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength Athletics) check. On a success, the creature breaks free and destroys the shackles.</text>
@@ -4127,6 +4298,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4148,6 +4320,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4166,6 +4339,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4184,6 +4358,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4204,6 +4379,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -4255,6 +4431,7 @@
     <name>Driftglobe</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small sphere of thick glass weighs 1 pound. If you are within 60 feet of it, you can speak its command word and cause it to emanate the light or daylight spell. Once used, the daylight effect can't be used again until the next dawn.</text>
     <text>You can speak another command word as an action to make the illuminated globe rise into the air and float no more than 5 feet off the ground. The globe hovers in this way until you or another creature grasps it. If you move more than 60 feet from the hovering globe, it follows you until it is within 60 feet of you. It takes the shortest route to do so. If prevented from moving, the globe sinks gently to the ground and becomes inactive, and its light winks out.</text>
@@ -4357,6 +4534,7 @@
 	<item>
     <name>Dust of Disappearance</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small packet, this powder resembles very fine sand. There is enough of it for one use. When you use an action to throw the dust into the air, you and each creature and object within 10 feet of you become invisible for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. If a creature affected by the dust attacks or casts a spell, the invisibility ends for that creature.</text>
     <text />
@@ -4365,6 +4543,7 @@
   <item>
     <name>Dust of Dryness</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small packet contains 1d6 + 4 pinches of dust. You can use an action to sprinkle a pinch of it over water. The dust turns a cube of water 15 feet on a side into one marble-sized pellet, which floats or rests near where the dust was sprinkled. The pellet's weight is negligible.</text>
     <text>Someone can use an action to smash the pellet against a hard surface, causing the pellet to shatter and release the water the dust absorbed. Doing so ends that pellet's magic.</text>
@@ -4376,6 +4555,7 @@
   <item>
     <name>Dust of Sneezing and Choking</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small container, this powder resembles very fine sand. It appears to be dust of disappearance, and an identify spell reveals it to be such. There is enough of it for one use.</text>
     <text>When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The lesser restoration spell can also end the effect on a creature.</text>
@@ -4389,6 +4569,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	While wearing this armor, you gain a +2 bonus to AC. In addition, if an effect moves you against your will along the ground, you can use your reaction to reduce the distance you are moved by up to 10 feet.</text>
     <text />
@@ -4404,6 +4585,7 @@
     <dmgType>B</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Dwarf</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. It has the thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 damage or, if the target is a giant, 2d8 damage. Immediately after the attack, the weapon flies back to your hand.</text>
@@ -4424,6 +4606,7 @@
     <name>Efreeti Bottle</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This painted brass bottle weighs 1 pound. When you use an action to remove the stopper, a cloud of thick smoke flows out of the bottle. At the end of your turn, the smoke disappears with a flash of harmless fire, and an efreeti appears in an unoccupied space within 30 feet of you. See the Monster Manual for the efreeti's statistics.</text>
     <text>The first time the bottle is opened, the DM rolls to determine what happens.</text>
@@ -4442,6 +4625,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you gain a +3 bonus to AC, you are immune to fire damage, and you can understand and speak Primordial. In addition, you can stand on and walk across molten rock as if it were solid ground.</text>
@@ -4471,6 +4655,7 @@
 	<item>
     <name>Elemental Gem, Blue Sapphire</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, an air elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
@@ -4501,6 +4686,7 @@
     <name>Elixir of Health</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, it cures any disease afflicting you, and it removes the blinded, deafened, paralyzed, and poisoned conditions. The clear red liquid has tiny bubbles of light in it.</text>
     <text />
@@ -4511,6 +4697,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to AC while you wear this armor. You are considered proficient with this armor even if you lack proficiency with medium armor.</text>
     <text />
@@ -4553,6 +4740,7 @@
     <name>Eversmoking Bottle</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Smoke leaks from the lead-stoppered mouth of this brass bottle, which weighs 1 pound. When you use an action to remove the stopper, a cloud of thick smoke pours out in a 60-foot radius from the bottle. The cloud's area is heavily obscured. Each minute the bottle remains open and within the cloud, the radius increases by 10 feet until it reaches its maximum radius of 120 feet.</text>
     <text>The cloud persists as long as the bottle is open. Closing the bottle requires you to speak its command word as an action. Once the bottle is closed, the cloud disperses after 10 minutes. A moderate wind (11 to 20 miles per hour) can also disperse the smoke after 1 minute, and a strong wind (21 or more miles per hour) can do so after 1 round.</text>
@@ -4587,6 +4775,7 @@
 	<item>
     <name>Eye of Vecna</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -4618,6 +4807,7 @@
   <item>
     <name>Eyes of Charming</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -4628,6 +4818,7 @@
   <item>
     <name>Eyes of Minute Seeing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These crystal lenses fit over the eyes. While wearing them, you can see much better than normal out to a range of 1 foot. You have advantage on Intelligence (Investigation) checks that rely on sight while searching an area or studying an object within that range.</text>
     <text />
@@ -4636,6 +4827,7 @@
   <item>
     <name>Eyes of the Eagle</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -4646,6 +4838,7 @@
   <item>
     <name>Figurine of Wondrous Power, Bronze Griffon</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics.</text>
@@ -4659,6 +4852,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ebony Fly</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4672,6 +4866,7 @@
   <item>
     <name>Figurine of Wondrous Power, Golden Lions</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics.</text>
@@ -4685,6 +4880,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ivory Goats</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4701,6 +4897,7 @@
   <item>
     <name>Figurine of Wondrous Power, Marble Elephant</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4714,6 +4911,7 @@
   <item>
     <name>Figurine of Wondrous Power, Obsidian Steed</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4728,6 +4926,7 @@
   <item>
     <name>Figurine of Wondrous Power, Onyx Dog</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4741,6 +4940,7 @@
   <item>
     <name>Figurine of Wondrous Power, Serpentine Owl</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4754,6 +4954,7 @@
   <item>
     <name>Figurine of Wondrous Power, Silver Raven</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -4795,6 +4996,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4808,6 +5010,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4821,6 +5024,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4834,6 +5038,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -4847,6 +5052,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4866,6 +5072,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4882,6 +5089,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4898,6 +5106,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4916,6 +5125,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -4953,6 +5163,7 @@
     <name>Folding Boat</name>
     <type>W</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep. It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring you to use an action to speak it.</text>
     <text>One command word causes the box to unfold into a boat 10 feet long, 4 feet wide, and 2 feet deep. The boat has one pair of oars, an anchor, a mast, and a lateen sail. The boat can hold up to four Medium creatures comfortably.</text>
@@ -4978,6 +5189,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -4999,6 +5211,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5017,6 +5230,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5035,6 +5249,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5055,6 +5270,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -5071,6 +5287,7 @@
   <item>
     <name>Gauntlets of Ogre Power</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -5082,6 +5299,7 @@
         <name>Gavel of the Venn Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This wooden gavel is small by giant reckoning but nearly the size of a warhammcr in human hands. The venn (friend) rune is inscribed in mithral in the base of the haft. Among giants, this item is used as part of rituals to resolve disputes. The gavel has the following properties.</text>
@@ -5096,6 +5314,7 @@
     <name>Gem of Brightness</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This prism has 50 charges. While you are holding it, you can use an action to speak one of three command words to cause one of the following effects:</text>
     <text>• The first command word causes the gem to shed bright light in a 30-foot radius and dim light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you use a bonus action to repeat the command word or until you use another function of the gem.</text>
@@ -5109,6 +5328,7 @@
     <name>Gem of Seeing</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -5126,6 +5346,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5144,6 +5365,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5164,6 +5386,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5185,6 +5408,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5208,6 +5432,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5226,6 +5451,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5244,6 +5470,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5264,6 +5491,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -5298,6 +5526,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5318,6 +5547,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5338,6 +5568,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5358,6 +5589,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5375,6 +5607,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	While wearing this armor, you gain a +1 bonus to AC. You can also use a bonus action to speak the armor's command word and cause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like, including color, style, and accessories, but the armor retains its normal bulk and weight. The illusory appearance last until you use this property again or remove the armor.</text>
     <text />
@@ -5402,6 +5635,7 @@
 	<item>
     <name>Gloves of Missile Snaring</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -5413,6 +5647,7 @@
   <item>
     <name>Gloves of Swimming and Climbing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -5423,6 +5658,7 @@
   <item>
     <name>Gloves of Thievery</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These gloves are invisible while worn. While wearing them, you gain a +5 bonus to Dexterity (Sleight of Hand) checks and Dexterity checks made to pick locks.</text>
     <text />
@@ -5431,6 +5667,7 @@
   <item>
     <name>Goggles of Night</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing these dark lenses, you have darkvision out to a range of 60 feet. If you already have darkvision. wearing the goggles increases its range by 60 feet.</text>
     <text />
@@ -5461,6 +5698,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -5497,6 +5735,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5515,6 +5754,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5533,6 +5773,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5551,6 +5792,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5580,6 +5822,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5596,6 +5839,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5612,6 +5856,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5628,6 +5873,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5657,6 +5903,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5675,6 +5922,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5693,6 +5941,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5711,6 +5960,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -5728,6 +5978,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -5747,6 +5998,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -5770,6 +6022,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5787,6 +6040,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -5828,6 +6082,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to poison damage.</text>
@@ -5864,6 +6119,7 @@
         <dmgType>S</dmgType>
         <property>H,2H</property>
         <text>This item requires attunement</text>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text>In the Year of the Icy Axe (123 DR), the frost giant lord Gurt fell to Uthgar Gardolfsson—leader of the folk who would become the Uthgardt barbarians—in a battle that marked the ascendance of humankind over the giants in the Dessarin Valley. Gurt’s greataxe was buried in Morgur’s Mound until it was unearthed and brought back to Waterdeep. After laying in the city’s vaults for decades, the axe was given to Harshnag, a frost giant adventurer, in recognition of his service to Waterdeep. Uthgardt barbarians recognize the weapon on sight and attack any giant that wields it.</text>
         <text>You gain a +1 bonus to attack and damage rolls made with this magic weapon. It is sized for a giant, weighs 325 pounds, and deals 3dl2 slashing damage on a hit, plus an extra 2d12 slashing damage if the target is human.</text>
@@ -5895,6 +6151,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5915,6 +6172,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5935,6 +6193,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5955,6 +6214,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -5984,6 +6244,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -5996,6 +6257,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -6008,6 +6270,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -6020,6 +6283,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -6032,6 +6296,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -6044,6 +6309,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -6056,6 +6322,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -6068,6 +6335,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -6080,6 +6348,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -6092,6 +6361,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -6104,6 +6374,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -6116,6 +6387,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -6128,6 +6400,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -6149,6 +6422,7 @@
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text />
@@ -6194,6 +6468,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6218,6 +6493,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6242,6 +6518,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6266,6 +6543,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -6284,6 +6562,7 @@
   <item>
     <name>Hand of Vecna</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -6337,6 +6616,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6358,6 +6638,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6379,6 +6660,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6400,6 +6682,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -6415,6 +6698,7 @@
   <item>
     <name>Hat of Disguise</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -6453,6 +6737,7 @@
   <item>
     <name>Headband of Intellect</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -6500,6 +6785,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6526,6 +6812,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6552,6 +6839,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -6578,6 +6866,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -6598,6 +6887,7 @@
   <item>
     <name>Helm of Brilliance</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -6615,6 +6905,7 @@
   <item>
     <name>Helm of Comprehending Languages</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this helm, you can use an action to cast the comprehend languages spell from it at will.</text>
     <text />
@@ -6623,6 +6914,7 @@
   <item>
     <name>Helm of Telepathy</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -6634,6 +6926,7 @@
   <item>
     <name>Helm of Teleportation</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -6664,6 +6957,7 @@
     <name>Heward's Handy Haversack</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 20 pounds of material, not exceeding a volume of 2 cubic feet. The large central pouch can hold up to 8 cubic feet or 80 pounds of material. The backpack always weighs 5 pounds, regardless of its contents.</text>
     <text>Placing an object in the haversack follows the normal rules for interacting with objects. Retrieving an item from the haversack requires you to use an action. When you reach into the haversack for a specific item, the item is always magically on top.</text>
@@ -6687,6 +6981,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -6698,6 +6993,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -6709,6 +7005,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -6720,6 +7017,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -6731,6 +7029,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -6742,6 +7041,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -6753,6 +7053,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -6764,6 +7065,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -6775,6 +7077,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -6786,6 +7089,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -6797,6 +7101,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -6808,6 +7113,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -6819,6 +7125,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -6832,6 +7139,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6854,6 +7162,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6873,6 +7182,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6892,6 +7202,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6913,6 +7224,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -7012,6 +7324,7 @@
     <name>Horn of Blasting</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to speak the horn's command word and then blow the horn, which emits a thunderous blast in a 30-foot cone that is audible 600 feet away. Each creature in the cone must make a DC 15 Constitution saving throw. On a failed save, a creature takes 5d6 thunder damage and is deafened for 1 minute. On a successful save, a creature takes half as much damage and isn't deafened. Creatures and objects made of glass or crystal have disadvantage on the saving throw and take 10d6 thunder damage instead of 5d6.</text>
     <text>Each use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 fire damage to the blower and destroys the horn.</text>
@@ -7023,6 +7336,7 @@
     <name>Horn of Valhalla, Brass</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>A brass horn summons 3d4 + 3 berserkers.  To use the brass horn, you must be proficient with all simple weapons.</text>
@@ -7035,6 +7349,7 @@
     <name>Horn of Valhalla, Bronze</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>A bronze horn summons 4d4 + 4 berserkers.  To use the bronze horn, you must be proficient with medium armor.</text>
@@ -7047,6 +7362,7 @@
     <name>Horn of Valhalla, Iron</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>The iron horn summons 5d4 + 5 berserkers.  To use the iron horn, you must be proficient with all martial weapons.</text>
@@ -7059,6 +7375,7 @@
     <name>Horn of Valhalla, Silver</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>The silver horn summons 2d4 + 2 berserkers.</text>
@@ -7070,6 +7387,7 @@
   <item>
     <name>Horseshoes of Speed</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they increase the creature's walking speed by 30 feet.</text>
     <text />
@@ -7078,6 +7396,7 @@
   <item>
     <name>Horseshoes of a Zephyr</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above the ground. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores difficult terrain. In addition, the creature can move at normal speed for up to 12 hours a day without suffering exhaustion from a forced march.</text>
     <text />
@@ -7122,6 +7441,7 @@
     <name>Immovable Rod</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This flat iron rod has a button on one end. You can use an action to press the button, which causes the rod to become magically fixed in place. Until you or another creature uses an action to push the button again, the rod doesn't move, even if it is defying gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can use an action to make a DC 30 Strength check, moving the fixed rod up to 10 feet on a success</text>
     <text />
@@ -7131,6 +7451,7 @@
         <name>Ingot of the Skold Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This appears to be a simple ingot of iron ore, about a foot long and a few inches across. Inspection of its surface reveals the faint, silvery outline ofthe skold (shield) rune. The ingot has the following properties, which work only while it's on your person.</text>
@@ -7169,6 +7490,7 @@
     <name>Instrument of the Bards, Anstruth Harp</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7184,6 +7506,7 @@
     <name>Instrument of the Bards, Canaith Mandolin</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7199,6 +7522,7 @@
     <name>Instrument of the Bards, Cli Lyre</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7214,6 +7538,7 @@
     <name>Instrument of the Bards, Doss Lute</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7229,6 +7554,7 @@
     <name>Instrument of the Bards, Fochlucan Bandore</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7244,6 +7570,7 @@
     <name>Instrument of the Bards, Mac-Fuirmidh Cittern</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7259,6 +7586,7 @@
     <name>Instrument of the Bards, Ollamh Harp</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -7273,6 +7601,7 @@
   <item>
     <name>Ioun Stone, Absorption</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7289,6 +7618,7 @@
   <item>
     <name>Ioun Stone, Agility</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7305,6 +7635,7 @@
   <item>
     <name>Ioun Stone, Awareness</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7320,6 +7651,7 @@
   <item>
     <name>Ioun Stone, Fortitude</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7336,6 +7668,7 @@
   <item>
     <name>Ioun Stone, Greater Absorption</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -7351,6 +7684,7 @@
   <item>
     <name>Ioun Stone, Insight</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7367,6 +7701,7 @@
   <item>
     <name>Ioun Stone, Intellect</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7383,6 +7718,7 @@
   <item>
     <name>Ioun Stone, Leadership</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7399,6 +7735,7 @@
   <item>
     <name>Ioun Stone, Mastery</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -7415,6 +7752,7 @@
   <item>
     <name>Ioun Stone, Protection</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7431,6 +7769,7 @@
   <item>
     <name>Ioun Stone, Regeneration</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -7446,6 +7785,7 @@
   <item>
     <name>Ioun Stone, Reserve</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7463,6 +7803,7 @@
   <item>
     <name>Ioun Stone, Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7479,6 +7820,7 @@
   <item>
     <name>Ioun Stone, Sustenance</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -7495,6 +7837,7 @@
     <name>Iron Bands of Bilarro</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can use an action to speak the command word and throw the sphere at a Huge or smaller creature you can see within 60 feet of you. As the sphere moves through the air, it opens into a tangle of metal bands.</text>
     <text>Make a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your proficiency bonus. On a hit, the target is restrained until you take a bonus action to speak the command word again to release it. Doing so, or missing with the attack, causes the bands to contract and become a sphere once more.</text>
@@ -7507,6 +7850,7 @@
     <name>Iron Flask</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This iron bottle has a brass stopper. You can use an action to speak the flask's command word, targeting a creature that you can see within 60 feet of you. If the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has advantage on the saving throw. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at a time. A creature trapped in the flask doesn't need to breathe, eat, or drink and doesn't age.</text>
     <text>You can use an action to remove the flask's stopper and release the creature the flask contains. The creature is friendly to you and your companions for 1 hour and obeys your commands for that duration. If you give no commands or give it a command that is likely to result in its death, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.</text>
@@ -7618,6 +7962,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7637,6 +7982,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7656,6 +8002,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7675,6 +8022,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This javelin is a magic weapon. When you hurl it and speak its command word, it transforms into a bolt of lightning, forming a line 5 feet wide that extends out from you to a target within 120 feet. Each creature in the line excluding you and the target must make a DC 13 Dexterity saving throw, taking 4d6 lightning damage on a failed save, and half as much damage on a successful one. The lightning bolt turns back into a javelin when it reaches the target. Make a ranged weapon attack against the target. On a hit, the target takes damage from the javelin plus 4d6 lightning damage.</text>
     <text>The javelin's property can't be used again until the next dawn. In the meantime, the javelin can still be used as a magic weapon.</text>
@@ -7694,6 +8042,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -7725,6 +8074,7 @@
 	<item>
     <name>Keoghtom's Ointment</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This glass jar, 3 inches in diameter, contains 1d4 + 1 doses of a thick mixture that smells faintly of aloe. The jar and its contents weigh 1/2 pound.</text>
     <text>As an action, one dose of the ointment can be swallowed or applied to the skin. The creature that receives it regains 2d8 + 2 hit points, ceases to be poisoned, and is cured of any disease.</text>
@@ -7740,6 +8090,7 @@
         <dmgType>B</dmgType>
         <property>L</property>
         <text>This item requires attunement</text>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
         <text>The Korolnor Scepter is one of ten Ruling Scepters of Shanatar, forged by the dwarven gods and given to the ruling houses of the ancient dwarven empire. The Korolnor Scepter’s location was unknown for the longest time until a storm giant queen, Neri, found it in a barnacle-covered shipwreck at the bottom of the Trackless Sea. The Ruling Scepters are all roughly the same size and shape, but their materials and properties vary.</text>
@@ -7792,6 +8143,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7808,6 +8160,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7824,6 +8177,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -7840,6 +8194,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -7852,6 +8207,7 @@
     <name>Lantern of Revealing</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's bright light. You can use an action to lower the hood, reducing the light to dim light in a 5-foot radius.</text>
     <text />
@@ -7872,6 +8228,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -7883,6 +8240,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -7894,6 +8252,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -7905,6 +8264,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -7916,6 +8276,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -7927,6 +8288,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -7938,6 +8300,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -7949,6 +8312,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -7960,6 +8324,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -7971,6 +8336,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -7982,6 +8348,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -7993,6 +8360,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -8004,6 +8372,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -8048,6 +8417,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8072,6 +8442,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8096,6 +8467,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8120,6 +8492,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8160,6 +8533,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8181,6 +8555,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8202,6 +8577,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8223,6 +8599,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8273,6 +8650,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8297,6 +8675,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8321,6 +8700,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8345,6 +8725,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8381,6 +8762,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8398,6 +8780,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8415,6 +8798,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8432,6 +8816,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -8448,6 +8833,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -8466,6 +8852,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -8488,6 +8875,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8504,6 +8892,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -8534,6 +8923,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8559,6 +8949,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8581,6 +8972,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8603,6 +8995,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8627,6 +9020,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -8685,6 +9079,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8698,6 +9093,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8711,6 +9107,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -8724,6 +9121,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit a fiend or an undead with this magic weapon, that creature takes an extra 2d6 radiant damage. If the target has 25 hit points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature becomes frightened of you until the end of your next turn.</text>
@@ -8738,6 +9136,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. The bonus increases to +3 when you use the mace to attack a construct.</text>
     <text>When you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 bludgeoning damage, or an extra 14 bludgeoning damage if it's a construct. If a construct has 25 hit points or fewer after taking this damage, it is destroyed.</text>
@@ -8752,6 +9151,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon has 3 charges. While holding it, you can use an action and expend 1 charge to release a wave of terror. Each creature of your choice in a 30-foot radius extending from you must succeed on a DC 15 Wisdom saving throw or become frightened of you for 1 minute. While it is frightened in this way, a creature must spend its turns trying to move as far away from you as it can, and it can't willingly move to a space within 30 feet of you. It also can't take reactions. For its action it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can use the Dodge action. At the end of each of its turns, a creature can repeat the saving throw, ending the effect on itself on a success.</text>
@@ -8766,6 +9166,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -8801,6 +9202,7 @@
 	<item>
     <name>Mantle of Spell Resistance</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8812,6 +9214,7 @@
     <name>Manual of Bodily Health</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains health and diet tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -8821,6 +9224,7 @@
     <name>Manual of Clay Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a clay golem, you must spend 30 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 65,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8831,6 +9235,7 @@
     <name>Manual of Flesh Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a flesh golem, you must spend 60 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 50,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8841,6 +9246,7 @@
     <name>Manual of Gainful Exercise</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strength score increase- by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -8850,6 +9256,7 @@
     <name>Manual of Iron Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create an iron golem, you must spend 120 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 100,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8860,6 +9267,7 @@
     <name>Manual of Quickness of Action</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains coordination and balance exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -8869,6 +9277,7 @@
     <name>Manual of Stone Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a golem, you must spend 90 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 80,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -8889,6 +9298,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8901,6 +9311,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8911,6 +9322,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8922,6 +9334,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8932,6 +9345,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8942,6 +9356,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8953,6 +9368,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8965,6 +9381,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8976,6 +9393,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -8987,6 +9405,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -9009,6 +9428,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -9019,6 +9439,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -9064,6 +9485,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9082,6 +9504,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9100,6 +9523,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9119,6 +9543,7 @@
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -9133,6 +9558,7 @@
     <name>Medallion of Thoughts</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9180,6 +9606,7 @@
     <name>Mirror of Life Trapping</name>
     <type>W</type>
     <weight>50</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When this 4-foot-tall mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, 10 hit points, and vulnerability to bludgeoning damage. It shatters and is destroyed when reduced to 0 hit points.</text>
     <text>If the mirror is hanging on a vertical surface and you are within 5 feet of it, you can use an action to speak its command word and activate it. It remains activated until you use an action to speak the command word again.</text>
@@ -9196,6 +9623,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9206,6 +9634,7 @@
     <type>HA</type>
     <weight>55</weight>
     <ac>16</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9216,6 +9645,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9226,6 +9656,7 @@
     <type>MA</type>
     <weight>40</weight>
     <ac>15</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9236,6 +9667,7 @@
     <type>HA</type>
     <weight>65</weight>
     <ac>18</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9246,6 +9678,7 @@
     <type>HA</type>
     <weight>40</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9256,6 +9689,7 @@
     <type>MA</type>
     <weight>45</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9275,6 +9709,7 @@
     <type>HA</type>
     <weight>60</weight>
     <ac>17</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -9311,6 +9746,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by an elf or half-elf of neutral good alignment</text>
     <text />
@@ -9360,6 +9796,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9373,6 +9810,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9386,6 +9824,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -9399,6 +9838,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -9409,6 +9849,7 @@
         <name>Navigation Orb</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>A navigation orb is a hollow, 7-foot-diameter sphere of thin, polished mithral with a large skye (cloud) rune embossed on its outer surface. The orb levitates 10 feet above the ground and is keyed to a particular cloud castle, allowing you to control that castle's altitude and movement while the orb is inside the castle. If the orb is destroyed or removed from its castle, the castle's altitude and location remain ﬁxed until the orb is returned or replaced.</text>
@@ -9433,6 +9874,7 @@
     <name>Necklace of Adaptation</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9444,6 +9886,7 @@
     <name>Necklace of Fireballs</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This necklace has 1d6 + 3 beads hanging from it. You can use an action to detach a bead and throw it up to 6 feet away. When it reaches the end of its trajectory, the bead detonates as a 3rd-level fireball spell (save DC 15).</text>
     <text>You can hurl multiple beads, or even the whole necklace, as one action. When you do so, increase the level of the fireball by 1 for each bead beyond the first.</text>
@@ -9455,6 +9898,7 @@
     <name>Necklace of Prayer Beads</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Cleric, Druid, or Paladin</text>
     <text />
@@ -9493,6 +9937,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -9513,6 +9958,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -9533,6 +9979,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -9553,6 +10000,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -9570,6 +10018,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9591,6 +10040,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9609,6 +10059,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9627,6 +10078,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9647,6 +10099,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -9664,6 +10117,7 @@
     <name>Nolzur's Marvelous Pigments</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Typically found in 1d4 pots inside a fine wooden box with a brush (weighing 1 pound in total), these pigments allow you to create three-dimensional objects by painting them in two dimensions. The paint flows from the brush to form the desired object as you concentrate on its image.</text>
     <text>Each pot of paint is sufficient to cover 1,000 square feet of a surface, which lets you create inanimate objects or terrain features-such as a door, a pit, flowers, trees, cells, rooms, or weapons- that are up to 10,000 cubic feet. It takes 10 minutes to cover 100 square feet.</text>
@@ -9681,6 +10135,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you nock an arrow on this bow, it whispers in Elvish, "Swift defeat to my enemies." When you use this weapon to make a ranged attack, you can, as a command phrase, say, "Swift death to you who have wronged me." The target of your attack becomes your sworn enemy until it dies or until dawn seven days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.</text>
@@ -9712,6 +10167,7 @@
     <name>Oil of Etherealness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Beads of this cloudy gray oil form on the outside of its container and quickly evaporate. The oil can cover a Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the etherealness spell for 1 hour.</text>
     <text />
@@ -9721,6 +10177,7 @@
     <name>Oil of Sharpness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This clear, gelatinous oil sparkles with tiny, ultrathin silver shards. The oil can coat one slashing or piercing weapon or up to 5 pieces of slashing or piercing ammunition. Applying the oil takes 1 minute. For 1 hour, the coated item is magical and has a +3 bonus to attack and damage rolls.</text>
     <text />
@@ -9730,6 +10187,7 @@
     <name>Oil of Slipperiness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This sticky black unguent is thick and heavy in the container, but it flows quickly when poured. The oil can cover a Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of a freedom of movement spell for 8 hours.</text>
     <text>Alternatively, the oil can be poured on the ground as an action, where it covers a 10-foot square, duplicating the effect of the grease spell in that area for 8 hours.</text>
@@ -9749,6 +10207,7 @@
         <name>Opal of the Ild Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This triangular ﬁre opal measures about three inches on each side and is half an inch thick. The ild (ﬁre) rune shimmers within its core, causing it to be slightly warm to the touch. The opal has the following properties, which work only while it’s on your person.</text>
@@ -9773,6 +10232,7 @@
 	<item>
     <name>Orb of Dragonkind</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -9796,6 +10256,7 @@
         <name>Orb of the Stein Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This orb of granite is about the size of an adult human’s ﬁst. The stein (stone) rune appears on it in the form ofcrystalline veins that run across the surface. The orb has the following properties, which work only while it's on your person.</text>
@@ -9852,6 +10313,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -9864,6 +10326,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -9876,6 +10339,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -9888,6 +10352,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -9900,6 +10365,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -9912,6 +10378,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -9924,6 +10391,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -9936,6 +10404,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -9948,6 +10417,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -9960,6 +10430,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -9972,6 +10443,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -9984,6 +10456,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -9996,6 +10469,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -10049,6 +10523,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
 	<item>
     <name>Pearl of Power</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -10060,6 +10535,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
         <name>Pennant of the Vind Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This blue pennant is crafted from silk and is ﬁve feet long and whips about as if buffeted by a wind. The vind (wind) rune appears on its surface, looking almost like a cloud. The pennant has the following properties, which work only while it’s on your person.</text>
@@ -10084,6 +10560,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Periapt of Health</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You are immune to contracting any disease while you wear this pendant. If you are already infected with a disease, the effects of the disease are suppressed you while you wear the pendant.</text>
     <text />
@@ -10093,6 +10570,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Periapt of Proof Against Poison</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, poisons have no effect on you. You are immune to the poisoned condition and have immunity to poison damage.</text>
     <text />
@@ -10102,6 +10580,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Periapt of Wound Closure</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10113,6 +10592,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Philter of Love</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>The next time you see a creature within 10 minutes after drinking this philter, you become charmed by that creature for 1 hour. If the creature is of a species and gender you are normally attracted to, you regard it as your true love while you are charmed. This potion's rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart.</text>
     <text />
@@ -10141,6 +10621,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -10161,6 +10642,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -10181,6 +10663,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -10201,6 +10684,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -10217,6 +10701,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Pipes of Haunting</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You must be proficient with wind instruments to use these pipes. They have 3 charges. You can use an action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature within 30 feet of you that hears you play must succeed on a DC 15 Wisdom saving throw or become frightened of you for 1 minute. If you wish, all creatures in the area that aren't hostile toward you automatically succeed on the saving throw. A creature that fails the saving throw can repeat it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its saving throw is immune to the effect of these pipes for 24 hours. The pipes regain 1d3 expended charges daily at dawn.</text>
     <text />
@@ -10227,6 +10712,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Pipes of the Sewers</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10292,6 +10778,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -10305,6 +10792,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -10318,6 +10806,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -10331,6 +10820,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -10344,6 +10834,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -10357,6 +10848,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	While you're wearing this armor, you can speak its command word as an action to gain the effect of the etherealness spell, which last for 10 minutes or until you remove the armor or use an action to speak the command word again. This property of the armor can't be used again until the next dawn.</text>
@@ -10370,6 +10862,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -10383,6 +10876,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -10396,6 +10890,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -10409,6 +10904,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -10422,6 +10918,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -10435,6 +10932,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -10448,6 +10946,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -10461,6 +10960,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -10513,6 +11013,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Portable Hole</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
     <text>You can use an action to unfold a portable hole and place it on or against a solid surface, whereupon the portable hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane, so it can't be used to create open passages. Any creature inside an open portable hole can exit the hole by climbing out of it.</text>
@@ -10535,6 +11036,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Acid Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to acid damage for 1 hour.</text>
     <text />
@@ -10544,6 +11046,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Animal Friendship</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you can cast the animal friendship spell (save DC 13) for 1 hour at will. Agitating this muddy liquid brings little bits into view: a fish scale, a hummingbird tongue, a cat claw, or a squirrel hair.</text>
     <text />
@@ -10553,6 +11056,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Clairvoyance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the clairvoyance spell. An eyeball bobs in this yellowish liquid but vanishes when the potion is opened.</text>
     <text />
@@ -10562,6 +11066,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Climbing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>When you drink this potion, you gain a climbing speed equal to your walking speed for 1 hour. During this time, you have advantage on Strength (Athletics) checks you make to climb. The potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors.</text>
     <text />
@@ -10571,6 +11076,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Cloud Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, your Strength score changes to 27 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a cloud giant.</text>
@@ -10581,6 +11087,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Cold Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to cold damage for 1 hour.</text>
     <text />
@@ -10590,6 +11097,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Diminution</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the "reduce" effect of the enlarge/reduce spell for 1d4 hours (no concentration required). The red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process.</text>
     <text />
@@ -10600,6 +11108,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Fire Breath</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>After drinking this potion, you can use a bonus action to exhale fire at a target within 30 feet of you. The target must make a DC 13 Dexterity saving throw, taking 4d6 fire damage on a failed save, or half as much damage on a successful one. The effect ends after you exhale the fire three times or when 1 hour has passed. This potion's orange liquid flickers, and smoke fills the top of the container and wafts out whenever it is opened.</text>
     <text />
@@ -10610,6 +11119,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Fire Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 25 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a fire giant.</text>
@@ -10620,6 +11130,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Fire Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to fire damage for 1 hour.</text>
     <text />
@@ -10629,6 +11140,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Flying</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, you gain a flying speed equal to your walking speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft. This potion's clear liquid floats at the top of its container and has cloudy white impurities drifting in it.</text>
     <text />
@@ -10638,6 +11150,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Force Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to force damage for 1 hour.</text>
     <text />
@@ -10647,6 +11160,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Frost Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 23 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a frost giant.</text>
@@ -10657,6 +11171,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Gaseous Form</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the gaseous form spell for 1 hour (no concentration required) or until you end the effect as a bonus action. This potion's container seems to hold fog that moves and pours like water.</text>
     <text />
@@ -10665,6 +11180,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
         <name>Potion of Giant Size</name>
         <type>P</type>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
         <text>When you drink this potion, you become Huge for 24 hours if you are Medium or smaller, otherwise the potion does nothing. For that duration, your Strength becomes 25, if it isn't already higher, and your hit point maximum is doubled (your current hit points are doubled when you drink the potion). In addition, the reach of your melee attacks increases by 5 feet.</text>
@@ -10677,6 +11193,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Greater Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You regain 4d4 + 4 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10687,6 +11204,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Growth</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain the "enlarge" effect of the enlarge/reduce spell for 1d4 hours (no concentration required). The red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process.</text>
     <text />
@@ -10697,6 +11215,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>You regain 2d4 + 2 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10707,6 +11226,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Heroism</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>For 1 hour after drinking it, you gain 10 temporary hit points that last for 1 hour. For the same duration, you are under the effect of the bless spell (no concentration required). This blue potion bubbles and steams as if boiling.</text>
     <text />
@@ -10716,6 +11236,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Hill Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, your Strength score changes to 21 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a hill giant.</text>
@@ -10726,6 +11247,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Invisibility</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This potion's container looks empty but feels as though it holds liquid. When you drink it, you become invisible for 1 hour. Anything you wear or carry is invisible with you. The effect ends early if you attack or cast a spell.</text>
     <text />
@@ -10735,6 +11257,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Invulnerability</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>For 1 minute after you drink this potion, you have resistance to all damage. The potion's syrupy liquid looks like liquefied iron.</text>
     <text />
@@ -10744,6 +11267,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Lightning Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to lightning damage for 1 hour.</text>
     <text />
@@ -10753,6 +11277,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Longevity</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, your physical age is reduced by 1d6 + 6 years, to a minimum of 13 years. Each time you subsequently drink a potion of longevity, there is 10 percent cumulative chance that you instead age by 1d6 + 6 years. Suspended in this amber liquid are a scorpion's tail, an adder's fang, a dead spider, and a tiny heart that, against all reason, is still beating. These ingredients vanish when the potion is opened.</text>
     <text />
@@ -10763,6 +11288,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Mind Reading</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the detect thoughts spell (save DC 13). The potion's dense, purple liquid has an ovoid cloud of pink floating in it.</text>
     <text />
@@ -10772,6 +11298,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Necrotic Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to necrotic damage for 1 hour.</text>
     <text />
@@ -10781,6 +11308,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Poison</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This concoction looks, smells, and tastes like a potion of healing or other beneficial potion. However, it is actually poison masked by illusion magic. An identify spell reveals its true nature.</text>
     <text>If you drink it, you take 3d6 poison damage, and you must succeed on a DC 13 Constitution saving throw or be poisoned. At the start of each of your turns while you are poisoned in this way, you take 3d6 poison damage. At the end of each of your turns, you can repeat the saving throw. On a successful save, the poison damage you take on your subsequent turns decreases by 1d6. The poison ends when the damage decreases to 0.</text>
@@ -10794,6 +11322,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Poison Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to poison damage for 1 hour.</text>
     <text />
@@ -10803,6 +11332,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Psychic Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to psychic damage for 1 hour.</text>
     <text />
@@ -10812,6 +11342,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Radiant Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to radiant damage for 1 hour.</text>
     <text />
@@ -10821,6 +11352,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Speed</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, you gain resistance to acid damage for 1 hour.</text>
     <text />
@@ -10830,6 +11362,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Stone Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 23 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a stone giant.</text>
@@ -10840,6 +11373,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Storm Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>When you drink this potion, your Strength score changes to 29 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a storm giant.</text>
@@ -10850,6 +11384,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Superior Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You regain 8d4 + 8 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10860,6 +11395,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Supreme Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You regain 10d4 + 20 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -10870,6 +11406,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Thunder Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to thunder damage for 1 hour.</text>
     <text />
@@ -10879,6 +11416,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Vitality</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, it removes any exhaustion you are suffering and cures any disease or poison affecting you. For the next 24 hours, you regain the maximum number of hit points for any Hit Die you spend. The potion's crimson liquid regularly pulses with dull light, calling to mind a heartbeat.</text>
     <text />
@@ -10888,6 +11426,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Potion of Water Breathing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You can breathe underwater for 1 hour after drinking this potion. Its cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it.</text>
     <text />
@@ -10953,6 +11492,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Quaal's Feather Token, Anchor</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10963,6 +11503,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Bird</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10973,6 +11514,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Fan</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10983,6 +11525,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Swan Boat</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -10993,6 +11536,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Tree</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11003,6 +11547,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Whip</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11034,6 +11579,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11051,6 +11597,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11068,6 +11615,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11085,6 +11633,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -11106,6 +11655,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Quiver of Ehlonna</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to sixty arrows, bolts, or similar objects. The midsize compartment holds up to eighteen javelins or similar objects. The longest compartment holds up to six long objects, such as bows, quarterstaffs, or spears.</text>
     <text>You can draw any item the quiver contains as if doing so from a regular quiver or scabbard.</text>
@@ -11131,6 +11681,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11147,6 +11698,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11163,6 +11715,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -11179,6 +11732,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -11194,6 +11748,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -11215,6 +11770,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -11230,6 +11786,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -11278,6 +11835,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -11303,6 +11861,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -11315,6 +11874,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -11327,6 +11887,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -11339,6 +11900,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -11351,6 +11913,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -11363,6 +11926,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -11375,6 +11939,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -11387,6 +11952,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -11399,6 +11965,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -11411,6 +11978,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -11423,6 +11991,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -11435,6 +12004,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -11447,6 +12017,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -11456,6 +12027,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Acid Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11466,6 +12038,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Air Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11483,6 +12056,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Animal Influence</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can use an action to expend 1 of its charges to cast one of the following spells:</text>
     <text>• Animal friendship (save DC 13)</text>
@@ -11495,6 +12069,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Cold Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11505,6 +12080,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Djinni Summoning</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11517,6 +12093,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Earth Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11534,6 +12111,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Evasion</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11545,6 +12123,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Feather Falling</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11555,6 +12134,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Fire Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11571,6 +12151,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Fire Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11581,6 +12162,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Force Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11591,6 +12173,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Free Action</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11601,6 +12184,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Invisibility</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11611,6 +12195,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Jumping</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11621,6 +12206,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Lightning Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11631,6 +12217,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Mind Shielding</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11643,6 +12230,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Necrotic Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11653,6 +12241,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Poison Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11663,6 +12252,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Protection</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11675,6 +12265,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Psychic Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11685,6 +12276,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Radiant Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11695,6 +12287,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Regeneration</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11706,6 +12299,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Shooting Stars</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement Outdoors at Night</text>
     <text />
@@ -11731,6 +12325,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Spell Storing</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11743,6 +12338,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Spell Turning</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11753,6 +12349,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Swimming</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You have a swimming speed of 40 feet while wearing this ring.</text>
     <text />
@@ -11761,6 +12358,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Telekinesis</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11771,6 +12369,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Three Wishes</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>While wearing this ring, you can use an action to expend 1 of its 3 charges to cast the wish spell from it. The ring becomes nonmagical when you use the last charge.</text>
     <text />
@@ -11779,6 +12378,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Thunder Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11789,6 +12389,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Warmth</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11799,6 +12400,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Water Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11815,6 +12417,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Water Walking</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this ring, you can stand on and move across any liquid surface as if it were solid ground.</text>
     <text />
@@ -11823,6 +12426,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of X-ray Vision</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11834,6 +12438,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of the Ram</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11851,6 +12456,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Eyes</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11866,6 +12472,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Scintillating Colors</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11878,6 +12485,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Robe of Serpants</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Uncommon</rarity>
         <text>Rarity: Uncommon</text>
         <text />
         <text>A robe of serpents is a stylish silk garment that is popular among wealthy nobles and retired assassins. The robe is emblazoned with 1d4 + 3 stylized serpents, all brightly colored.</text>
@@ -11888,6 +12496,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
     <name>Robe of Stars</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11902,6 +12511,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Useful Items</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This robe has cloth patches of various shapes and colors covering it. While wearing the robe. you can use an action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.</text>
     <text>The robe has two of each of the following patches:</text>
@@ -11933,6 +12543,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of the Archmagi</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -11968,6 +12579,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Absorption</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11982,6 +12594,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Alertness</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -12000,6 +12613,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Lordly Might</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -12026,6 +12640,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Resurrection</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Cleric, Druid, or Paladin</text>
     <text />
@@ -12038,6 +12653,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Rulership</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -12049,6 +12665,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of Security</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>While holding this rod, you can use an action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a paradise that exists in an extraplanar space. You choose the form that the paradise takes. It could be a tranquil garden, lovely glade, cheery tavern, immense palace, tropical island, fantastic carnival, or whatever else you can imagine. Regardless of its nature, the paradise contains enough water and food to sustain its visitors. Everything else that can be interacted with inside the extraplanar space can exist only there. For example, a flower picked from a garden in the paradise disappears if it is taken outside the extraplanar space.</text>
     <text>For each hour spent in the paradise, a visitor regains hit points as if it had spent 1 Hit Die. Also, creatures don't age while in the paradise, although time passes normally. Visitors can remain in the paradise for up to 200 days divided by the number of creatures present (round down).</text>
@@ -12060,6 +12677,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of the Pact Keeper, +1</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -12074,6 +12692,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of the Pact Keeper, +2</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -12088,6 +12707,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rod of the Pact Keeper, +3</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -12102,6 +12722,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Rod of the Vonindod</name>
         <type>RD</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>The ﬁre giant duke Zalto hired a wizard to craft several of these adamantine rods. Each measures 4 feet long, weighs 100 pounds, and is sized to ﬁt comfortably in a ﬁre giant’s hand. The rod has two prongs at one end and a molded handle grip on the opposite end.</text>
@@ -12114,6 +12735,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rope of Climbing</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This 60-foot length of silk rope weighs 3 pounds and can hold up to 3,000 pounds. If you hold one end of the rope and use an action to speak the command word, the rope animates. As a bonus action, you can command the other end to move toward a destination you choose. That end moves 10 feet on your turn when you first command it and 10 feet on each of your turns until reaching its destination, up to its maximum length away, or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.</text>
     <text>If you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, the rope shortens to a 50-foot length and grants advantage on checks made to climb it.</text>
@@ -12125,6 +12747,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Rope of Entanglement</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This rope is 30 feet long and weighs 3 pounds. If you hold one end of the rope and use an action to speak its command word, the other end darts forward to entangle a creature you can see within 20 feet of you. The target must succeed on a DC 15 Dexterity saving throw or become restrained.</text>
     <text>You can release the creature by using a bonus action to speak a second command word. A target restrained by the rope can use an action to make a DC 15 Strength or Dexterity check (target's choice). On a success, the creature is no longer restrained by the rope.</text>
@@ -12144,6 +12767,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Saddle of the Cavalier</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While in this saddle on a mount, you can't be dismounted against your will if you're conscious, and attack rolls against the mount have disadvantage.</text>
     <text />
@@ -12187,6 +12811,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -12199,6 +12824,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -12211,6 +12837,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -12223,6 +12850,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -12235,6 +12863,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -12247,6 +12876,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -12259,6 +12889,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -12271,6 +12902,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -12283,6 +12915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -12295,6 +12928,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -12307,6 +12941,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -12319,6 +12954,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -12331,6 +12967,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -12340,6 +12977,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scarab of Protection</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -12393,6 +13031,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12411,6 +13050,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12429,6 +13069,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12447,6 +13088,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -12464,6 +13106,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -12483,6 +13126,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon. In addition, you can make one attack with it as a bonus action on each of your turns.</text>
@@ -12502,6 +13146,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -12525,6 +13170,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -12542,6 +13188,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -12557,6 +13204,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Aberrations</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents aberrations from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an aberration would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12565,6 +13213,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Beasts</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents beasts from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a beast would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12573,6 +13222,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Celestials</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents celestials from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a celestial would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12581,6 +13231,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Elementals</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents elementals from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an elemental would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12589,6 +13240,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Fey</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fey from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fey would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12597,6 +13249,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Fiends</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fiends from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fiend would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12605,6 +13258,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Plants</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents plants from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a plant would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12613,6 +13267,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Undead</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents undead from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an undead would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -12648,6 +13303,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sending Stones</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Sending stones come in pairs, with each smooth stone carved to match the other so the pairing is easily recognized. While you touch one stone, you can use an action to cast the sending spell from it. The target is the bearer of the other stone. If no creature bears the other stone, you know that fact as soon as you use the stone and don't cast the spell.</text>
     <text>Once sending is cast through the stones, they can't be used again until the next dawn. If one of the stones in a pair is destroyed, the other one becomes nonmagical.</text>
@@ -12659,6 +13315,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While holding this shield, you have advantage on initiative rolls and Wisdom (Perception) checks. The shield is emblazoned with a symbol of an eye.</text>
     <text />
@@ -12679,6 +13336,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Shard of the Ise Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This shard of ice is long and slender, roughly the size of a dagger. The ise (ice) rune glows within it. The shard has the following properties, which work only while it’s on your person.</text>
@@ -12720,6 +13378,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While holding this shield, you have a +1 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -12731,6 +13390,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	While holding this shield, you have a +2 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -12742,6 +13402,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	While holding this shield, you have a +3 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -12753,6 +13414,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you have resistance to damage from ranged weapon attacks.</text>
@@ -12788,6 +13450,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12810,6 +13473,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12832,6 +13496,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12854,6 +13519,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -12888,6 +13554,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12906,6 +13573,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12924,6 +13592,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -12942,6 +13611,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -12959,6 +13629,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -12982,6 +13653,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -12999,6 +13671,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -13037,6 +13710,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13053,6 +13727,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13069,6 +13744,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13085,6 +13761,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -13139,6 +13816,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.</text>
@@ -13178,6 +13856,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13198,6 +13877,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13218,6 +13898,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13234,6 +13915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullet of Slaying</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A sling bullet of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both bullets of dragon slaying and bullets of blue dragon slaying. If a creature belonging to the type, race, or group associated with a bullet of slaying takes damage from the bullet the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a bullet of slaying deals its extra damage to a creature, it becomes a nonmagical sling bullet.</text>
@@ -13263,6 +13945,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullets +1</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -13274,6 +13957,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullets +2</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -13285,6 +13969,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Sling Bullets +3</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -13300,6 +13985,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -13314,6 +14000,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Slippers of Spider Climbing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -13339,6 +14026,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Sovereign Glue</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with oil of slipperiness. When found, a container contains 1d6 + 1 ounces.</text>
     <text>One ounce of the glue can cover a 1-foot square surface. The glue takes 1 minute to set. Once it has done so, the bond it creates can be broken only by the application of universal solvent or oil of etherealness, or with a wish spell.</text>
@@ -13372,6 +14060,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13394,6 +14083,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13416,6 +14106,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -13438,6 +14129,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -13583,6 +14275,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (1st Level)</name>
     <type>SC</type>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 11.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13597,6 +14290,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (2nd Level)</name>
     <type>SC</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 12.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13611,6 +14305,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (3rd Level)</name>
     <type>SC</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 13.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13625,6 +14320,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (4th Level)</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 14.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13639,6 +14335,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (5th Level)</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 15.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13653,6 +14350,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (6th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 16.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13667,6 +14365,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (7th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 17.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13681,6 +14380,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (8th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 18.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13695,6 +14395,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (9th Level)</name>
     <type>SC</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 19.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13709,6 +14410,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (Cantrip)</name>
     <type>SC</type>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC equals 10.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -13734,6 +14436,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you have advantage on saving throws against spells and other magical effects, and spell attacks have disadvantage against you</text>
@@ -13743,6 +14446,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sphere of Annihilation</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.</text>
     <text>The sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an artifact is susceptible to damage from a sphere of annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 4d10 force damage.</text>
@@ -13946,6 +14650,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -13959,6 +14664,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -13972,6 +14678,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -13985,6 +14692,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -13998,6 +14706,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -14011,6 +14720,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -14024,6 +14734,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -14037,6 +14748,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -14050,6 +14762,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -14063,6 +14776,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -14076,6 +14790,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -14089,6 +14804,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -14102,6 +14818,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -14138,6 +14855,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Charming</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14167,6 +14885,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Fire</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14181,6 +14900,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Frost</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14195,6 +14915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Healing</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, or Druid</text>
     <text />
@@ -14208,6 +14929,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Power</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14237,6 +14959,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Striking</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -14253,6 +14976,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Swarming Insects</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14269,6 +14993,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Thunder and Lightning</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -14293,6 +15018,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of Withering</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -14307,6 +15033,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Adder</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -14322,6 +15049,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Magi</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -14349,6 +15077,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Python</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -14362,6 +15091,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Staff of the Woodlands</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Druid</text>
     <text />
@@ -14388,6 +15118,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Stone of Controlling Earth Elementals</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>If the stone is touching the ground, you can use an action to speak its command word and summon an earth elemental, as if you had cast the conjure elemental spell. The stone can't be used this way again until the next dawn. The stone weighs 5 pounds.</text>
     <text />
@@ -14396,6 +15127,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Stone of Good Luck</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -14445,6 +15177,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -14456,6 +15189,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -14467,6 +15201,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -14478,6 +15213,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -14489,6 +15225,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -14500,6 +15237,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -14511,6 +15249,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -14522,6 +15261,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -14533,6 +15273,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -14544,6 +15285,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -14555,6 +15297,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -14566,6 +15309,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -14577,6 +15321,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -14591,6 +15336,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>F,V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	This item appears to be a longsword hilt. While grasping the hilt, you can use a bonus action to cause a blade of pure radiance to spring into existence, or make the blade disappear. While the blade exists, this magic longsword has the finesse property. If you are proficient with shortswords or longswords, you are proficient with the sun blade.</text>
     <text>You gain a +2 bonus to attack and damage rolls made with this weapon, which deals radiant damage instead of slashing damage. When you hit an undead with it, that target takes an extra 1d8 radiant damage.</text>
@@ -14639,6 +15385,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14659,6 +15406,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14679,6 +15427,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14699,6 +15448,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14719,6 +15469,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14739,6 +15490,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14759,6 +15511,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14779,6 +15532,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14799,6 +15553,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -14819,6 +15574,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -14847,6 +15603,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Talisman of Pure Good</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Creature of Good Alignment</text>
     <text />
@@ -14862,6 +15619,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Talisman of Ultimate Evil</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Creature of Evil Alignment</text>
     <text />
@@ -14877,6 +15635,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Talisman of the Sphere</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -14896,6 +15655,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tentacle Rod</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -14976,6 +15736,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of Clear Thought</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -14985,6 +15746,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of Leadership and Influence</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -15002,6 +15764,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of Understanding</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -15011,6 +15774,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Tome of the Stilled Tongue</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Wizard</text>
     <text />
@@ -15082,6 +15846,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -15104,6 +15869,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -15126,6 +15892,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -15148,6 +15915,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This trident is a magic weapon. It has 3 charges. While you carry it, you can use an action and expend 1 charge to cast dominate beast (save DC 15) from it on a beast that has an innate swimming speed. The trident regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -15169,6 +15937,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -15421,6 +16190,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Universal Solvent</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This tube holds milky liquid with a strong alcohol smell. You can use an action to pour the contents of the tube onto a surface within reach. The liquid instantly dissolves up to 1 square foot of adhesive it touches, including sovereign glue.</text>
     <text />
@@ -15442,6 +16212,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15457,6 +16228,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15476,6 +16248,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15491,6 +16264,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15512,6 +16286,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15529,6 +16304,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15541,6 +16317,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15559,6 +16336,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15575,6 +16353,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15589,6 +16368,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15605,6 +16385,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15624,6 +16405,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15646,6 +16428,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15665,6 +16448,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15689,6 +16473,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15705,6 +16490,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15720,6 +16506,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15742,6 +16529,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15761,6 +16549,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15783,6 +16572,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15796,6 +16586,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15809,6 +16600,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15824,6 +16616,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15836,6 +16629,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15855,6 +16649,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15869,6 +16664,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15883,6 +16679,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15900,6 +16697,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15919,6 +16717,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15935,6 +16734,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -15950,6 +16750,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -15969,6 +16770,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -15989,6 +16791,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -16006,6 +16809,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -16019,6 +16823,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -16033,6 +16838,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -16062,6 +16868,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -16084,6 +16891,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -16103,6 +16911,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -16130,6 +16939,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Binding</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16145,6 +16955,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Enemy Detection</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -16158,6 +16969,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Fear</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -16174,6 +16986,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Fireballs</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16194,6 +17007,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Lightning Bolts</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16214,6 +17028,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Magic Detection</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wand has 3 charges. While holding it, you can expend 1 charge as an action to cast the detect magic spell from it. The wand regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -16224,6 +17039,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Magic Missiles</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wand has 7 charges. While holding it, you can use an action to expend 1 or more of its charges to cast the magic missile spell from it. For 1 charge, you cast the 1st-level version of the spell. You can increase the spell slot level by one for each additional charge you expend.</text>
     <text>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed.</text>
@@ -16242,6 +17058,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Orcus</name>
     <type>WD</type>
     <weight>4</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -16275,6 +17092,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Paralysis</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16289,6 +17107,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Polymorph</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16302,6 +17121,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Secrets</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>The wand has 3 charges. While holding it. you can use an action to expend 1 of its charges, and if a secret door or trap is within 30 feet of you, the wand pulses and points at the one nearest to you. The wand regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -16325,6 +17145,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Web</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16348,6 +17169,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of Wonder</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16387,6 +17209,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of the War Mage, +1</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16399,6 +17222,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of the War Mage, +2</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16411,6 +17235,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <name>Wand of the War Mage, +3</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -16434,6 +17259,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16447,6 +17273,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16460,6 +17287,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16473,6 +17301,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -16500,6 +17329,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16517,6 +17347,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16534,6 +17365,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16551,6 +17383,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -16577,6 +17410,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a creature that worships a god of the sea</text>
     <text />
@@ -16618,6 +17452,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Well of Many Worlds</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
     <text>You can use an action to unfold and place the well of many worlds on a solid surface, whereupon it creates a two-way portal to another world or plane of existence. Each time the item opens a portal, the DM decides where it leads. You can use an action to close an open portal by taking hold of the edges of the cloth and folding it up. Once well of many worlds has opened a portal, it can't do so again for 1d8 hours.</text>
@@ -16634,6 +17469,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmgType>B</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a dwarf</text>
     <text />
@@ -16678,6 +17514,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16696,6 +17533,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16714,6 +17552,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -16732,6 +17571,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -16771,6 +17611,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.</text>
@@ -16782,6 +17623,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wind Fan</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While holding this fan, you can use an action to cast the gust of wind spell (save DC 13) from it. Once used, the fan shouldn't be used again until the next dawn. Each time it is used again before then, it has a cumulative 20 percent chance of not working and tearing into useless, nonmagical tatters.</text>
     <text />
@@ -16821,6 +17663,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Winged Boots</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -16832,6 +17675,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wings of Flying</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -16871,6 +17715,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
         <name>Wyrmskull Throne</name>
         <type>W</type>
+        <rarity>Artifact</rarity>
         <text>Rarity: Artifact</text>
         <text />
         <text>Built by dwarven gods and entrusted to the rulers of Shanatar, an ancient dwarven empire. the Wyrmskull Throne was a symbol of dwarven power and pride for ages untold. The throne hovers a foot off the ground and is a massive thing made of polished obsidian with oversized feet—the impaled skulls of four ancient blue dragons. Runes glisten in the carved obsidian winking to life with blue energy when the throne's powers are activated.</text>

--- a/Items/Magic Items.xml
+++ b/Items/Magic Items.xml
@@ -8,6 +8,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -20,6 +21,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -31,6 +33,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -43,6 +46,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -55,6 +59,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -68,6 +73,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -81,6 +87,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -94,6 +101,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -107,6 +115,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -120,6 +129,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -133,6 +143,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -146,6 +157,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -159,6 +171,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -172,6 +185,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -185,6 +199,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -197,6 +212,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -208,6 +224,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -220,6 +237,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -230,6 +248,7 @@
     <type>HA</type>
     <weight>55</weight>
     <ac>16</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -240,6 +259,7 @@
     <type>HA</type>
     <weight>65</weight>
     <ac>18</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -250,6 +270,7 @@
     <type>HA</type>
     <weight>40</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -260,6 +281,7 @@
     <type>HA</type>
     <weight>60</weight>
     <ac>17</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -272,6 +294,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -285,6 +308,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -298,6 +322,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -311,6 +336,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -324,6 +350,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -337,6 +364,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -350,6 +378,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -363,6 +392,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -376,6 +406,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -389,6 +420,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -401,6 +433,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -413,6 +446,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -425,6 +459,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -437,6 +472,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -449,6 +485,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -461,6 +498,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -473,6 +511,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -485,6 +524,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -497,6 +537,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -509,6 +550,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -522,6 +564,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -535,6 +578,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -548,6 +592,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -561,6 +606,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -574,6 +620,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -587,6 +634,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -600,6 +648,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -613,6 +662,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -626,6 +676,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -639,6 +690,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -650,6 +702,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -661,6 +714,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -672,6 +726,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -683,6 +738,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -694,6 +750,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -705,6 +762,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -716,6 +774,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -727,6 +786,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -738,6 +798,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -749,6 +810,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -760,6 +822,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -771,6 +834,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -781,6 +845,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -792,6 +857,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -804,6 +870,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -816,6 +883,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -828,6 +896,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -840,6 +909,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -852,6 +922,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -864,6 +935,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -876,6 +948,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -888,6 +961,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -900,6 +974,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -911,6 +986,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -922,6 +998,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -933,6 +1010,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -944,6 +1022,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -955,6 +1034,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -966,6 +1046,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -977,6 +1058,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -988,6 +1070,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -999,6 +1082,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -1010,6 +1094,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -1024,6 +1109,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1039,6 +1125,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1055,6 +1142,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1075,6 +1163,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1088,6 +1177,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1107,6 +1197,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1124,6 +1215,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1139,6 +1231,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1156,6 +1249,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1176,6 +1270,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1196,6 +1291,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1213,6 +1309,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1229,6 +1326,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1249,6 +1347,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1263,6 +1362,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1277,6 +1377,7 @@
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1293,6 +1394,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1306,6 +1408,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1326,6 +1429,7 @@
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1341,6 +1445,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1356,6 +1461,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1373,6 +1479,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1390,6 +1497,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1407,6 +1515,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1428,6 +1537,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1448,6 +1558,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1462,6 +1573,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1477,6 +1589,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1496,6 +1609,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1508,6 +1622,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1526,6 +1641,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1542,6 +1658,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1556,6 +1673,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1572,6 +1690,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1591,6 +1710,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1610,6 +1730,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1626,6 +1747,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1641,6 +1763,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1660,6 +1783,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1673,6 +1797,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1686,6 +1811,7 @@
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1701,6 +1827,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1713,6 +1840,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1732,6 +1860,7 @@
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1746,6 +1875,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1760,6 +1890,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1776,6 +1907,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1792,6 +1924,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1808,6 +1941,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1828,6 +1962,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1845,6 +1980,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -1858,6 +1994,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -1872,6 +2009,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 slashing damage.</text>
     <text />
@@ -1887,6 +2025,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1901,6 +2040,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1916,6 +2056,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -1931,6 +2072,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -1941,6 +2083,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -1952,6 +2095,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -1963,6 +2107,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.</text>
     <text />
@@ -1974,6 +2119,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.</text>
@@ -1988,6 +2134,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.</text>
@@ -2002,6 +2149,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -2015,6 +2163,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2026,6 +2175,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2037,6 +2187,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2048,6 +2199,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2059,6 +2211,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2070,6 +2223,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2081,6 +2235,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2092,6 +2247,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2103,6 +2259,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2114,6 +2271,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2126,6 +2284,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.</text>
@@ -2139,6 +2298,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2150,6 +2310,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2161,6 +2322,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2172,6 +2334,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2183,6 +2346,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2194,6 +2358,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2205,6 +2370,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2216,6 +2382,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2227,6 +2394,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2238,6 +2406,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2250,6 +2419,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.</text>
@@ -2264,6 +2434,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -2278,6 +2449,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to poison damage.</text>
@@ -2292,6 +2464,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2304,6 +2477,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2316,6 +2490,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2328,6 +2503,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2340,6 +2516,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2352,6 +2529,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2364,6 +2542,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2376,6 +2555,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2388,6 +2568,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2400,6 +2581,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2411,6 +2593,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2422,6 +2605,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2433,6 +2617,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2444,6 +2629,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2455,6 +2641,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2466,6 +2653,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2477,6 +2665,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2488,6 +2677,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2499,6 +2689,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2510,6 +2701,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2521,6 +2713,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -2531,6 +2724,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -2542,6 +2736,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -2552,6 +2747,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -2563,6 +2759,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs.</text>
     <text />
@@ -2573,6 +2770,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -2583,6 +2781,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -2593,6 +2792,7 @@
     <type>MA</type>
     <weight>40</weight>
     <ac>15</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -2603,6 +2803,7 @@
     <type>MA</type>
     <weight>45</weight>
     <ac>14</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
     <text />
@@ -2614,6 +2815,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.</text>
@@ -2628,6 +2830,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to acid damage while you wear this armor.</text>
@@ -2640,6 +2843,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to cold damage while you wear this armor.</text>
@@ -2652,6 +2856,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to fire damage while you wear this armor.</text>
@@ -2664,6 +2869,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to force damage while you wear this armor.</text>
@@ -2676,6 +2882,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to lightning damage while you wear this armor.</text>
@@ -2688,6 +2895,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to necrotic damage while you wear this armor.</text>
@@ -2700,6 +2908,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to poison damage while you wear this armor.</text>
@@ -2712,6 +2921,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to psychic damage while you wear this armor.</text>
@@ -2724,6 +2934,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to radiant damage while you wear this armor.</text>
@@ -2736,6 +2947,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to thunder damage while you wear this armor.</text>
@@ -2748,6 +2960,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.</text>
@@ -2762,6 +2975,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	Dragon scale mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them to humanoids. Other times, hunters carefully skin and preserve the hide of a dead dragon. In either case, dragon scale mail is highly valued. While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.</text>
@@ -2778,6 +2992,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2799,6 +3014,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2819,6 +3035,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2842,6 +3059,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2867,6 +3085,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2890,6 +3109,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2912,6 +3132,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2930,6 +3151,7 @@
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2951,6 +3173,7 @@
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when incapacitated by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins.</text>
@@ -2970,6 +3193,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -2990,6 +3214,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -3009,6 +3234,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -3031,6 +3257,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -3055,6 +3282,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -3077,6 +3305,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -3099,6 +3328,7 @@
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 piercing damage.</text>
     <text />
@@ -3119,6 +3349,7 @@
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	When you roll a 20 with this magic weapon, the target takes an extra 7 bludgeoning damage.</text>
     <text />
@@ -3133,6 +3364,7 @@
     <name>Arrows +1</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3144,6 +3376,7 @@
     <name>Arrows +2</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3155,6 +3388,7 @@
     <name>Arrows +3</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3166,6 +3400,7 @@
     <name>Blowgun Needles +1</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3177,6 +3412,7 @@
     <name>Blowgun Needles +2</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3188,6 +3424,7 @@
     <name>Blowgun Needles +3</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3199,6 +3436,7 @@
     <name>Crossbow Bolts +1</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3210,6 +3448,7 @@
     <name>Crossbow Bolts +2</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3221,6 +3460,7 @@
     <name>Crossbow Bolts +3</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3232,6 +3472,7 @@
     <name>Sling Bullets +1</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3243,6 +3484,7 @@
     <name>Sling Bullets +2</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3254,6 +3496,7 @@
     <name>Sling Bullets +3</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.</text>
     <text />
@@ -3268,6 +3511,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -3281,6 +3525,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -3294,6 +3539,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -3307,6 +3553,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -3320,6 +3567,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -3333,6 +3581,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -3345,6 +3594,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -3357,6 +3607,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -3369,6 +3620,7 @@
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -3382,6 +3634,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -3395,6 +3648,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -3408,6 +3662,7 @@
     <ac>17</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -3419,6 +3674,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -3430,6 +3686,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -3441,6 +3698,7 @@
     <type>LA</type>
     <weight>10</weight>
     <ac>11</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -3453,6 +3711,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -3465,6 +3724,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -3477,6 +3737,7 @@
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -3488,6 +3749,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -3499,6 +3761,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -3510,6 +3773,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>12</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -3524,6 +3788,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3541,6 +3806,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3558,6 +3824,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3574,6 +3841,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3590,6 +3858,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3606,6 +3875,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <property>L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3623,6 +3893,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3646,6 +3917,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3669,6 +3941,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3690,6 +3963,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3703,6 +3977,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3716,6 +3991,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3730,6 +4006,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3750,6 +4027,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3770,6 +4048,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3790,6 +4069,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3808,6 +4088,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3826,6 +4107,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3844,6 +4126,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3860,6 +4143,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3876,6 +4160,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
     <property>2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3892,6 +4177,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3910,6 +4196,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3928,6 +4215,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3946,6 +4234,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3966,6 +4255,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -3986,6 +4276,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4007,6 +4298,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4028,6 +4320,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4049,6 +4342,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4070,6 +4364,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4089,6 +4384,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4108,6 +4404,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4126,6 +4423,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4142,6 +4440,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4158,6 +4457,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
     <property>R,S</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4175,6 +4475,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4196,6 +4497,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4217,6 +4519,7 @@
     <dmgType>B</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4238,6 +4541,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4255,6 +4559,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4272,6 +4577,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4287,6 +4593,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4300,6 +4607,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4313,6 +4621,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4327,6 +4636,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4345,6 +4655,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4363,6 +4674,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4380,6 +4692,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4393,6 +4706,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4406,6 +4720,7 @@
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4420,6 +4735,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4440,6 +4756,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4460,6 +4777,7 @@
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
     <property>H,R,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4481,6 +4799,7 @@
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4498,6 +4817,7 @@
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4515,6 +4835,7 @@
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4531,6 +4852,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4547,6 +4869,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4563,6 +4886,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4579,6 +4903,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4597,6 +4922,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4615,6 +4941,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4633,6 +4960,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4651,6 +4979,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4669,6 +4998,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4687,6 +5017,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4703,6 +5034,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4719,6 +5051,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4737,6 +5070,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4759,6 +5093,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4781,6 +5116,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4803,6 +5139,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4825,6 +5162,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4847,6 +5185,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4866,6 +5205,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4879,6 +5219,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4892,6 +5233,7 @@
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4907,6 +5249,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4924,6 +5267,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4941,6 +5285,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>B</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4957,6 +5302,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4975,6 +5321,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -4993,6 +5340,7 @@
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
     <property>F,R</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5009,6 +5357,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -5020,6 +5369,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -5031,6 +5381,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>14</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -5042,6 +5393,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -5053,6 +5405,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -5064,6 +5417,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -5076,6 +5430,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -5088,6 +5443,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -5100,6 +5456,7 @@
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -5111,6 +5468,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -5122,6 +5480,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -5133,6 +5492,7 @@
     <type>MA</type>
     <weight>12</weight>
     <ac>12</ac>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -5145,6 +5505,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +1 bonus to AC while wearing this armor.</text>
     <text />
@@ -5157,6 +5518,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +2 bonus to AC while wearing this armor.</text>
     <text />
@@ -5169,6 +5531,7 @@
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You have a +3 bonus to AC while wearing this armor.</text>
     <text />
@@ -5183,6 +5546,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5205,6 +5569,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5227,6 +5592,7 @@
     <dmgType>P</dmgType>
     <property>A,LD</property>
     <range>25/100</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5249,6 +5615,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5270,6 +5637,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5291,6 +5659,7 @@
     <dmgType>P</dmgType>
     <property>F,T</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5312,6 +5681,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5336,6 +5706,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5360,6 +5731,7 @@
     <dmgType>P</dmgType>
     <property>A,L,LD</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5384,6 +5756,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5410,6 +5783,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5436,6 +5810,7 @@
     <dmgType>P</dmgType>
     <property>A,H,LD,2H</property>
     <range>100/400</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5462,6 +5837,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5486,6 +5862,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5510,6 +5887,7 @@
     <dmgType>P</dmgType>
     <property>A,LD,2H</property>
     <range>80/320</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5534,6 +5912,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5558,6 +5937,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5582,6 +5962,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5605,6 +5986,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -5625,6 +6007,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -5645,6 +6028,7 @@
     <dmg1>0</dmg1>
     <property>S,T</property>
     <range>5/15</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack rolls made with this weapon.</text>
     <text />
@@ -5666,6 +6050,7 @@
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5688,6 +6073,7 @@
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5710,6 +6096,7 @@
     <dmgType>P</dmgType>
     <property>A,2H</property>
     <range>80/320</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5732,6 +6119,7 @@
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	You have a +1 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5752,6 +6140,7 @@
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You have a +2 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5772,6 +6161,7 @@
     <dmgType>B</dmgType>
     <property>A</property>
     <range>30/120</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	You have a +3 bonus to attack and damage rolls made with this weapon.</text>
     <text />
@@ -5789,6 +6179,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While holding this shield, you have a +1 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -5800,6 +6191,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	While holding this shield, you have a +2 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -5811,6 +6203,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	While holding this shield, you have a +3 bonus to AC. This bonus is in addition to the shield's normal bonus to AC.</text>
     <text />
@@ -5821,6 +6214,7 @@
     <name>Arrow of Slaying</name>
     <type>A</type>
     <weight>0.05</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	An arrow of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both arrows of dragon slaying and arrows of blue dragon slaying. If a creature belonging to the type, race, or group associated with an arrow of slaying takes damage from the arrow, the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once an arrow of slaying deals its extra damage to a creature, it becomes a nonmagical arrow.</text>
@@ -5832,6 +6226,7 @@
     <name>Blowgun Needle of Slaying</name>
     <type>A</type>
     <weight>0.02</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A blowgun needle of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both needles of dragon slaying and needles of blue dragon slaying. If a creature belonging to the type, race, or group associated with a needle of slaying takes damage from the needle the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a needle of slaying deals its extra damage to a creature, it becomes a nonmagical blowgun needle.</text>
@@ -5843,6 +6238,7 @@
     <name>Crossbow Bolt of Slaying</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A crossbow bolt of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both bolts of dragon slaying and bolts of blue dragon slaying. If a creature belonging to the type, race, or group associated with a bolt of slaying takes damage from the bolt the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a bolt of slaying deals its extra damage to a creature, it becomes a nonmagical crossbow bolt.</text>
@@ -5854,6 +6250,7 @@
     <name>Sling Bullet of Slaying</name>
     <type>A</type>
     <weight>0.075</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	A sling bullet of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both bullets of dragon slaying and bullets of blue dragon slaying. If a creature belonging to the type, race, or group associated with a bullet of slaying takes damage from the bullet the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.</text>
     <text>Once a bullet of slaying deals its extra damage to a creature, it becomes a nonmagical sling bullet.</text>
@@ -5868,6 +6265,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You have resistance to nonmagical damage while you wear this armor. Additionally, you can use an action to make yourself immune to nonmagical damage for 10 minutes or until you are no longer wearing the armor. Once this special action is used, it can't be used again until the next dawn.</text>
@@ -5881,6 +6279,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to bludgeoning damage.</text>
@@ -5896,6 +6295,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to piercing damage.</text>
@@ -5911,6 +6311,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you have resistance to slashing damage.</text>
@@ -5926,6 +6327,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you gain a +1 bonus to AC, and you can understand and speak Abyssal. In addition, the armor's clawed gauntlets turn unarmed strikes with your hands into magic weapons that deal slashing damage, with a +1 bonus to attack rolls and damage rolls and a damage die of 1d8.</text>
@@ -5942,6 +6344,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>	While wearing this armor, you gain a +2 bonus to AC. In addition, if an effect moves you against your will along the ground, you can use your reaction to reduce the distance you are moved by up to 10 feet.</text>
     <text />
@@ -5955,6 +6358,7 @@
     <ac>16</ac>
     <strength>13</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	While wearing this armor, you gain a +3 bonus to AC, you are immune to fire damage, and you can understand and speak Primordial. In addition, you can stand on and walk across molten rock as if it were solid ground.</text>
@@ -5969,6 +6373,7 @@
     <ac>18</ac>
     <strength>15</strength>
     <stealth>YES</stealth>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	While you're wearing this armor, you can speak its command word as an action to gain the effect of the etherealness spell, which last for 10 minutes or until you remove the armor or use an action to speak the command word again. This property of the armor can't be used again until the next dawn.</text>
@@ -5980,6 +6385,7 @@
     <type>LA</type>
     <weight>13</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	While wearing this armor, you gain a +1 bonus to AC. You can also use a bonus action to speak the armor's command word and cause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like, including color, style, and accessories, but the armor retains its normal bulk and weight. The illusory appearance last until you use this property again or remove the armor.</text>
     <text />
@@ -5994,6 +6400,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -6014,6 +6421,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -6037,6 +6445,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.</text>
@@ -6062,6 +6471,7 @@
     <dmgType>P</dmgType>
     <property>F,L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>You can use an action to cause thick, black poison to coat the blade. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 poison damage and become poisoned for 1 minute. The dagger can't be used this way again until the next dawn.</text>
@@ -6086,6 +6496,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -6106,6 +6517,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -6123,6 +6535,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -6140,6 +6553,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -6159,6 +6573,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.</text>
@@ -6178,6 +6593,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -6199,6 +6615,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -6217,6 +6634,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -6235,6 +6653,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -6255,6 +6674,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -6275,6 +6695,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -6296,6 +6717,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -6314,6 +6736,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -6332,6 +6755,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -6352,6 +6776,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, "dragon" refers to any creature with the dragon type, including dragon turtles and wyverns.</text>
@@ -6374,6 +6799,7 @@
     <dmgType>B</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Dwarf</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. It has the thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 damage or, if the target is a giant, 2d8 damage. Immediately after the attack, the weapon flies back to your hand.</text>
@@ -6397,6 +6823,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -6416,6 +6843,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -6432,6 +6860,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -6448,6 +6877,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -6466,6 +6896,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You can use a bonus action to speak this magic sword' command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra 2d6 fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword.</text>
@@ -6484,6 +6915,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -6505,6 +6937,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -6523,6 +6956,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -6541,6 +6975,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -6561,6 +6996,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit with an attack using this magic sword, the target takes an extra 1d6 cold damage. In addition, while you hold the sword, you have resistance to fire damage.</text>
@@ -6582,6 +7018,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6600,6 +7037,7 @@
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6620,6 +7058,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6641,6 +7080,7 @@
     <dmgType>S</dmgType>
     <property>L,T</property>
     <range>20/60</range>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6664,6 +7104,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6682,6 +7123,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6700,6 +7142,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6720,6 +7163,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text>When you hit a giant with it, the giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall prone. For the purpose of this weapon, "giant" refers to any creature with the giant type, including ettins and trolls.</text>
@@ -6738,6 +7182,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -6755,6 +7200,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -6774,6 +7220,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -6797,6 +7244,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -6817,6 +7265,7 @@
     <dmg2>2d6</dmg2>
     <dmgType>B</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
     <text />
@@ -6840,6 +7289,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6862,6 +7312,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6881,6 +7332,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6900,6 +7352,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6921,6 +7374,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Paladin</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra 2d10 radiant damage.</text>
@@ -6943,6 +7397,7 @@
     <dmgType>P</dmgType>
     <property>T</property>
     <range>30/120</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This javelin is a magic weapon. When you hurl it and speak its command word, it transforms into a bolt of lightning, forming a line 5 feet wide that extends out from you to a target within 120 feet. Each creature in the line excluding you and the target must make a DC 13 Dexterity saving throw, taking 4d6 lightning damage on a failed save, and half as much damage on a successful one. The lightning bolt turns back into a javelin when it reaches the target. Make a ranged weapon attack against the target. On a hit, the target takes damage from the javelin plus 4d6 lightning damage.</text>
     <text>The javelin's property can't be used again until the next dawn. In the meantime, the javelin can still be used as a magic weapon.</text>
@@ -6962,6 +7417,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -6978,6 +7434,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -6996,6 +7453,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7018,6 +7476,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -7035,6 +7494,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -7060,6 +7520,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -7082,6 +7543,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -7104,6 +7566,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -7128,6 +7591,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. While the sword is on your person, you also gain a +1 bonus to saving throws.</text>
@@ -7151,6 +7615,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you hit a fiend or an undead with this magic weapon, that creature takes an extra 2d6 radiant damage. If the target has 25 hit points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature becomes frightened of you until the end of your next turn.</text>
@@ -7165,6 +7630,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon. The bonus increases to +3 when you use the mace to attack a construct.</text>
     <text>When you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 bludgeoning damage, or an extra 14 bludgeoning damage if it's a construct. If a construct has 25 hit points or fewer after taking this damage, it is destroyed.</text>
@@ -7179,6 +7645,7 @@
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	This magic weapon has 3 charges. While holding it, you can use an action and expend 1 charge to release a wave of terror. Each creature of your choice in a 30-foot radius extending from you must succeed on a DC 15 Wisdom saving throw or become frightened of you for 1 minute. While it is frightened in this way, a creature must spend its turns trying to move as far away from you as it can, and it can't willingly move to a space within 30 feet of you. It also can't take reactions. For its action it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can use the Dodge action. At the end of each of its turns, a creature can repeat the saving throw, ending the effect on itself on a success.</text>
@@ -7194,6 +7661,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7215,6 +7683,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7233,6 +7702,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7251,6 +7721,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7271,6 +7742,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7291,6 +7763,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -7306,6 +7779,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7327,6 +7801,7 @@
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
     <property>F</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -7344,6 +7819,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -7361,6 +7837,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.</text>
@@ -7380,6 +7857,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to attack and damage rolls made with this magic weapon. In addition, you can make one attack with it as a bonus action on each of your turns.</text>
@@ -7399,6 +7877,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7422,6 +7901,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -7441,6 +7921,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.</text>
@@ -7458,6 +7939,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text>	You gain a +1 bonus to attack and damage rolls made with this magic weapon.</text>
@@ -7481,6 +7963,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
     <property>F,L</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.</text>
@@ -7501,6 +7984,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>F,V</property>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	This item appears to be a longsword hilt. While grasping the hilt, you can use a bonus action to cause a blade of pure radiance to spring into existence, or make the blade disappear. While the blade exists, this magic longsword has the finesse property. If you are proficient with shortswords or longswords, you are proficient with the sun blade.</text>
     <text>You gain a +2 bonus to attack and damage rolls made with this weapon, which deals radiant damage instead of slashing damage. When you hit an undead with it, that target takes an extra 1d8 radiant damage.</text>
@@ -7523,6 +8007,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7543,6 +8028,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7563,6 +8049,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7583,6 +8070,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Chaotic Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7603,6 +8091,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7623,6 +8112,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7643,6 +8133,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Good Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7663,6 +8154,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Lawful Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7683,6 +8175,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Neutral Evil Creature)</text>
     <text>	In the world of Greyhawk, only nine of these blades are known to exist. Each is patterned after the legendary sword Fragarach, which is variously translated as "Final Word." Each of the nine swords has its own name and alignment, and each bears a different gem in its pommel.</text>
@@ -7704,6 +8197,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	This trident is a magic weapon. It has 3 charges. While you carry it, you can use an action and expend 1 charge to cast dominate beast (save DC 15) from it on a beast that has an innate swimming speed. The trident regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -7723,6 +8217,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -7745,6 +8240,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -7764,6 +8260,7 @@
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
     <property>F,L</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text>	You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.</text>
@@ -7783,6 +8280,7 @@
     <type>MA</type>
     <weight>20</weight>
     <ac>13</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>	You gain a +1 bonus to AC while you wear this armor. You are considered proficient with this armor even if you lack proficiency with medium armor.</text>
     <text />
@@ -7797,6 +8295,7 @@
     <dmgType>P</dmgType>
     <property>A,H,2H</property>
     <range>150/600</range>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	When you nock an arrow on this bow, it whispers in Elvish, "Swift defeat to my enemies." When you use this weapon to make a ranged attack, you can, as a command phrase, say, "Swift death to you who have wronged me." The target of your attack becomes your sworn enemy until it dies or until dawn seven days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.</text>
@@ -7820,6 +8319,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you can speak its command word as a bonus action to cause it to animate. The shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The shield remains animated for 1 minute, until you use a bonus action to end this effect, or until you are incapacitated or die, at which point the shield falls to the ground or into your hand if you have one free.</text>
@@ -7831,6 +8331,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	You gain a +2 bonus to AC against ranged attacks while you wield this shield. This bonus is in addition to the shield's normal bonus to AC. In addition, whenever an attacker makes a ranged attack against a target within 5 feet of you, you can use your reaction to become the target of the attack instead.</text>
@@ -7842,6 +8343,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>	While holding this shield, you have advantage on initiative rolls and Wisdom (Perception) checks. The shield is emblazoned with a symbol of an eye.</text>
     <text />
@@ -7853,6 +8355,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you have resistance to damage from ranged weapon attacks.</text>
@@ -7866,6 +8369,7 @@
     <type>S</type>
     <weight>6</weight>
     <ac>2</ac>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text>	While holding this shield, you have advantage on saving throws against spells and other magical effects, and spell attacks have disadvantage against you</text>
@@ -7876,6 +8380,7 @@
     <name>Elixir of Health</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, it cures any disease afflicting you, and it removes the blinded, deafened, paralyzed, and poisoned conditions. The clear red liquid has tiny bubbles of light in it.</text>
     <text />
@@ -7885,6 +8390,7 @@
     <name>Oil of Etherealness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Beads of this cloudy gray oil form on the outside of its container and quickly evaporate. The oil can cover a Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the etherealness spell for 1 hour.</text>
     <text />
@@ -7894,6 +8400,7 @@
     <name>Oil of Sharpness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This clear, gelatinous oil sparkles with tiny, ultrathin silver shards. The oil can coat one slashing or piercing weapon or up to 5 pieces of slashing or piercing ammunition. Applying the oil takes 1 minute. For 1 hour, the coated item is magical and has a +3 bonus to attack and damage rolls.</text>
     <text />
@@ -7903,6 +8410,7 @@
     <name>Oil of Slipperiness</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This sticky black unguent is thick and heavy in the container, but it flows quickly when poured. The oil can cover a Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of a freedom of movement spell for 8 hours.</text>
     <text>Alternatively, the oil can be poured on the ground as an action, where it covers a 10-foot square, duplicating the effect of the grease spell in that area for 8 hours.</text>
@@ -7913,6 +8421,7 @@
     <name>Philter of Love</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>The next time you see a creature within 10 minutes after drinking this philter, you become charmed by that creature for 1 hour. If the creature is of a species and gender you are normally attracted to, you regard it as your true love while you are charmed. This potion's rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart.</text>
     <text />
@@ -7922,6 +8431,7 @@
     <name>Potion of Acid Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to acid damage for 1 hour.</text>
     <text />
@@ -7931,6 +8441,7 @@
     <name>Potion of Animal Friendship</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you can cast the animal friendship spell (save DC 13) for 1 hour at will. Agitating this muddy liquid brings little bits into view: a fish scale, a hummingbird tongue, a cat claw, or a squirrel hair.</text>
     <text />
@@ -7940,6 +8451,7 @@
     <name>Potion of Clairvoyance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the clairvoyance spell. An eyeball bobs in this yellowish liquid but vanishes when the potion is opened.</text>
     <text />
@@ -7949,6 +8461,7 @@
     <name>Potion of Climbing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>When you drink this potion, you gain a climbing speed equal to your walking speed for 1 hour. During this time, you have advantage on Strength (Athletics) checks you make to climb. The potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors.</text>
     <text />
@@ -7958,6 +8471,7 @@
     <name>Potion of Cloud Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, your Strength score changes to 27 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a cloud giant.</text>
@@ -7968,6 +8482,7 @@
     <name>Potion of Cold Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to cold damage for 1 hour.</text>
     <text />
@@ -7977,6 +8492,7 @@
     <name>Potion of Diminution</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the "reduce" effect of the enlarge/reduce spell for 1d4 hours (no concentration required). The red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process.</text>
     <text />
@@ -7987,6 +8503,7 @@
     <name>Potion of Fire Breath</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>After drinking this potion, you can use a bonus action to exhale fire at a target within 30 feet of you. The target must make a DC 13 Dexterity saving throw, taking 4d6 fire damage on a failed save, or half as much damage on a successful one. The effect ends after you exhale the fire three times or when 1 hour has passed. This potion's orange liquid flickers, and smoke fills the top of the container and wafts out whenever it is opened.</text>
     <text />
@@ -7997,6 +8514,7 @@
     <name>Potion of Fire Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 25 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a fire giant.</text>
@@ -8007,6 +8525,7 @@
     <name>Potion of Fire Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to fire damage for 1 hour.</text>
     <text />
@@ -8016,6 +8535,7 @@
     <name>Potion of Flying</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, you gain a flying speed equal to your walking speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft. This potion's clear liquid floats at the top of its container and has cloudy white impurities drifting in it.</text>
     <text />
@@ -8025,6 +8545,7 @@
     <name>Potion of Force Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to force damage for 1 hour.</text>
     <text />
@@ -8034,6 +8555,7 @@
     <name>Potion of Frost Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 23 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a frost giant.</text>
@@ -8044,6 +8566,7 @@
     <name>Potion of Gaseous Form</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the gaseous form spell for 1 hour (no concentration required) or until you end the effect as a bonus action. This potion's container seems to hold fog that moves and pours like water.</text>
     <text />
@@ -8053,6 +8576,7 @@
     <name>Potion of Greater Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You regain 4d4 + 4 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -8063,6 +8587,7 @@
     <name>Potion of Growth</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain the "enlarge" effect of the enlarge/reduce spell for 1d4 hours (no concentration required). The red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process.</text>
     <text />
@@ -8073,6 +8598,7 @@
     <name>Potion of Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>You regain 2d4 + 2 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -8083,6 +8609,7 @@
     <name>Potion of Heroism</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>For 1 hour after drinking it, you gain 10 temporary hit points that last for 1 hour. For the same duration, you are under the effect of the bless spell (no concentration required). This blue potion bubbles and steams as if boiling.</text>
     <text />
@@ -8092,6 +8619,7 @@
     <name>Potion of Hill Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, your Strength score changes to 21 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a hill giant.</text>
@@ -8102,6 +8630,7 @@
     <name>Potion of Invisibility</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This potion's container looks empty but feels as though it holds liquid. When you drink it, you become invisible for 1 hour. Anything you wear or carry is invisible with you. The effect ends early if you attack or cast a spell.</text>
     <text />
@@ -8111,6 +8640,7 @@
     <name>Potion of Invulnerability</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>For 1 minute after you drink this potion, you have resistance to all damage. The potion's syrupy liquid looks like liquefied iron.</text>
     <text />
@@ -8120,6 +8650,7 @@
     <name>Potion of Lightning Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to lightning damage for 1 hour.</text>
     <text />
@@ -8129,6 +8660,7 @@
     <name>Potion of Longevity</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, your physical age is reduced by 1d6 + 6 years, to a minimum of 13 years. Each time you subsequently drink a potion of longevity, there is 10 percent cumulative chance that you instead age by 1d6 + 6 years. Suspended in this amber liquid are a scorpion's tail, an adder's fang, a dead spider, and a tiny heart that, against all reason, is still beating. These ingredients vanish when the potion is opened.</text>
     <text />
@@ -8139,6 +8671,7 @@
     <name>Potion of Mind Reading</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, you gain the effect of the detect thoughts spell (save DC 13). The potion's dense, purple liquid has an ovoid cloud of pink floating in it.</text>
     <text />
@@ -8148,6 +8681,7 @@
     <name>Potion of Necrotic Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to necrotic damage for 1 hour.</text>
     <text />
@@ -8157,6 +8691,7 @@
     <name>Potion of Poison</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This concoction looks, smells, and tastes like a potion of healing or other beneficial potion. However, it is actually poison masked by illusion magic. An identify spell reveals its true nature.</text>
     <text>If you drink it, you take 3d6 poison damage, and you must succeed on a DC 13 Constitution saving throw or be poisoned. At the start of each of your turns while you are poisoned in this way, you take 3d6 poison damage. At the end of each of your turns, you can repeat the saving throw. On a successful save, the poison damage you take on your subsequent turns decreases by 1d6. The poison ends when the damage decreases to 0.</text>
@@ -8170,6 +8705,7 @@
     <name>Potion of Poison Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to poison damage for 1 hour.</text>
     <text />
@@ -8179,6 +8715,7 @@
     <name>Potion of Psychic Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to psychic damage for 1 hour.</text>
     <text />
@@ -8188,6 +8725,7 @@
     <name>Potion of Radiant Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to radiant damage for 1 hour.</text>
     <text />
@@ -8197,6 +8735,7 @@
     <name>Potion of Speed</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, you gain resistance to acid damage for 1 hour.</text>
     <text />
@@ -8206,6 +8745,7 @@
     <name>Potion of Stone Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>When you drink this potion, your Strength score changes to 23 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a stone giant.</text>
@@ -8216,6 +8756,7 @@
     <name>Potion of Storm Giant Strength</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>When you drink this potion, your Strength score changes to 29 for 1 hour. The potion has no effect on you if your Strength is equal to or greater than that score.</text>
     <text>This potion's transparent liquid has floating in it a sliver of fingernail from a storm giant.</text>
@@ -8226,6 +8767,7 @@
     <name>Potion of Superior Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You regain 8d4 + 8 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -8236,6 +8778,7 @@
     <name>Potion of Supreme Healing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You regain 10d4 + 20 hit points when you drink this potion.  The potion's red liquid glimmers when agitated.</text>
     <text />
@@ -8246,6 +8789,7 @@
     <name>Potion of Thunder Resistance</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>When you drink this potion, you gain resistance to thunder damage for 1 hour.</text>
     <text />
@@ -8255,6 +8799,7 @@
     <name>Potion of Vitality</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When you drink this potion, it removes any exhaustion you are suffering and cures any disease or poison affecting you. For the next 24 hours, you regain the maximum number of hit points for any Hit Die you spend. The potion's crimson liquid regularly pulses with dull light, calling to mind a heartbeat.</text>
     <text />
@@ -8264,6 +8809,7 @@
     <name>Potion of Water Breathing</name>
     <type>P</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You can breathe underwater for 1 hour after drinking this potion. Its cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it.</text>
     <text />
@@ -8273,6 +8819,7 @@
     <name>Immovable Rod</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This flat iron rod has a button on one end. You can use an action to press the button, which causes the rod to become magically fixed in place. Until you or another creature uses an action to push the button again, the rod doesn't move, even if it is defying gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can use an action to make a DC 30 Strength check, moving the fixed rod up to 10 feet on a success</text>
     <text />
@@ -8282,6 +8829,7 @@
     <name>Rod of Absorption</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8296,6 +8844,7 @@
     <name>Rod of Alertness</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8314,6 +8863,7 @@
     <name>Rod of Lordly Might</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8340,6 +8890,7 @@
     <name>Rod of Resurrection</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Cleric, Druid, or Paladin</text>
     <text />
@@ -8352,6 +8903,7 @@
     <name>Rod of Rulership</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8363,6 +8915,7 @@
     <name>Rod of Security</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>While holding this rod, you can use an action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a paradise that exists in an extraplanar space. You choose the form that the paradise takes. It could be a tranquil garden, lovely glade, cheery tavern, immense palace, tropical island, fantastic carnival, or whatever else you can imagine. Regardless of its nature, the paradise contains enough water and food to sustain its visitors. Everything else that can be interacted with inside the extraplanar space can exist only there. For example, a flower picked from a garden in the paradise disappears if it is taken outside the extraplanar space.</text>
     <text>For each hour spent in the paradise, a visitor regains hit points as if it had spent 1 Hit Die. Also, creatures don't age while in the paradise, although time passes normally. Visitors can remain in the paradise for up to 200 days divided by the number of creatures present (round down).</text>
@@ -8374,6 +8927,7 @@
     <name>Rod of the Pact Keeper, +1</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -8388,6 +8942,7 @@
     <name>Rod of the Pact Keeper, +2</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -8402,6 +8957,7 @@
     <name>Rod of the Pact Keeper, +3</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Warlock</text>
     <text />
@@ -8416,6 +8972,7 @@
     <name>Tentacle Rod</name>
     <type>RD</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8428,6 +8985,7 @@
   <item>
     <name>Ring of Acid Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8438,6 +8996,7 @@
   <item>
     <name>Ring of Air Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8455,6 +9014,7 @@
   <item>
     <name>Ring of Animal Influence</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can use an action to expend 1 of its charges to cast one of the following spells:</text>
     <text>• Animal friendship (save DC 13)</text>
@@ -8467,6 +9027,7 @@
   <item>
     <name>Ring of Cold Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8477,6 +9038,7 @@
   <item>
     <name>Ring of Djinni Summoning</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8489,6 +9051,7 @@
   <item>
     <name>Ring of Earth Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8506,6 +9069,7 @@
   <item>
     <name>Ring of Evasion</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8517,6 +9081,7 @@
   <item>
     <name>Ring of Feather Falling</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8527,6 +9092,7 @@
   <item>
     <name>Ring of Fire Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8543,6 +9109,7 @@
   <item>
     <name>Ring of Fire Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8553,6 +9120,7 @@
   <item>
     <name>Ring of Force Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8563,6 +9131,7 @@
   <item>
     <name>Ring of Free Action</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8573,6 +9142,7 @@
   <item>
     <name>Ring of Invisibility</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8583,6 +9153,7 @@
   <item>
     <name>Ring of Jumping</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -8593,6 +9164,7 @@
   <item>
     <name>Ring of Lightning Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8603,6 +9175,7 @@
   <item>
     <name>Ring of Mind Shielding</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -8615,6 +9188,7 @@
   <item>
     <name>Ring of Necrotic Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8625,6 +9199,7 @@
   <item>
     <name>Ring of Poison Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8635,6 +9210,7 @@
   <item>
     <name>Ring of Protection</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8647,6 +9223,7 @@
   <item>
     <name>Ring of Psychic Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8657,6 +9234,7 @@
   <item>
     <name>Ring of Radiant Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8667,6 +9245,7 @@
   <item>
     <name>Ring of Regeneration</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8678,6 +9257,7 @@
   <item>
     <name>Ring of Shooting Stars</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement Outdoors at Night</text>
     <text />
@@ -8703,6 +9283,7 @@
   <item>
     <name>Ring of Spell Storing</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8715,6 +9296,7 @@
   <item>
     <name>Ring of Spell Turning</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8725,6 +9307,7 @@
   <item>
     <name>Ring of Swimming</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You have a swimming speed of 40 feet while wearing this ring.</text>
     <text />
@@ -8733,6 +9316,7 @@
   <item>
     <name>Ring of Telekinesis</name>
     <type>RG</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8743,6 +9327,7 @@
   <item>
     <name>Ring of the Ram</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8760,6 +9345,7 @@
   <item>
     <name>Ring of Three Wishes</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>While wearing this ring, you can use an action to expend 1 of its 3 charges to cast the wish spell from it. The ring becomes nonmagical when you use the last charge.</text>
     <text />
@@ -8768,6 +9354,7 @@
   <item>
     <name>Ring of Thunder Resistance</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8778,6 +9365,7 @@
   <item>
     <name>Ring of Warmth</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -8788,6 +9376,7 @@
   <item>
     <name>Ring of Water Elemental Command</name>
     <type>RG</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -8804,6 +9393,7 @@
   <item>
     <name>Ring of Water Walking</name>
     <type>RG</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this ring, you can stand on and move across any liquid surface as if it were solid ground.</text>
     <text />
@@ -8812,6 +9402,7 @@
   <item>
     <name>Ring of X-ray Vision</name>
     <type>RG</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -8823,6 +9414,7 @@
   <item>
     <name>Scroll of Protection from Aberrations</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents aberrations from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an aberration would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8831,6 +9423,7 @@
   <item>
     <name>Scroll of Protection from Beasts</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents beasts from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a beast would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8839,6 +9432,7 @@
   <item>
     <name>Scroll of Protection from Celestials</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents celestials from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a celestial would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8847,6 +9441,7 @@
   <item>
     <name>Scroll of Protection from Elementals</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents elementals from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an elemental would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8855,6 +9450,7 @@
   <item>
     <name>Scroll of Protection from Fey</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fey from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fey would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8863,6 +9459,7 @@
   <item>
     <name>Scroll of Protection from Fiends</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fiends from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fiend would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8871,6 +9468,7 @@
   <item>
     <name>Scroll of Protection from Plants</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents plants from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a plant would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8879,6 +9477,7 @@
   <item>
     <name>Scroll of Protection from Undead</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents undead from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an undead would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
     <text />
@@ -8887,6 +9486,7 @@
   <item>
     <name>Spell Scroll (1st Level)</name>
     <type>SC</type>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 11.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8901,6 +9501,7 @@
   <item>
     <name>Spell Scroll (2nd Level)</name>
     <type>SC</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 12.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8915,6 +9516,7 @@
   <item>
     <name>Spell Scroll (3rd Level)</name>
     <type>SC</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 13.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8929,6 +9531,7 @@
   <item>
     <name>Spell Scroll (4th Level)</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 14.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8943,6 +9546,7 @@
   <item>
     <name>Spell Scroll (5th Level)</name>
     <type>SC</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 15.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8957,6 +9561,7 @@
   <item>
     <name>Spell Scroll (6th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 16.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8971,6 +9576,7 @@
   <item>
     <name>Spell Scroll (7th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 17.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8985,6 +9591,7 @@
   <item>
     <name>Spell Scroll (8th Level)</name>
     <type>SC</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 18.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -8999,6 +9606,7 @@
   <item>
     <name>Spell Scroll (9th Level)</name>
     <type>SC</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC is 19.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -9013,6 +9621,7 @@
   <item>
     <name>Spell Scroll (Cantrip)</name>
     <type>SC</type>
+    <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
     <text>If the spell is on your class's spell list but of a higher level than you can normally cast, you must make an ability check using your spellcasting ability to determine whether you cast it successfully. The DC equals 10.  On a failed check, the spell disappears from the scroll with no other effect.</text>
@@ -9028,6 +9637,7 @@
     <name>Staff of Charming</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -9042,6 +9652,7 @@
     <name>Staff of Fire</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -9056,6 +9667,7 @@
     <name>Staff of Frost</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -9070,6 +9682,7 @@
     <name>Staff of Healing</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, or Druid</text>
     <text />
@@ -9083,6 +9696,7 @@
     <name>Staff of Power</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -9112,6 +9726,7 @@
     <name>Staff of Striking</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9128,6 +9743,7 @@
     <name>Staff of Swarming Insects</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -9144,6 +9760,7 @@
     <name>Staff of the Adder</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -9159,6 +9776,7 @@
     <name>Staff of the Magi</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -9186,6 +9804,7 @@
     <name>Staff of the Python</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -9199,6 +9818,7 @@
     <name>Staff of the Woodlands</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Druid</text>
     <text />
@@ -9218,6 +9838,7 @@
     <name>Staff of Thunder and Lightning</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9242,6 +9863,7 @@
     <name>Staff of Withering</name>
     <type>ST</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Cleric, Druid, or Warlock</text>
     <text />
@@ -9256,6 +9878,7 @@
     <name>Alchemy Jug</name>
     <type>W</type>
     <weight>12</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ceramic jug appears to be able to hold a gallon of liquid and weighs 12 pounds whether full or empty. Sloshing sounds can be heard from within the jug when it is shaken, even if the jug is empty.</text>
     <text>You can use an action and name one liquid from the table below to cause the jug to produce the chosen liquid. Afterward, you can uncork the jug as an action and pour that liquid out, up to 2 gallons per minute. The maximum amount of liquid the jug can produce depends on the liquid you named.</text>
@@ -9279,6 +9902,7 @@
     <name>Amulet of Health</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9290,6 +9914,7 @@
     <name>Amulet of Proof Against Detection and Location</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9301,6 +9926,7 @@
     <name>Amulet of the Planes</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9312,6 +9938,7 @@
     <name>Apparatus of Kwalish</name>
     <type>W</type>
     <weight>500</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This item first appears to be a Large sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move either up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.</text>
     <text>The apparatus of Kwalish is a Large object with the following statistics:</text>
@@ -9354,6 +9981,7 @@
     <name>Bag of Beans</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Inside this heavy cloth bag are 3d4 dry beans. The bag weighs 1/2 pound plus 1/4 pound for each bean it contains.</text>
     <text>If you dump the bag's contents out on the ground, they explode in a 10-foot radius, extending from the beans. Each creature in the area, including you, must make a DC 15 Dexterity saving throw, taking 5d4 fire damage on a failed save, or half as much damage on a successful one. The fire ignites flammable objects in the area that aren't being worn or carried.</text>
@@ -9381,6 +10009,7 @@
     <name>Bag of Devouring</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This bag superficially resembles a bag of holding but is a feeding orifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.</text>
     <text>The extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can use its action to try to escape with a successful DC 15 Strength check. Another creature can use its action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength check (provided it isn't pulled inside the bag first). Any creature that starts its turn inside the bag is devoured, its body destroyed.</text>
@@ -9393,6 +10022,7 @@
     <name>Bag of Holding</name>
     <type>W</type>
     <weight>15</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This bag has an interior space considerably larger than its outside dimensions, roughly 2 feet in diameter at the mouth and 4 feet deep. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 15 pounds, regardless of its contents. Retrieving an item from the bag requires an action.</text>
     <text>If the bag is overloaded, pierced, or torn, it ruptures and is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth, unharmed, but the bag must be put right before it can be used again. Breathing creatures inside the bag can survive up to a number of minutes equal to 10 divided by the number of creatures (minimum 1 minute), after which time they begin to suffocate.</text>
@@ -9404,6 +10034,7 @@
     <name>Bag of Tricks, Gray</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from gray cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics. The creature vanishes at the next dawn or when it is reduced to 0 hit points.</text>
@@ -9427,6 +10058,7 @@
     <name>Bag of Tricks, Rust</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from rust cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics.</text>
@@ -9451,6 +10083,7 @@
     <name>Bag of Tricks, Tan</name>
     <type>W</type>
     <weight>0.5</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This ordinary bag, made from tan cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.</text>
     <text>You can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color. See the Monster Manual for the creature's statistics.</text>
@@ -9474,6 +10107,7 @@
     <name>Bead of Force</name>
     <type>W</type>
     <weight>0.0625</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 beads of force are found together.</text>
     <text>You can use an action to throw the bead up to 60 feet. The bead explodes on impact and is destroyed. Each creature within a 10-foot radius of where the bead landed must succeed on a DC 15 Dexterity saving throw or take 5d4 force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save, or are partially within the area, are pushed away from the center of the sphere until they are no longer inside it. Only breathable air can pass through the sphere's wall. No attack or other effect can.</text>
@@ -9485,6 +10119,7 @@
   <item>
     <name>Belt of Cloud Giant Strength</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -9495,6 +10130,7 @@
   <item>
     <name>Belt of Dwarvenkind</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9513,6 +10149,7 @@
   <item>
     <name>Belt of Fire Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9523,6 +10160,7 @@
   <item>
     <name>Belt of Frost Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9533,6 +10171,7 @@
   <item>
     <name>Belt of Hill Giant Strength</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9543,6 +10182,7 @@
   <item>
     <name>Belt of Stone Giant Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9553,6 +10193,7 @@
   <item>
     <name>Belt of Storm Giant Strength</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -9563,6 +10204,7 @@
   <item>
     <name>Boots of Elvenkind</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have advantage on Dexterity (Stealth) checks that rely on moving silently.</text>
     <text />
@@ -9571,6 +10213,7 @@
   <item>
     <name>Boots of Levitation</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9581,6 +10224,7 @@
   <item>
     <name>Boots of Speed</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9592,6 +10236,7 @@
   <item>
     <name>Boots of Striding and Springing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9602,6 +10247,7 @@
   <item>
     <name>Boots of the Winterlands</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9616,6 +10262,7 @@
     <name>Bowl of Commanding Water Elementals</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While this bowl is filled with water, you can use an action to speak the bowl's command word and summon a water elemental, as if you had cast the conjure elemental spell. The bowl can't be used this way again until the next dawn.</text>
     <text>The bowl is about 1 foot in diameter and half as deep. It weighs 3 pounds and holds about 3 gallons.</text>
@@ -9625,6 +10272,7 @@
   <item>
     <name>Bracers of Archery</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9635,6 +10283,7 @@
   <item>
     <name>Bracers of Defense</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9647,6 +10296,7 @@
     <name>Brazier of Commanding Fire Elementals</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While a fire burns in this brass brazier, you can use an action to speak the brazier's command word and summon a fire elemental, as if you had cast the conjure elemental spell. The brazier can't be used this way again until the next dawn.</text>
     <text>The brazier weighs 5 pounds.</text>
@@ -9656,6 +10306,7 @@
   <item>
     <name>Brooch of Shielding</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9667,6 +10318,7 @@
     <name>Broom of Flying</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wooden broom, which weighs 3 pounds, functions like a mundane broom until you stand astride it and speak its command word. It then hovers beneath you and can be ridden in the air. It has a flying speed of 50 feet. It can carry up to 400 pounds, but its flying speed becomes 30 feet while carrying over 200 pounds. The broom stops hovering when you land.</text>
     <text>You can send the broom to travel alone to a destination within 1 mile of you if you speak the command word, name the location, and are familiar with that place. The broom comes back to you when you speak another command word, provided that the broom is still within 1 mile of you.</text>
@@ -9676,6 +10328,7 @@
   <item>
     <name>Candle of Invocation</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9701,6 +10354,7 @@
   <item>
     <name>Cap of Water Breathing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cap underwater, you can speak its command word as an action to create a bubble of air around your head. It allows you to breathe normally underwater. This bubble stays with you until you speak the command word again, the cap is removed, or you are no longer underwater.</text>
     <text />
@@ -9709,6 +10363,7 @@
   <item>
     <name>Cape of the Mountebank</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This cape smells faintly of brimstone. While wearing it, you can use it to cast the dimension door spell as an action. This property of the cape can't be used again until the next dawn.</text>
     <text>When you disappear, you leave behind a cloud of smoke, and you appear in a similar cloud of smoke at your destination. The smoke lightly obscures the space you left and the space you appear in, and it dissipates at the end of your next turn. A light or stronger wind disperses the smoke.</text>
@@ -9718,6 +10373,7 @@
   <item>
     <name>Carpet of Flying, 3 ft. x 5 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 3 ft. x 5 ft. carpet can carry up to 200 lb. at a fly speed of 80 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -9727,6 +10383,7 @@
   <item>
     <name>Carpet of Flying, 4 ft. x 6 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 4 ft. x 6 ft. carpet can carry up to 400 lb. at a fly speed of 60 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -9736,6 +10393,7 @@
   <item>
     <name>Carpet of Flying, 5 ft. x 7 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 5 ft. x 7 ft. carpet can carry up to 600 lb. at a fly speed of 40 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -9745,6 +10403,7 @@
   <item>
     <name>Carpet of Flying, 6 ft. x 9 ft.</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
     <text>A 6 ft. x 9 ft. carpet can carry up to 800 lb. at a fly speed of 30 feet.  A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.</text>
@@ -9755,6 +10414,7 @@
     <name>Censer of Controlling Air Elementals</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>While incense is burning in this censer, you can use an action to speak the censer's command word and summon an air elemental, as if you had cast the conjure elemental spell. The censer can't be used this way again until the next dawn.</text>
     <text>This 6-inch-wide, 1-foot-high vessel resembles a chalice with a decorated lid. It weighs 1 pound.</text>
@@ -9765,6 +10425,7 @@
     <name>Chime of Opening</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This hollow metal tube measures about 1 foot long and weighs 1 pound. You can strike it as an action, pointing it at an object within 120 feet of you that can be opened, such as a door, lid, or lock. The chime issues a clear tone, and one lock or latch on the object opens unless the sound can't reach the object. If no locks or latches remain, the object itself opens.</text>
     <text>The chime can be used ten times. After the tenth time it cracks and becomes useless.</text>
@@ -9774,6 +10435,7 @@
   <item>
     <name>Circlet of Blasting</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this circlet, you can use an action to cast the scorching ray spell with it. When you make the spell's attacks, you do so with an attack bonus of +5. The circlet can't be used this way again until the next dawn.</text>
     <text />
@@ -9783,6 +10445,7 @@
   <item>
     <name>Cloak of Arachnida</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9798,6 +10461,7 @@
   <item>
     <name>Cloak of Displacement</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9808,6 +10472,7 @@
   <item>
     <name>Cloak of Elvenkind</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9818,6 +10483,7 @@
   <item>
     <name>Cloak of Invisibility</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -9828,6 +10494,7 @@
   <item>
     <name>Cloak of Protection</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -9840,6 +10507,7 @@
   <item>
     <name>Cloak of the Bat</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9851,6 +10519,7 @@
   <item>
     <name>Cloak of the Manta Ray</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cloak with its hood up, you can breathe underwater, and you have a swimming speed of 60 feet. Pulling the hood up or down requires an action.</text>
     <text />
@@ -9860,6 +10529,7 @@
     <name>Crystal Ball</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9871,6 +10541,7 @@
     <name>Crystal Ball of Mind Reading</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -9883,6 +10554,7 @@
     <name>Crystal Ball of Telepathy</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -9895,6 +10567,7 @@
     <name>Crystal Ball of True Seeing</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -9906,6 +10579,7 @@
   <item>
     <name>Cube of Force</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -9936,6 +10610,7 @@
   <item>
     <name>Cubic Gate</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the DM.</text>
     <text>You can use an action to press one side of the cube to cast the gate spell with it, opening a portal to the plane keyed to that side. Alternatively, if you use an action to press one side twice, you can cast the plane shift spell (save DC 17) with the cube and transport the targets to the plane keyed to that side.</text>
@@ -9947,6 +10622,7 @@
   <item>
     <name>Daern's Instant Fortress</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place this 1-inch metal cube on the ground and speak its command word. The cube rapidly grows into a fortress that remains until you use an action to speak the command word that dismisses it, which works only if the fortress is empty.</text>
     <text>The fortress is a square tower, 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors. with a ladder running along one wall to connect them. The ladder ends at a trapdoor leading to the roof. When activated, the tower has a small door on the side facing you. The door opens only at your command, which you can speak as a bonus action. It is immune to the knock spell and similar magic, such as that of a chime of opening.</text>
@@ -9960,6 +10636,7 @@
     <name>Decanter of Endless Water</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This stoppered flask sloshes when shaken, as if it contains water. The decanter weighs 2 pounds.</text>
     <text>You can use an action to remove the stopper and speak one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following options:</text>
@@ -9973,6 +10650,7 @@
   <item>
     <name>Deck of Illusions</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This box contains a set of parchment cards. A full deck has 34 cards. A deck found as treasure is usually missing 1d20 - 1 cards.</text>
     <text>The magic of the deck functions only if cards are drawn at random (you can use an altered deck of playing cards to simulate the deck). You can use an action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of you.</text>
@@ -10019,6 +10697,7 @@
   <item>
     <name>Deck of Many Things</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have only thirteen cards, but the rest have twenty-two.</text>
     <text>Before you draw a card, you must declare how many cards you intend to draw and then draw them randomly (you can use an altered deck of playing cards to simulate the deck). Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.</text>
@@ -10077,6 +10756,7 @@
   <item>
     <name>Dimensional Shackles</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place these shackles on an incapacitated creature. The shackles adjust to fit a creature of Small to Large size. In addition to serving as mundane manacles, the shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing-through an interdimensional portal.</text>
     <text>You and any creature you designate when you use the shackles can use an action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength Athletics) check. On a success, the creature breaks free and destroys the shackles.</text>
@@ -10087,6 +10767,7 @@
     <name>Driftglobe</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small sphere of thick glass weighs 1 pound. If you are within 60 feet of it, you can speak its command word and cause it to emanate the light or daylight spell. Once used, the daylight effect can't be used again until the next dawn.</text>
     <text>You can speak another command word as an action to make the illuminated globe rise into the air and float no more than 5 feet off the ground. The globe hovers in this way until you or another creature grasps it. If you move more than 60 feet from the hovering globe, it follows you until it is within 60 feet of you. It takes the shortest route to do so. If prevented from moving, the globe sinks gently to the ground and becomes inactive, and its light winks out.</text>
@@ -10096,6 +10777,7 @@
   <item>
     <name>Dust of Disappearance</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small packet, this powder resembles very fine sand. There is enough of it for one use. When you use an action to throw the dust into the air, you and each creature and object within 10 feet of you become invisible for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. If a creature affected by the dust attacks or casts a spell, the invisibility ends for that creature.</text>
     <text />
@@ -10104,6 +10786,7 @@
   <item>
     <name>Dust of Dryness</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small packet contains 1d6 + 4 pinches of dust. You can use an action to sprinkle a pinch of it over water. The dust turns a cube of water 15 feet on a side into one marble-sized pellet, which floats or rests near where the dust was sprinkled. The pellet's weight is negligible.</text>
     <text>Someone can use an action to smash the pellet against a hard surface, causing the pellet to shatter and release the water the dust absorbed. Doing so ends that pellet's magic.</text>
@@ -10115,6 +10798,7 @@
   <item>
     <name>Dust of Sneezing and Choking</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small container, this powder resembles very fine sand. It appears to be dust of disappearance, and an identify spell reveals it to be such. There is enough of it for one use.</text>
     <text>When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The lesser restoration spell can also end the effect on a creature.</text>
@@ -10125,6 +10809,7 @@
     <name>Efreeti Bottle</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This painted brass bottle weighs 1 pound. When you use an action to remove the stopper, a cloud of thick smoke flows out of the bottle. At the end of your turn, the smoke disappears with a flash of harmless fire, and an efreeti appears in an unoccupied space within 30 feet of you. See the Monster Manual for the efreeti's statistics.</text>
     <text>The first time the bottle is opened, the DM rolls to determine what happens.</text>
@@ -10139,6 +10824,7 @@
   <item>
     <name>Elemental Gem, Blue Sapphire</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, an air elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
@@ -10169,6 +10855,7 @@
     <name>Eversmoking Bottle</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Smoke leaks from the lead-stoppered mouth of this brass bottle, which weighs 1 pound. When you use an action to remove the stopper, a cloud of thick smoke pours out in a 60-foot radius from the bottle. The cloud's area is heavily obscured. Each minute the bottle remains open and within the cloud, the radius increases by 10 feet until it reaches its maximum radius of 120 feet.</text>
     <text>The cloud persists as long as the bottle is open. Closing the bottle requires you to speak its command word as an action. Once the bottle is closed, the cloud disperses after 10 minutes. A moderate wind (11 to 20 miles per hour) can also disperse the smoke after 1 minute, and a strong wind (21 or more miles per hour) can do so after 1 round.</text>
@@ -10178,6 +10865,7 @@
   <item>
     <name>Eyes of Charming</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10188,6 +10876,7 @@
   <item>
     <name>Eyes of Minute Seeing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These crystal lenses fit over the eyes. While wearing them, you can see much better than normal out to a range of 1 foot. You have advantage on Intelligence (Investigation) checks that rely on sight while searching an area or studying an object within that range.</text>
     <text />
@@ -10196,6 +10885,7 @@
   <item>
     <name>Eyes of the Eagle</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10206,6 +10896,7 @@
   <item>
     <name>Figurine of Wondrous Power, Bronze Griffon</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics.</text>
@@ -10219,6 +10910,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ebony Fly</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -10232,6 +10924,7 @@
   <item>
     <name>Figurine of Wondrous Power, Golden Lions</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics.</text>
@@ -10245,6 +10938,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ivory Goats</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -10261,6 +10955,7 @@
   <item>
     <name>Figurine of Wondrous Power, Marble Elephant</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -10274,6 +10969,7 @@
   <item>
     <name>Figurine of Wondrous Power, Obsidian Steed</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -10288,6 +10984,7 @@
   <item>
     <name>Figurine of Wondrous Power, Onyx Dog</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -10301,6 +10998,7 @@
   <item>
     <name>Figurine of Wondrous Power, Serpentine Owl</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -10314,6 +11012,7 @@
   <item>
     <name>Figurine of Wondrous Power, Silver Raven</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
     <text>The creature is friendly to you and your companions. It understands your languages and obeys your spoken commands. If you issue no commands, the creature defends itself but takes no other actions. See the Monster Manual for the creature's statistics, except for the giant fly.</text>
@@ -10328,6 +11027,7 @@
     <name>Folding Boat</name>
     <type>W</type>
     <weight>4</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep. It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring you to use an action to speak it.</text>
     <text>One command word causes the box to unfold into a boat 10 feet long, 4 feet wide, and 2 feet deep. The boat has one pair of oars, an anchor, a mast, and a lateen sail. The boat can hold up to four Medium creatures comfortably.</text>
@@ -10340,6 +11040,7 @@
   <item>
     <name>Gauntlets of Ogre Power</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10351,6 +11052,7 @@
     <name>Gem of Brightness</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This prism has 50 charges. While you are holding it, you can use an action to speak one of three command words to cause one of the following effects:</text>
     <text>• The first command word causes the gem to shed bright light in a 30-foot radius and dim light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you use a bonus action to repeat the command word or until you use another function of the gem.</text>
@@ -10364,6 +11066,7 @@
     <name>Gem of Seeing</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10376,6 +11079,7 @@
   <item>
     <name>Gloves of Missile Snaring</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10387,6 +11091,7 @@
   <item>
     <name>Gloves of Swimming and Climbing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10397,6 +11102,7 @@
   <item>
     <name>Gloves of Thievery</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These gloves are invisible while worn. While wearing them, you gain a +5 bonus to Dexterity (Sleight of Hand) checks and Dexterity checks made to pick locks.</text>
     <text />
@@ -10405,6 +11111,7 @@
   <item>
     <name>Goggles of Night</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing these dark lenses, you have darkvision out to a range of 60 feet. If you already have darkvision. wearing the goggles increases its range by 60 feet.</text>
     <text />
@@ -10413,6 +11120,7 @@
   <item>
     <name>Hat of Disguise</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10423,6 +11131,7 @@
   <item>
     <name>Headband of Intellect</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10433,6 +11142,7 @@
   <item>
     <name>Helm of Brilliance</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10450,6 +11160,7 @@
   <item>
     <name>Helm of Comprehending Languages</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this helm, you can use an action to cast the comprehend languages spell from it at will.</text>
     <text />
@@ -10458,6 +11169,7 @@
   <item>
     <name>Helm of Telepathy</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -10469,6 +11181,7 @@
   <item>
     <name>Helm of Teleportation</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10481,6 +11194,7 @@
     <name>Heward's Handy Haversack</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 20 pounds of material, not exceeding a volume of 2 cubic feet. The large central pouch can hold up to 8 cubic feet or 80 pounds of material. The backpack always weighs 5 pounds, regardless of its contents.</text>
     <text>Placing an object in the haversack follows the normal rules for interacting with objects. Retrieving an item from the haversack requires you to use an action. When you reach into the haversack for a specific item, the item is always magically on top.</text>
@@ -10493,6 +11207,7 @@
     <name>Horn of Blasting</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to speak the horn's command word and then blow the horn, which emits a thunderous blast in a 30-foot cone that is audible 600 feet away. Each creature in the cone must make a DC 15 Constitution saving throw. On a failed save, a creature takes 5d6 thunder damage and is deafened for 1 minute. On a successful save, a creature takes half as much damage and isn't deafened. Creatures and objects made of glass or crystal have disadvantage on the saving throw and take 10d6 thunder damage instead of 5d6.</text>
     <text>Each use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 fire damage to the blower and destroys the horn.</text>
@@ -10504,6 +11219,7 @@
     <name>Horn of Valhalla, Brass</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>A brass horn summons 3d4 + 3 berserkers.  To use the brass horn, you must be proficient with all simple weapons.</text>
@@ -10516,6 +11232,7 @@
     <name>Horn of Valhalla, Bronze</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>A bronze horn summons 4d4 + 4 berserkers.  To use the bronze horn, you must be proficient with medium armor.</text>
@@ -10528,6 +11245,7 @@
     <name>Horn of Valhalla, Iron</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>The iron horn summons 5d4 + 5 berserkers.  To use the iron horn, you must be proficient with all martial weapons.</text>
@@ -10540,6 +11258,7 @@
     <name>Horn of Valhalla, Silver</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to blow this horn. In response, warrior spirits from the plane of Ysgard appear within 60 feet of you. These spirits use the berserker statistics from the Monster Manual. They return to Ysgard after 1 hour or when they drop to 0 hit points. Once you use the horn, it can't be used again until 7 days have passed.</text>
     <text>The silver horn summons 2d4 + 2 berserkers.</text>
@@ -10551,6 +11270,7 @@
   <item>
     <name>Horseshoes of a Zephyr</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above the ground. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores difficult terrain. In addition, the creature can move at normal speed for up to 12 hours a day without suffering exhaustion from a forced march.</text>
     <text />
@@ -10559,6 +11279,7 @@
   <item>
     <name>Horseshoes of Speed</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they increase the creature's walking speed by 30 feet.</text>
     <text />
@@ -10568,6 +11289,7 @@
     <name>Instrument of the Bards, Anstruth Harp</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -10583,6 +11305,7 @@
     <name>Instrument of the Bards, Canaith Mandolin</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -10598,6 +11321,7 @@
     <name>Instrument of the Bards, Cli Lyre</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -10613,6 +11337,7 @@
     <name>Instrument of the Bards, Doss Lute</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -10628,6 +11353,7 @@
     <name>Instrument of the Bards, Fochlucan Bandore</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -10643,6 +11369,7 @@
     <name>Instrument of the Bards, Mac-Fuirmidh Cittern</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -10658,6 +11385,7 @@
     <name>Instrument of the Bards, Ollamh Harp</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Bard</text>
     <text />
@@ -10672,6 +11400,7 @@
   <item>
     <name>Ioun Stone, Absorption</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10688,6 +11417,7 @@
   <item>
     <name>Ioun Stone, Agility</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10704,6 +11434,7 @@
   <item>
     <name>Ioun Stone, Awareness</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10719,6 +11450,7 @@
   <item>
     <name>Ioun Stone, Fortitude</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10735,6 +11467,7 @@
   <item>
     <name>Ioun Stone, Greater Absorption</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -10750,6 +11483,7 @@
   <item>
     <name>Ioun Stone, Insight</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10766,6 +11500,7 @@
   <item>
     <name>Ioun Stone, Intellect</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10782,6 +11517,7 @@
   <item>
     <name>Ioun Stone, Leadership</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10798,6 +11534,7 @@
   <item>
     <name>Ioun Stone, Mastery</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -10814,6 +11551,7 @@
   <item>
     <name>Ioun Stone, Protection</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10830,6 +11568,7 @@
   <item>
     <name>Ioun Stone, Regeneration</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -10845,6 +11584,7 @@
   <item>
     <name>Ioun Stone, Reserve</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10862,6 +11602,7 @@
   <item>
     <name>Ioun Stone, Strength</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10878,6 +11619,7 @@
   <item>
     <name>Ioun Stone, Sustenance</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10894,6 +11636,7 @@
     <name>Iron Bands of Bilarro</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can use an action to speak the command word and throw the sphere at a Huge or smaller creature you can see within 60 feet of you. As the sphere moves through the air, it opens into a tangle of metal bands.</text>
     <text>Make a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your proficiency bonus. On a hit, the target is restrained until you take a bonus action to speak the command word again to release it. Doing so, or missing with the attack, causes the bands to contract and become a sphere once more.</text>
@@ -10906,6 +11649,7 @@
     <name>Iron Flask</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This iron bottle has a brass stopper. You can use an action to speak the flask's command word, targeting a creature that you can see within 60 feet of you. If the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has advantage on the saving throw. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at a time. A creature trapped in the flask doesn't need to breathe, eat, or drink and doesn't age.</text>
     <text>You can use an action to remove the flask's stopper and release the creature the flask contains. The creature is friendly to you and your companions for 1 hour and obeys your commands for that duration. If you give no commands or give it a command that is likely to result in its death, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.</text>
@@ -10948,6 +11692,7 @@
   <item>
     <name>Keoghtom's Ointment</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This glass jar, 3 inches in diameter, contains 1d4 + 1 doses of a thick mixture that smells faintly of aloe. The jar and its contents weigh 1/2 pound.</text>
     <text>As an action, one dose of the ointment can be swallowed or applied to the skin. The creature that receives it regains 2d8 + 2 hit points, ceases to be poisoned, and is cured of any disease.</text>
@@ -10959,6 +11704,7 @@
     <name>Lantern of Revealing</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's bright light. You can use an action to lower the hood, reducing the light to dim light in a 5-foot radius.</text>
     <text />
@@ -10967,6 +11713,7 @@
   <item>
     <name>Mantle of Spell Resistance</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -10978,6 +11725,7 @@
     <name>Manual of Bodily Health</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains health and diet tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -10987,6 +11735,7 @@
     <name>Manual of Clay Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a clay golem, you must spend 30 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 65,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -10997,6 +11746,7 @@
     <name>Manual of Flesh Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a flesh golem, you must spend 60 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 50,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -11007,6 +11757,7 @@
     <name>Manual of Gainful Exercise</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strength score increase- by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -11016,6 +11767,7 @@
     <name>Manual of Iron Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create an iron golem, you must spend 120 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 100,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -11026,6 +11778,7 @@
     <name>Manual of Quickness of Action</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains coordination and balance exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -11035,6 +11788,7 @@
     <name>Manual of Stone Golems</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This tome contains information and incantations necessary to make a particular type of golem. The DM chooses the type or determines it randomly. To decipher and use the manual, you must be a spellcaster with at least two 5th-level spell slots. A creature that can't use a manual of golems and attempts to read it takes 6d6 psychic damage.</text>
     <text>To create a golem, you must spend 90 days, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay 80,000 gp to purchase supplies. Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. It is under your control, and it understands and obeys your spoken commands. See the Monster Manual for its game statistics.</text>
@@ -11045,6 +11799,7 @@
     <name>Medallion of Thoughts</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11057,6 +11812,7 @@
     <name>Mirror of Life Trapping</name>
     <type>W</type>
     <weight>50</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>When this 4-foot-tall mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, 10 hit points, and vulnerability to bludgeoning damage. It shatters and is destroyed when reduced to 0 hit points.</text>
     <text>If the mirror is hanging on a vertical surface and you are within 5 feet of it, you can use an action to speak its command word and activate it. It remains activated until you use an action to speak the command word again.</text>
@@ -11072,6 +11828,7 @@
     <name>Necklace of Adaptation</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11083,6 +11840,7 @@
     <name>Necklace of Fireballs</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This necklace has 1d6 + 3 beads hanging from it. You can use an action to detach a bead and throw it up to 6 feet away. When it reaches the end of its trajectory, the bead detonates as a 3rd-level fireball spell (save DC 15).</text>
     <text>You can hurl multiple beads, or even the whole necklace, as one action. When you do so, increase the level of the fireball by 1 for each bead beyond the first.</text>
@@ -11094,6 +11852,7 @@
     <name>Necklace of Prayer Beads</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Cleric, Druid, or Paladin</text>
     <text />
@@ -11114,6 +11873,7 @@
     <name>Nolzur's Marvelous Pigments</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Typically found in 1d4 pots inside a fine wooden box with a brush (weighing 1 pound in total), these pigments allow you to create three-dimensional objects by painting them in two dimensions. The paint flows from the brush to form the desired object as you concentrate on its image.</text>
     <text>Each pot of paint is sufficient to cover 1,000 square feet of a surface, which lets you create inanimate objects or terrain features-such as a door, a pit, flowers, trees, cells, rooms, or weapons- that are up to 10,000 cubic feet. It takes 10 minutes to cover 100 square feet.</text>
@@ -11126,6 +11886,7 @@
   <item>
     <name>Pearl of Power</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11137,6 +11898,7 @@
     <name>Periapt of Health</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You are immune to contracting any disease while you wear this pendant. If you are already infected with a disease, the effects of the disease are suppressed you while you wear the pendant.</text>
     <text />
@@ -11146,6 +11908,7 @@
     <name>Periapt of Proof Against Poison</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, poisons have no effect on you. You are immune to the poisoned condition and have immunity to poison damage.</text>
     <text />
@@ -11155,6 +11918,7 @@
     <name>Periapt of Wound Closure</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11166,6 +11930,7 @@
     <name>Pipes of Haunting</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You must be proficient with wind instruments to use these pipes. They have 3 charges. You can use an action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature within 30 feet of you that hears you play must succeed on a DC 15 Wisdom saving throw or become frightened of you for 1 minute. If you wish, all creatures in the area that aren't hostile toward you automatically succeed on the saving throw. A creature that fails the saving throw can repeat it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its saving throw is immune to the effect of these pipes for 24 hours. The pipes regain 1d3 expended charges daily at dawn.</text>
     <text />
@@ -11176,6 +11941,7 @@
     <name>Pipes of the Sewers</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11189,6 +11955,7 @@
   <item>
     <name>Portable Hole</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
     <text>You can use an action to unfold a portable hole and place it on or against a solid surface, whereupon the portable hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane, so it can't be used to create open passages. Any creature inside an open portable hole can exit the hole by climbing out of it.</text>
@@ -11201,6 +11968,7 @@
   <item>
     <name>Quaal's Feather Token, Anchor</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11211,6 +11979,7 @@
   <item>
     <name>Quaal's Feather Token, Bird</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11221,6 +11990,7 @@
   <item>
     <name>Quaal's Feather Token, Fan</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11231,6 +12001,7 @@
   <item>
     <name>Quaal's Feather Token, Swan Boat</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11241,6 +12012,7 @@
   <item>
     <name>Quaal's Feather Token, Tree</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11251,6 +12023,7 @@
   <item>
     <name>Quaal's Feather Token, Whip</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
     <text />
@@ -11265,6 +12038,7 @@
     <name>Quiver of Ehlonna</name>
     <type>W</type>
     <weight>2</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to sixty arrows, bolts, or similar objects. The midsize compartment holds up to eighteen javelins or similar objects. The longest compartment holds up to six long objects, such as bows, quarterstaffs, or spears.</text>
     <text>You can draw any item the quiver contains as if doing so from a regular quiver or scabbard.</text>
@@ -11274,6 +12048,7 @@
   <item>
     <name>Robe of Eyes</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11289,6 +12064,7 @@
   <item>
     <name>Robe of Scintillating Colors</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11300,6 +12076,7 @@
   <item>
     <name>Robe of Stars</name>
     <type>W</type>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11314,6 +12091,7 @@
   <item>
     <name>Robe of the Archmagi</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
     <text />
@@ -11332,6 +12110,7 @@
   <item>
     <name>Robe of Useful Items</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This robe has cloth patches of various shapes and colors covering it. While wearing the robe. you can use an action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.</text>
     <text>The robe has two of each of the following patches:</text>
@@ -11364,6 +12143,7 @@
     <name>Rope of Climbing</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This 60-foot length of silk rope weighs 3 pounds and can hold up to 3,000 pounds. If you hold one end of the rope and use an action to speak the command word, the rope animates. As a bonus action, you can command the other end to move toward a destination you choose. That end moves 10 feet on your turn when you first command it and 10 feet on each of your turns until reaching its destination, up to its maximum length away, or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.</text>
     <text>If you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, the rope shortens to a 50-foot length and grants advantage on checks made to climb it.</text>
@@ -11375,6 +12155,7 @@
     <name>Rope of Entanglement</name>
     <type>W</type>
     <weight>3</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This rope is 30 feet long and weighs 3 pounds. If you hold one end of the rope and use an action to speak its command word, the other end darts forward to entangle a creature you can see within 20 feet of you. The target must succeed on a DC 15 Dexterity saving throw or become restrained.</text>
     <text>You can release the creature by using a bonus action to speak a second command word. A target restrained by the rope can use an action to make a DC 15 Strength or Dexterity check (target's choice). On a success, the creature is no longer restrained by the rope.</text>
@@ -11385,6 +12166,7 @@
   <item>
     <name>Saddle of the Cavalier</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While in this saddle on a mount, you can't be dismounted against your will if you're conscious, and attack rolls against the mount have disadvantage.</text>
     <text />
@@ -11393,6 +12175,7 @@
   <item>
     <name>Scarab of Protection</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11405,6 +12188,7 @@
   <item>
     <name>Sending Stones</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Sending stones come in pairs, with each smooth stone carved to match the other so the pairing is easily recognized. While you touch one stone, you can use an action to cast the sending spell from it. The target is the bearer of the other stone. If no creature bears the other stone, you know that fact as soon as you use the stone and don't cast the spell.</text>
     <text>Once sending is cast through the stones, they can't be used again until the next dawn. If one of the stones in a pair is destroyed, the other one becomes nonmagical.</text>
@@ -11414,6 +12198,7 @@
   <item>
     <name>Slippers of Spider Climbing</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11424,6 +12209,7 @@
   <item>
     <name>Sovereign Glue</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with oil of slipperiness. When found, a container contains 1d6 + 1 ounces.</text>
     <text>One ounce of the glue can cover a 1-foot square surface. The glue takes 1 minute to set. Once it has done so, the bond it creates can be broken only by the application of universal solvent or oil of etherealness, or with a wish spell.</text>
@@ -11433,6 +12219,7 @@
   <item>
     <name>Sphere of Annihilation</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.</text>
     <text>The sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an artifact is susceptible to damage from a sphere of annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 4d10 force damage.</text>
@@ -11452,6 +12239,7 @@
     <name>Stone of Controlling Earth Elementals</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>If the stone is touching the ground, you can use an action to speak its command word and summon an earth elemental, as if you had cast the conjure elemental spell. The stone can't be used this way again until the next dawn. The stone weighs 5 pounds.</text>
     <text />
@@ -11460,6 +12248,7 @@
   <item>
     <name>Stone of Good Luck</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11472,6 +12261,7 @@
     <name>Talisman of Pure Good</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Creature of Good Alignment</text>
     <text />
@@ -11487,6 +12277,7 @@
     <name>Talisman of the Sphere</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
     <text />
@@ -11498,6 +12289,7 @@
     <name>Talisman of Ultimate Evil</name>
     <type>W</type>
     <weight>1</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Creature of Evil Alignment</text>
     <text />
@@ -11513,6 +12305,7 @@
     <name>Tome of Clear Thought</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -11522,6 +12315,7 @@
     <name>Tome of Leadership and Influence</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -11531,6 +12325,7 @@
     <name>Tome of the Stilled Tongue</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Wizard</text>
     <text />
@@ -11545,6 +12340,7 @@
     <name>Tome of Understanding</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century.</text>
     <text />
@@ -11553,6 +12349,7 @@
   <item>
     <name>Universal Solvent</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This tube holds milky liquid with a strong alcohol smell. You can use an action to pour the contents of the tube onto a surface within reach. The liquid instantly dissolves up to 1 square foot of adhesive it touches, including sovereign glue.</text>
     <text />
@@ -11561,6 +12358,7 @@
   <item>
     <name>Well of Many Worlds</name>
     <type>W</type>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
     <text>You can use an action to unfold and place the well of many worlds on a solid surface, whereupon it creates a two-way portal to another world or plane of existence. Each time the item opens a portal, the DM decides where it leads. You can use an action to close an open portal by taking hold of the edges of the cloth and folding it up. Once well of many worlds has opened a portal, it can't do so again for 1d8 hours.</text>
@@ -11571,6 +12369,7 @@
   <item>
     <name>Wind Fan</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While holding this fan, you can use an action to cast the gust of wind spell (save DC 13) from it. Once used, the fan shouldn't be used again until the next dawn. Each time it is used again before then, it has a cumulative 20 percent chance of not working and tearing into useless, nonmagical tatters.</text>
     <text />
@@ -11579,6 +12378,7 @@
   <item>
     <name>Winged Boots</name>
     <type>W</type>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
     <text />
@@ -11590,6 +12390,7 @@
   <item>
     <name>Wings of Flying</name>
     <type>W</type>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11602,6 +12403,7 @@
     <name>Wand of Binding</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11617,6 +12419,7 @@
     <name>Wand of Enemy Detection</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11630,6 +12433,7 @@
     <name>Wand of Fear</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
     <text />
@@ -11646,6 +12450,7 @@
     <name>Wand of Fireballs</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11666,6 +12471,7 @@
     <name>Wand of Lightning Bolts</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11686,6 +12492,7 @@
     <name>Wand of Magic Detection</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wand has 3 charges. While holding it, you can expend 1 charge as an action to cast the detect magic spell from it. The wand regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -11696,6 +12503,7 @@
     <name>Wand of Magic Missiles</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This wand has 7 charges. While holding it, you can use an action to expend 1 or more of its charges to cast the magic missile spell from it. For 1 charge, you cast the 1st-level version of the spell. You can increase the spell slot level by one for each additional charge you expend.</text>
     <text>The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed.</text>
@@ -11714,6 +12522,7 @@
     <name>Wand of Paralysis</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11728,6 +12537,7 @@
     <name>Wand of Polymorph</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11741,6 +12551,7 @@
     <name>Wand of Secrets</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>The wand has 3 charges. While holding it. you can use an action to expend 1 of its charges, and if a secret door or trap is within 30 feet of you, the wand pulses and points at the one nearest to you. The wand regains 1d3 expended charges daily at dawn.</text>
     <text />
@@ -11751,6 +12562,7 @@
     <name>Wand of the War Mage, +1</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11763,6 +12575,7 @@
     <name>Wand of the War Mage, +2</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11775,6 +12588,7 @@
     <name>Wand of the War Mage, +3</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11787,6 +12601,7 @@
     <name>Wand of Web</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11800,6 +12615,7 @@
     <name>Wand of Wonder</name>
     <type>WD</type>
     <weight>1</weight>
+    <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement by a Spellcaster</text>
     <text />
@@ -11844,6 +12660,7 @@
     <dmgType>S</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -11876,6 +12693,7 @@
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
     <property>H,2H</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a creature of non-lawful alignment</text>
     <text />
@@ -11906,6 +12724,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by an elf or half-elf of neutral good alignment</text>
     <text />
@@ -11948,6 +12767,7 @@
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
     <property>V</property>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -11981,6 +12801,7 @@
     <dmgType>P</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a creature that worships a god of the sea</text>
     <text />
@@ -12007,6 +12828,7 @@
     <dmgType>B</dmgType>
     <property>T,V</property>
     <range>20/60</range>
+    <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires attunement by a dwarf</text>
     <text />
@@ -12027,6 +12849,7 @@
     <name>Book of Exalted Deeds</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement by a creature of good alignment</text>
     <text />
@@ -12049,6 +12872,7 @@
     <name>Book of Vile Darkness</name>
     <type>W</type>
     <weight>5</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -12079,6 +12903,7 @@
   <item>
     <name>Eye of Vecna</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -12110,6 +12935,7 @@
   <item>
     <name>Hand of Vecna</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -12141,6 +12967,7 @@
   <item>
     <name>Orb of Dragonkind</name>
     <type>W</type>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -12164,6 +12991,7 @@
     <name>Wand of Orcus</name>
     <type>WD</type>
     <weight>4</weight>
+    <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
     <text />
@@ -13231,6 +14059,7 @@
         <name>Banner of the Krig Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>Crafted from a thick, red fabric, this banner measures 5 feet high and 3 feet wide. The krig (war) rune is displayed on the fabric with round, metal plates sewn into it. It can be attached to a 10-foot pole to serve as a standard. Furling or unfurling the banner requires an action. The banner has the following properties.</text>
@@ -13246,6 +14075,7 @@
         <name>Blod Stone</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This diamond contains the blood of a creature—b1ood that appears in the form of the blod (blood) rune. While the item is on your person, you can use your action to divine the location of the creature nearest to you that is related to the blood in the item and that isn’t undead. You sense the distance and direction of the creature relative to your location. The creature is either the one whose blood is in the item or a blood relative.</text>
@@ -13257,6 +14087,7 @@
         <name>Claw of the Wyrm Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This dragon's claw has been covered with a coat of molten silver, upon which has been inscribed the wyrm (dragon) rune. The claw has the following properties.</text>
@@ -13271,6 +14102,7 @@
         <name>Conch of Teleportation</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This item is an ordinary, albeit rather large, conch shell that has been inscribed with the uvar rune. The conch measures 2 1/2 feet long and weighs 20 pounds.</text>
@@ -13282,6 +14114,7 @@
         <name>Gavel of the Venn Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This wooden gavel is small by giant reckoning but nearly the size of a warhammcr in human hands. The venn (friend) rune is inscribed in mithral in the base of the haft. Among giants, this item is used as part of rituals to resolve disputes. The gavel has the following properties.</text>
@@ -13300,6 +14133,7 @@
         <dmgType>S</dmgType>
         <property>H,2H</property>
         <text>This item requires attunement</text>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text>In the Year of the Icy Axe (123 DR), the frost giant lord Gurt fell to Uthgar Gardolfsson—leader of the folk who would become the Uthgardt barbarians—in a battle that marked the ascendance of humankind over the giants in the Dessarin Valley. Gurt’s greataxe was buried in Morgur’s Mound until it was unearthed and brought back to Waterdeep. After laying in the city’s vaults for decades, the axe was given to Harshnag, a frost giant adventurer, in recognition of his service to Waterdeep. Uthgardt barbarians recognize the weapon on sight and attack any giant that wields it.</text>
         <text>You gain a +1 bonus to attack and damage rolls made with this magic weapon. It is sized for a giant, weighs 325 pounds, and deals 3dl2 slashing damage on a hit, plus an extra 2d12 slashing damage if the target is human.</text>
@@ -13314,6 +14148,7 @@
         <name>Ingot of the Skold Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This appears to be a simple ingot of iron ore, about a foot long and a few inches across. Inspection of its surface reveals the faint, silvery outline ofthe skold (shield) rune. The ingot has the following properties, which work only while it's on your person.</text>
@@ -13334,6 +14169,7 @@
         <dmgType>B</dmgType>
         <property>L</property>
         <text>This item requires attunement</text>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
         <text>The Korolnor Scepter is one of ten Ruling Scepters of Shanatar, forged by the dwarven gods and given to the ruling houses of the ancient dwarven empire. The Korolnor Scepter’s location was unknown for the longest time until a storm giant queen, Neri, found it in a barnacle-covered shipwreck at the bottom of the Trackless Sea. The Ruling Scepters are all roughly the same size and shape, but their materials and properties vary.</text>
@@ -13353,6 +14189,7 @@
         <name>Navigation Orb</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>A navigation orb is a hollow, 7-foot-diameter sphere of thin, polished mithral with a large skye (cloud) rune embossed on its outer surface. The orb levitates 10 feet above the ground and is keyed to a particular cloud castle, allowing you to control that castle's altitude and movement while the orb is inside the castle. If the orb is destroyed or removed from its castle, the castle's altitude and location remain ﬁxed until the orb is returned or replaced.</text>
@@ -13368,6 +14205,7 @@
         <name>Opal of the Ild Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This triangular ﬁre opal measures about three inches on each side and is half an inch thick. The ild (ﬁre) rune shimmers within its core, causing it to be slightly warm to the touch. The opal has the following properties, which work only while it’s on your person.</text>
@@ -13384,6 +14222,7 @@
         <name>Orb of the Stein Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>This orb of granite is about the size of an adult human’s ﬁst. The stein (stone) rune appears on it in the form ofcrystalline veins that run across the surface. The orb has the following properties, which work only while it's on your person.</text>
@@ -13401,6 +14240,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
         <name>Pennant of the Vind Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This blue pennant is crafted from silk and is ﬁve feet long and whips about as if buffeted by a wind. The vind (wind) rune appears on its surface, looking almost like a cloud. The pennant has the following properties, which work only while it’s on your person.</text>
@@ -13418,6 +14258,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
         <name>Potion of Giant Size</name>
         <type>P</type>
+        <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
         <text>When you drink this potion, you become Huge for 24 hours if you are Medium or smaller, otherwise the potion does nothing. For that duration, your Strength becomes 25, if it isn't already higher, and your hit point maximum is doubled (your current hit points are doubled when you drink the potion). In addition, the reach of your melee attacks increases by 5 feet.</text>
@@ -13430,6 +14271,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Robe of Serpants</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Uncommon</rarity>
         <text>Rarity: Uncommon</text>
         <text />
         <text>A robe of serpents is a stylish silk garment that is popular among wealthy nobles and retired assassins. The robe is emblazoned with 1d4 + 3 stylized serpents, all brightly colored.</text>
@@ -13441,6 +14283,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Rod of the Vonindod</name>
         <type>RD</type>
         <text>This item requires attunement</text>
+        <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
         <text />
         <text>The ﬁre giant duke Zalto hired a wizard to craft several of these adamantine rods. Each measures 4 feet long, weighs 100 pounds, and is sized to ﬁt comfortably in a ﬁre giant’s hand. The rod has two prongs at one end and a molded handle grip on the opposite end.</text>
@@ -13453,6 +14296,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
         <name>Shard of the Ise Rune</name>
         <type>W</type>
         <text>This item requires attunement</text>
+        <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
         <text />
         <text>This shard of ice is long and slender, roughly the size of a dagger. The ise (ice) rune glows within it. The shard has the following properties, which work only while it’s on your person.</text>
@@ -13469,6 +14313,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
         <name>Wyrmskull Throne</name>
         <type>W</type>
+        <rarity>Artifact</rarity>
         <text>Rarity: Artifact</text>
         <text />
         <text>Built by dwarven gods and entrusted to the rulers of Shanatar, an ancient dwarven empire. the Wyrmskull Throne was a symbol of dwarven power and pride for ages untold. The throne hovers a foot off the ground and is a massive thing made of polished obsidian with oversized feet—the impaled skulls of four ancient blue dragons. Runes glisten in the carved obsidian winking to life with blue energy when the throne's powers are activated.</text>


### PR DESCRIPTION
I've been using the rarity property in my own scripts and figured it might be useful for others as well. Should make it easier to do searching/filtering without doing string manipulations on the item text fields.

I considered removing the rarity from the text description but since the property is new no existing apps use them yet so obviously decided against it.
