### PR TITLE
Updated the magic tags on all items

### DIFF
--- a/Compendiums/Items Compendium.xml
+++ b/Compendiums/Items Compendium.xml
@@ -837,7 +837,7 @@
 		<text />
 		<text>Source: Dungeon Master's Guide, page 135</text>
 	</item>
-<item>
+    <item>
 		<name>7500 GP - Gold cup set with emeralds</name>
 		<type>$</type>
 		<value>7500gp</value>
@@ -916,9 +916,10 @@
 		<text />
 		<text>Source: Player's Handbook, page 148</text>
 	</item>
-	<item>
+  <item>
     <name>Adamantine Breastplate</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -930,6 +931,7 @@
   <item>
     <name>Adamantine Chain Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -943,6 +945,7 @@
   <item>
     <name>Adamantine Chain Shirt</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Uncommon</rarity>
@@ -954,6 +957,7 @@
   <item>
     <name>Adamantine Half Plate Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -966,6 +970,7 @@
   <item>
     <name>Adamantine Plate Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -979,6 +984,7 @@
   <item>
     <name>Adamantine Ring Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -991,6 +997,7 @@
   <item>
     <name>Adamantine Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -1003,6 +1010,7 @@
   <item>
     <name>Adamantine Spiked Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -1013,6 +1021,7 @@
   <item>
     <name>Adamantine Splint Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -1068,6 +1077,7 @@
   <item>
     <name>Amulet of Health</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -1080,6 +1090,7 @@
   <item>
     <name>Amulet of Proof Against Detection and Location</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -1092,6 +1103,7 @@
   <item>
     <name>Amulet of the Planes</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -1104,6 +1116,7 @@
   <item>
     <name>Animated Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Very Rare</rarity>
@@ -1124,6 +1137,7 @@
 	<item>
     <name>Apparatus of Kwalish</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>500</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -1167,6 +1181,7 @@
   <item>
     <name>Armor of Invulnerability</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -1181,6 +1196,7 @@
   <item>
     <name>Armor of Vulnerability (Bludgeoning)</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -1197,6 +1213,7 @@
   <item>
     <name>Armor of Vulnerability (Piercing)</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -1213,6 +1230,7 @@
   <item>
     <name>Armor of Vulnerability (Slashing)</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -1229,6 +1247,7 @@
   <item>
     <name>Arrow of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -1241,6 +1260,7 @@
   <item>
     <name>Arrow-Catching Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Rare</rarity>
@@ -1271,6 +1291,7 @@
 	<item>
     <name>Arrows +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -1283,6 +1304,7 @@
   <item>
     <name>Arrows +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -1295,6 +1317,7 @@
   <item>
     <name>Arrows +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -1317,6 +1340,7 @@
 	<item>
     <name>Axe of the Dwarvish Lords</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1361,6 +1385,7 @@
 	<item>
     <name>Bag of Beans</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -1389,6 +1414,7 @@
   <item>
     <name>Bag of Devouring</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -1402,6 +1428,7 @@
   <item>
     <name>Bag of Holding</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>15</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -1414,6 +1441,7 @@
   <item>
     <name>Bag of Tricks, Gray</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -1438,6 +1466,7 @@
   <item>
     <name>Bag of Tricks, Rust</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -1463,6 +1492,7 @@
   <item>
     <name>Bag of Tricks, Tan</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -1509,6 +1539,7 @@
 	<item>
     <name>Balloon Pack</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This backpack contains the spirit of an air elemental and a compact leather balloon. While you're wearing the backpack, you can deploy the balloon as an action and gain the effect of the levitate spell for 10 minutes, targeting yourself and requiring no concentration. Alternatively, you can use a reaction to deploy the balloon when you're falling and gain the effect of the feather fall spell for yourself.</text>
     <text>When either spell ends, the balloon slowly deflates as the elemental spirit escapes and returns to the Elemental Plane of Air. As the balloon deflates, you descend gently toward the ground for up to 60 feet. IF you are still in the air at the end of this distance, you fall if you have no other means of staying aloft.</text>
     <text>After the spirit departs, the backpack's property is unusable unless the backpack is recharged for 1 hour in an elemental air node, which binds another spirit to the backpack.</text>
@@ -1518,6 +1549,7 @@
   <item>
         <name>Banner of the Krig Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -1573,6 +1605,7 @@
 	<item>
     <name>Battleaxe +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1591,6 +1624,7 @@
   <item>
     <name>Battleaxe +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1609,6 +1643,7 @@
   <item>
     <name>Battleaxe +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1627,6 +1662,7 @@
   <item>
     <name>Battleaxe of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1644,6 +1680,7 @@
   <item>
     <name>Bead of Force</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.0625</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -1670,6 +1707,7 @@
 	<item>
     <name>Belt of Cloud Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -1681,6 +1719,7 @@
   <item>
     <name>Belt of Dwarvenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -1700,6 +1739,7 @@
   <item>
     <name>Belt of Fire Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -1711,6 +1751,7 @@
   <item>
     <name>Belt of Frost Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -1722,6 +1763,7 @@
   <item>
     <name>Belt of Hill Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -1733,6 +1775,7 @@
   <item>
     <name>Belt of Stone Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -1744,6 +1787,7 @@
   <item>
     <name>Belt of Storm Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -1755,6 +1799,7 @@
   <item>
     <name>Berserker Battleaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1777,6 +1822,7 @@
   <item>
     <name>Berserker Greataxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -1800,6 +1846,7 @@
   <item>
     <name>Berserker Handaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -1826,6 +1873,7 @@
   <item>
     <name>Black Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This horned mask of glossy ebony has horns and a skull-like mien. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -1849,6 +1897,7 @@
   <item>
     <name>Black Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -1864,6 +1913,7 @@
   <item>
     <name>Blackrazor</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -1910,6 +1960,7 @@
 	<item>
         <name>Blod Stone</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -1922,6 +1973,7 @@
     <item>
     <name>Blood Spear</name>
     <type>M</type>
+    <magic>1</magic>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
     <dmgType>P</dmgType>
@@ -1957,6 +2009,7 @@
 	<item>
     <name>Blowgun +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -1980,6 +2033,7 @@
   <item>
     <name>Blowgun +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -2003,6 +2057,7 @@
   <item>
     <name>Blowgun +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -2026,6 +2081,7 @@
   <item>
     <name>Blowgun Needle of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -2056,6 +2112,7 @@
 	<item>
     <name>Blowgun Needles +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -2068,6 +2125,7 @@
   <item>
     <name>Blowgun Needles +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -2080,6 +2138,7 @@
   <item>
     <name>Blowgun Needles +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -2092,6 +2151,7 @@
   <item>
     <name>Blowgun of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -2114,6 +2174,7 @@
   <item>
     <name>Blue Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This mask of glossy azure has spikes around its edges and a ridged horn in its center. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -2137,6 +2198,7 @@
   <item>
     <name>Blue Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2161,6 +2223,7 @@
 	<item>
     <name>Book of Exalted Deeds</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
@@ -2184,6 +2247,7 @@
   <item>
     <name>Book of Vile Darkness</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
@@ -2216,6 +2280,7 @@
   <item>
     <name>Boots of Elvenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have advantage on Dexterity (Stealth) checks that rely on moving silently.</text>
@@ -2225,6 +2290,7 @@
   <item>
     <name>Boots of Levitation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -2236,6 +2302,7 @@
   <item>
     <name>Boots of Speed</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -2248,6 +2315,7 @@
   <item>
     <name>Boots of Striding and Springing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -2259,6 +2327,7 @@
   <item>
     <name>Boots of the Winterlands</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -2273,6 +2342,7 @@
   <item>
     <name>Bottled Breath</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <text>This bottle contains a breath of elemental air. When you inhale it, you either exhale it or hold it.</text>
     <text>If you inhale the breath, you gain the effect of the gust of wind spell. If you hold the breath, you don't need to breathe for 1 hour, though you can end this benefit early (for example, to speak). Ending it early doesn't give you the benefit of exhaling the breath.</text>
@@ -2282,6 +2352,7 @@
   <item>
     <name>Bowl of Commanding Water Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -2293,6 +2364,7 @@
   <item>
     <name>Bracers of Archery</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -2304,6 +2376,7 @@
   <item>
     <name>Bracers of Defense</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -2316,6 +2389,7 @@
   <item>
     <name>Brass Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2331,6 +2405,7 @@
   <item>
     <name>Brazier of Commanding Fire Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -2352,6 +2427,7 @@
 	<item>
     <name>Breastplate +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2364,6 +2440,7 @@
   <item>
     <name>Breastplate +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Very Rare</rarity>
@@ -2376,6 +2453,7 @@
   <item>
     <name>Breastplate +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Legendary</rarity>
@@ -2388,6 +2466,7 @@
   <item>
     <name>Breastplate of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2400,6 +2479,7 @@
   <item>
     <name>Breastplate of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2412,6 +2492,7 @@
   <item>
     <name>Breastplate of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2424,6 +2505,7 @@
   <item>
     <name>Breastplate of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2436,6 +2518,7 @@
   <item>
     <name>Breastplate of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2448,6 +2531,7 @@
   <item>
     <name>Breastplate of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2460,6 +2544,7 @@
   <item>
     <name>Breastplate of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2472,6 +2557,7 @@
   <item>
     <name>Breastplate of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2484,6 +2570,7 @@
   <item>
     <name>Breastplate of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2496,6 +2583,7 @@
   <item>
     <name>Breastplate of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2517,6 +2605,7 @@
 	<item>
     <name>Bronze Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2532,6 +2621,7 @@
   <item>
     <name>Brooch of Shielding</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -2543,6 +2633,7 @@
   <item>
     <name>Broom of Flying</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -2655,6 +2746,7 @@
 	<item>
     <name>Candle of Invocation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -2681,6 +2773,7 @@
   <item>
     <name>Cap of Water Breathing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cap underwater, you can speak its command word as an action to create a bubble of air around your head. It allows you to breathe normally underwater. This bubble stays with you until you speak the command word again, the cap is removed, or you are no longer underwater.</text>
@@ -2690,6 +2783,7 @@
   <item>
     <name>Cape of the Mountebank</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This cape smells faintly of brimstone. While wearing it, you can use it to cast the dimension door spell as an action. This property of the cape can't be used again until the next dawn.</text>
@@ -2709,6 +2803,7 @@
 	<item>
     <name>Carpet of Flying, 3 ft. x 5 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -2719,6 +2814,7 @@
   <item>
     <name>Carpet of Flying, 4 ft. x 6 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -2729,6 +2825,7 @@
   <item>
     <name>Carpet of Flying, 5 ft. x 7 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -2739,6 +2836,7 @@
   <item>
     <name>Carpet of Flying, 6 ft. x 9 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -2767,6 +2865,7 @@
 	<item>
     <name>Censer of Controlling Air Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -2799,6 +2898,7 @@
 	<item>
     <name>Chain Mail +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2813,6 +2913,7 @@
   <item>
     <name>Chain Mail +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2827,6 +2928,7 @@
   <item>
     <name>Chain Mail +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2841,6 +2943,7 @@
   <item>
     <name>Chain Mail of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2855,6 +2958,7 @@
   <item>
     <name>Chain Mail of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2869,6 +2973,7 @@
   <item>
     <name>Chain Mail of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2883,6 +2988,7 @@
   <item>
     <name>Chain Mail of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2897,6 +3003,7 @@
   <item>
     <name>Chain Mail of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2911,6 +3018,7 @@
   <item>
     <name>Chain Mail of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2925,6 +3033,7 @@
   <item>
     <name>Chain Mail of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2939,6 +3048,7 @@
   <item>
     <name>Chain Mail of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2953,6 +3063,7 @@
   <item>
     <name>Chain Mail of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2967,6 +3078,7 @@
   <item>
     <name>Chain Mail of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -2991,6 +3103,7 @@
 	<item>
     <name>Chain Shirt +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3003,6 +3116,7 @@
   <item>
     <name>Chain Shirt +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Very Rare</rarity>
@@ -3015,6 +3129,7 @@
   <item>
     <name>Chain Shirt +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Legendary</rarity>
@@ -3027,6 +3142,7 @@
   <item>
     <name>Chain Shirt of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3039,6 +3155,7 @@
   <item>
     <name>Chain Shirt of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3051,6 +3168,7 @@
   <item>
     <name>Chain Shirt of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3063,6 +3181,7 @@
   <item>
     <name>Chain Shirt of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3075,6 +3194,7 @@
   <item>
     <name>Chain Shirt of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3087,6 +3207,7 @@
   <item>
     <name>Chain Shirt of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3099,6 +3220,7 @@
   <item>
     <name>Chain Shirt of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3111,6 +3233,7 @@
   <item>
     <name>Chain Shirt of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3123,6 +3246,7 @@
   <item>
     <name>Chain Shirt of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3135,6 +3259,7 @@
   <item>
     <name>Chain Shirt of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -3162,6 +3287,7 @@
 	<item>
     <name>Chime of Opening</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -3173,6 +3299,7 @@
   <item>
     <name>Circlet of Blasting</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this circlet, you can use an action to cast the scorching ray spell with it. When you make the spell's attacks, you do so with an attack bonus of +5. The circlet can't be used this way again until the next dawn.</text>
@@ -3183,6 +3310,7 @@
   <item>
         <name>Claw of the Wyrm Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -3198,6 +3326,7 @@
     <item>
     <name>Claws of the Umber Hulk</name>
     <type>W</type>
+    <magic>1</magic>
     <text>These heavy gauntlets of brown iron are forged in the shape an umber hulk's claws, and they fit the wearer's hands and forearms all the way up to the elbow. While wearing both claws, you gain a burrowing speed of 20 feet, and you can tunnel through solid rock at a rate of 1 foot per round.</text>
     <text>You can use a claw as a melee weapon while wearing it. You have proficiency with it, and it deals 1d8 slashing damage on a hit (your Strength modifier applies to the attack and damage rolls, as normal)</text>
     <text>While wearing the claws, you can't manipulate objects or cast spells with somatic components</text>
@@ -3216,6 +3345,7 @@
 	<item>
     <name>Cloak of Arachnida</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -3232,6 +3362,7 @@
   <item>
     <name>Cloak of Displacement</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -3243,6 +3374,7 @@
   <item>
     <name>Cloak of Elvenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -3254,6 +3386,7 @@
   <item>
     <name>Cloak of Invisibility</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -3265,6 +3398,7 @@
   <item>
     <name>Cloak of Protection</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -3278,6 +3412,7 @@
   <item>
     <name>Cloak of the Bat</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -3290,6 +3425,7 @@
   <item>
     <name>Cloak of the Manta Ray</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cloak with its hood up, you can breathe underwater, and you have a swimming speed of 60 feet. Pulling the hood up or down requires an action.</text>
@@ -3311,6 +3447,7 @@
 	<item>
     <name>Club +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3328,6 +3465,7 @@
   <item>
     <name>Club +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3345,6 +3483,7 @@
   <item>
     <name>Club +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3362,6 +3501,7 @@
   <item>
     <name>Club of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3403,6 +3543,7 @@
 	<item>
         <name>Conch of Teleportation</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -3443,6 +3584,7 @@
 	<item>
     <name>Copper Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -3474,6 +3616,7 @@
 	<item>
     <name>Crossbow Bolt of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -3504,6 +3647,7 @@
 	<item>
     <name>Crossbow Bolts +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -3516,6 +3660,7 @@
   <item>
     <name>Crossbow Bolts +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -3528,6 +3673,7 @@
   <item>
     <name>Crossbow Bolts +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -3558,6 +3704,7 @@
 	<item>
     <name>Crystal Ball</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -3570,6 +3717,7 @@
   <item>
     <name>Crystal Ball of Mind Reading</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -3583,6 +3731,7 @@
   <item>
     <name>Crystal Ball of Telepathy</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -3596,6 +3745,7 @@
   <item>
     <name>Crystal Ball of True Seeing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -3609,6 +3759,7 @@
   <item>
     <name>Cube of Force</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -3640,6 +3791,7 @@
   <item>
     <name>Cubic Gate</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the DM.</text>
@@ -3652,6 +3804,7 @@
   <item>
     <name>Daern's Instant Fortress</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place this 1-inch metal cube on the ground and speak its command word. The cube rapidly grows into a fortress that remains until you use an action to speak the command word that dismisses it, which works only if the fortress is empty.</text>
@@ -3684,6 +3837,7 @@
 	<item>
     <name>Dagger +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3708,6 +3862,7 @@
   <item>
     <name>Dagger +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3732,6 +3887,7 @@
   <item>
     <name>Dagger +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3756,6 +3912,7 @@
   <item>
     <name>Dagger of Venom</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3782,6 +3939,7 @@
   <item>
     <name>Dagger of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3805,6 +3963,7 @@
   <item>
     <name>Dancing Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -3825,6 +3984,7 @@
   <item>
     <name>Dancing Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -3844,6 +4004,7 @@
   <item>
     <name>Dancing Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -3862,6 +4023,7 @@
   <item>
     <name>Dancing Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -3882,6 +4044,7 @@
   <item>
     <name>Dancing Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -3919,6 +4082,7 @@
 	<item>
     <name>Dart +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3941,6 +4105,7 @@
   <item>
     <name>Dart +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3963,6 +4128,7 @@
   <item>
     <name>Dart +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3985,6 +4151,7 @@
   <item>
     <name>Dart of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -4006,6 +4173,7 @@
   <item>
     <name>Dawnbringer</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -4037,6 +4205,7 @@
   <item>
     <name>Decanter of Endless Water</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -4052,6 +4221,7 @@
   <item>
     <name>Deck of Illusions</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This box contains a set of parchment cards. A full deck has 34 cards. A deck found as treasure is usually missing 1d20 - 1 cards.</text>
@@ -4099,6 +4269,7 @@
   <item>
     <name>Deck of Many Things</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have only thirteen cards, but the rest have twenty-two.</text>
@@ -4158,6 +4329,7 @@
   <item>
     <name>Defender Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -4179,6 +4351,7 @@
   <item>
     <name>Defender Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -4199,6 +4372,7 @@
   <item>
     <name>Defender Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4218,6 +4392,7 @@
   <item>
     <name>Defender Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4239,6 +4414,7 @@
   <item>
     <name>Defender Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -4260,6 +4436,7 @@
   <item>
     <name>Demon Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -4277,6 +4454,7 @@
   <item>
     <name>Devastation Orb of Air</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -4289,6 +4467,7 @@
   <item>
     <name>Devastation Orb of Earth</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -4300,6 +4479,7 @@
   <item>
     <name>Devastation Orb of Fire</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -4312,6 +4492,7 @@
   <item>
     <name>Devastation Orb of Water</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -4331,6 +4512,7 @@
 	<item>
     <name>Dimensional Shackles</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place these shackles on an incapacitated creature. The shackles adjust to fit a creature of Small to Large size. In addition to serving as mundane manacles, the shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing-through an interdimensional portal.</text>
@@ -4381,6 +4563,7 @@
 	<item>
     <name>Draakhorn</name>
     <type>W</type>
+    <magic>1</magic>
     <text>The Draakhorn was a gift from Tiamat in the war between dragons and giants. It was once the horn of her ancient red dragon consort, Ephelomon, that she gave to dragonkind to help them in their war against the giants. The Draakhorn is a signaling device, and it is so large that it requires two Medium creatures (or one Large or larger) to hold it while a third creature sounds it, making the earth resonate to its call. The horn has been blasted with fire into a dark ebony hue and is wrapped in bands of bronze with draconic runes that glow with purple eldritch fire.</text>
     <text>The low, moaning drone of the Draakhorn discomfits normal animals within a few miles, and it alerts all dragons within two thousand miles to rise and be wary, for great danger is at hand. Coded blasts were once used to signal specific messages. Knowledge of those codes has been lost to the ages.</text>
     <text>Those with knowledge of the Draakhorn's history know that it was first built to signal danger to chromatic dragons — a purpose the Cult of the Dragon has corrupted to call chromatic dragons to the Well of Dragons from across the North.</text>
@@ -4394,6 +4577,7 @@
   <item>
     <name>Dragon Slayer Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -4415,6 +4599,7 @@
   <item>
     <name>Dragon Slayer Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -4435,6 +4620,7 @@
   <item>
     <name>Dragon Slayer Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4454,6 +4640,7 @@
   <item>
     <name>Dragon Slayer Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4475,6 +4662,7 @@
   <item>
     <name>Dragon Slayer Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -4505,6 +4693,7 @@
 	<item>
     <name>Dragontooth Dagger</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -4530,6 +4719,7 @@
   <item>
     <name>Driftglobe</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -4550,6 +4740,7 @@
 	<item>
     <name>Drown</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -4634,6 +4825,7 @@
 	<item>
     <name>Dust of Disappearance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small packet, this powder resembles very fine sand. There is enough of it for one use. When you use an action to throw the dust into the air, you and each creature and object within 10 feet of you become invisible for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. If a creature affected by the dust attacks or casts a spell, the invisibility ends for that creature.</text>
@@ -4643,6 +4835,7 @@
   <item>
     <name>Dust of Dryness</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small packet contains 1d6 + 4 pinches of dust. You can use an action to sprinkle a pinch of it over water. The dust turns a cube of water 15 feet on a side into one marble-sized pellet, which floats or rests near where the dust was sprinkled. The pellet's weight is negligible.</text>
@@ -4655,6 +4848,7 @@
   <item>
     <name>Dust of Sneezing and Choking</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small container, this powder resembles very fine sand. It appears to be dust of disappearance, and an identify spell reveals it to be such. There is enough of it for one use.</text>
@@ -4665,6 +4859,7 @@
   <item>
     <name>Dwarven Plate</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -4679,6 +4874,7 @@
   <item>
     <name>Dwarven Thrower</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -4705,6 +4901,7 @@
   <item>
     <name>Efreeti Bottle</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -4721,6 +4918,7 @@
   <item>
     <name>Efreeti Chain</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -4755,6 +4953,7 @@
 	<item>
     <name>Elemental Gem, Blue Sapphire</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, an air elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
@@ -4764,6 +4963,7 @@
   <item>
     <name>Elemental Gem, Emerald</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, a water elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
     <text>Source: </text>
@@ -4771,6 +4971,7 @@
   <item>
     <name>Elemental Gem, Red Corundum</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, a fire elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
     <text>Source: </text>
@@ -4778,6 +4979,7 @@
   <item>
     <name>Elemental Gem, Yellow Diamond</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, an earth elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
     <text>Source: </text>
@@ -4785,6 +4987,7 @@
   <item>
     <name>Elixir of Health</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -4795,6 +4998,7 @@
   <item>
     <name>Elven Chain</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -4839,6 +5043,7 @@
 	<item>
     <name>Eversmoking Bottle</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -4875,6 +5080,7 @@
 	<item>
     <name>Eye of Vecna</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
@@ -4907,6 +5113,7 @@
   <item>
     <name>Eyes of Charming</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -4918,6 +5125,7 @@
   <item>
     <name>Eyes of Minute Seeing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These crystal lenses fit over the eyes. While wearing them, you can see much better than normal out to a range of 1 foot. You have advantage on Intelligence (Investigation) checks that rely on sight while searching an area or studying an object within that range.</text>
@@ -4927,6 +5135,7 @@
   <item>
     <name>Eyes of the Eagle</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -4938,6 +5147,7 @@
   <item>
     <name>Figurine of Wondrous Power, Bronze Griffon</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -4952,6 +5162,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ebony Fly</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -4966,6 +5177,7 @@
   <item>
     <name>Figurine of Wondrous Power, Golden Lions</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -4980,6 +5192,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ivory Goats</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -4997,6 +5210,7 @@
   <item>
     <name>Figurine of Wondrous Power, Marble Elephant</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -5011,6 +5225,7 @@
   <item>
     <name>Figurine of Wondrous Power, Obsidian Steed</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -5026,6 +5241,7 @@
   <item>
     <name>Figurine of Wondrous Power, Onyx Dog</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -5040,6 +5256,7 @@
   <item>
     <name>Figurine of Wondrous Power, Serpentine Owl</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -5054,6 +5271,7 @@
   <item>
     <name>Figurine of Wondrous Power, Silver Raven</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -5093,6 +5311,7 @@
 	<item>
     <name>Flail +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5107,6 +5326,7 @@
   <item>
     <name>Flail +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5121,6 +5341,7 @@
   <item>
     <name>Flail +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5135,6 +5356,7 @@
   <item>
     <name>Flail of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5148,6 +5370,7 @@
   <item>
     <name>Flame Tongue Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -5167,6 +5390,7 @@
   <item>
     <name>Flame Tongue Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -5185,6 +5409,7 @@
   <item>
     <name>Flame Tongue Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5202,6 +5427,7 @@
   <item>
     <name>Flame Tongue Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -5221,6 +5447,7 @@
   <item>
     <name>Flame Tongue Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -5262,6 +5489,7 @@
 	<item>
     <name>Folding Boat</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -5285,6 +5513,7 @@
 	<item>
     <name>Frost Brand Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -5306,6 +5535,7 @@
   <item>
     <name>Frost Brand Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -5326,6 +5556,7 @@
   <item>
     <name>Frost Brand Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5345,6 +5576,7 @@
   <item>
     <name>Frost Brand Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -5366,6 +5598,7 @@
   <item>
     <name>Frost Brand Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -5387,6 +5620,7 @@
   <item>
     <name>Gauntlets of Ogre Power</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -5398,6 +5632,7 @@
   <item>
         <name>Gavel of the Venn Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -5413,6 +5648,7 @@
     <item>
     <name>Gem of Brightness</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -5427,6 +5663,7 @@
   <item>
     <name>Gem of Seeing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -5441,6 +5678,7 @@
   <item>
     <name>Giant Slayer Battleaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -5461,6 +5699,7 @@
   <item>
     <name>Giant Slayer Greataxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -5482,6 +5721,7 @@
   <item>
     <name>Giant Slayer Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -5503,6 +5743,7 @@
   <item>
     <name>Giant Slayer Handaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -5527,6 +5768,7 @@
   <item>
     <name>Giant Slayer Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -5547,6 +5789,7 @@
   <item>
     <name>Giant Slayer Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5566,6 +5809,7 @@
   <item>
     <name>Giant Slayer Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -5587,6 +5831,7 @@
   <item>
     <name>Giant Slayer Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -5622,6 +5867,7 @@
 	<item>
     <name>Glaive +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -5643,6 +5889,7 @@
   <item>
     <name>Glaive +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -5664,6 +5911,7 @@
   <item>
     <name>Glaive +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -5685,6 +5933,7 @@
   <item>
     <name>Glaive of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -5705,6 +5954,7 @@
   <item>
     <name>Glamoured Studded Leather</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -5735,6 +5985,7 @@
 	<item>
     <name>Gloves of Missile Snaring</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -5747,6 +5998,7 @@
   <item>
     <name>Gloves of Swimming and Climbing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -5758,6 +6010,7 @@
   <item>
     <name>Gloves of Thievery</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These gloves are invisible while worn. While wearing them, you gain a +5 bonus to Dexterity (Sleight of Hand) checks and Dexterity checks made to pick locks.</text>
@@ -5767,6 +6020,7 @@
   <item>
     <name>Goggles of Night</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing these dark lenses, you have darkvision out to a range of 60 feet. If you already have darkvision. wearing the goggles increases its range by 60 feet.</text>
@@ -5795,6 +6049,7 @@
 	<item>
     <name>Gold Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -5831,6 +6086,7 @@
 	<item>
     <name>Greataxe +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -5850,6 +6106,7 @@
   <item>
     <name>Greataxe +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -5869,6 +6126,7 @@
   <item>
     <name>Greataxe +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -5888,6 +6146,7 @@
   <item>
     <name>Greataxe of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -5918,6 +6177,7 @@
 	<item>
     <name>Greatclub +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5935,6 +6195,7 @@
   <item>
     <name>Greatclub +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5952,6 +6213,7 @@
   <item>
     <name>Greatclub +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5969,6 +6231,7 @@
   <item>
     <name>Greatclub of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -5999,6 +6262,7 @@
 	<item>
     <name>Greatsword +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6018,6 +6282,7 @@
   <item>
     <name>Greatsword +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6037,6 +6302,7 @@
   <item>
     <name>Greatsword +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6056,6 +6322,7 @@
   <item>
     <name>Greatsword of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6074,6 +6341,7 @@
   <item>
     <name>Greatsword of Sharpness</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6094,6 +6362,7 @@
   <item>
     <name>Greatsword of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6118,6 +6387,7 @@
   <item>
     <name>Greatsword of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6136,6 +6406,7 @@
   <item>
     <name>Greatsword of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6156,6 +6427,7 @@
   <item>
     <name>Green Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This mottled green mask is surmounted by a frilled crest and has leathery spiked plates along its jaw. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties</text>
@@ -6179,6 +6451,7 @@
   <item>
     <name>Green Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -6194,6 +6467,7 @@
   <item>
     <name>Gulthias Staff</name>
     <type>ST</type>
+    <magic>1</magic>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
@@ -6214,6 +6488,7 @@
   <item>
         <name>Gurt's Greataxe</name>
         <type>M</type>
+    <magic>1</magic>
         <weight>14</weight>
         <dmg1>3d12</dmg1>
         <dmgType>S</dmgType>
@@ -6247,6 +6522,7 @@
 	<item>
     <name>Halberd +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -6268,6 +6544,7 @@
   <item>
     <name>Halberd +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -6289,6 +6566,7 @@
   <item>
     <name>Halberd +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -6310,6 +6588,7 @@
   <item>
     <name>Halberd of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -6341,6 +6620,7 @@
 	<item>
     <name>Half Plate Armor +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6354,6 +6634,7 @@
   <item>
     <name>Half Plate Armor +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6367,6 +6648,7 @@
   <item>
     <name>Half Plate Armor +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6380,6 +6662,7 @@
   <item>
     <name>Half Plate Armor of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6393,6 +6676,7 @@
   <item>
     <name>Half Plate Armor of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6406,6 +6690,7 @@
   <item>
     <name>Half Plate Armor of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6419,6 +6704,7 @@
   <item>
     <name>Half Plate Armor of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6432,6 +6718,7 @@
   <item>
     <name>Half Plate Armor of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6445,6 +6732,7 @@
   <item>
     <name>Half Plate Armor of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6458,6 +6746,7 @@
   <item>
     <name>Half Plate Armor of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6471,6 +6760,7 @@
   <item>
     <name>Half Plate Armor of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6484,6 +6774,7 @@
   <item>
     <name>Half Plate Armor of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6497,6 +6788,7 @@
   <item>
     <name>Half Plate Armor of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -6517,6 +6809,7 @@
 	<item>
     <name>Hammer of Thunderbolts</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmg2>2d6</dmg2>
@@ -6563,6 +6856,7 @@
 	<item>
     <name>Hand Crossbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6588,6 +6882,7 @@
   <item>
     <name>Hand Crossbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6613,6 +6908,7 @@
   <item>
     <name>Hand Crossbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6638,6 +6934,7 @@
   <item>
     <name>Hand Crossbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6662,6 +6959,7 @@
   <item>
     <name>Hand of Vecna</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
@@ -6711,6 +7009,7 @@
 	<item>
     <name>Handaxe +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6733,6 +7032,7 @@
   <item>
     <name>Handaxe +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6755,6 +7055,7 @@
   <item>
     <name>Handaxe +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6777,6 +7078,7 @@
   <item>
     <name>Handaxe of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6798,6 +7100,7 @@
   <item>
     <name>Hat of Disguise</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -6809,6 +7112,7 @@
   <item>
     <name>Hazirawn</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6837,6 +7141,7 @@
   <item>
     <name>Headband of Intellect</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -6880,6 +7185,7 @@
 	<item>
     <name>Heavy Crossbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -6907,6 +7213,7 @@
   <item>
     <name>Heavy Crossbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -6934,6 +7241,7 @@
   <item>
     <name>Heavy Crossbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -6961,6 +7269,7 @@
   <item>
     <name>Heavy Crossbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -6987,6 +7296,7 @@
   <item>
     <name>Helm of Brilliance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7005,6 +7315,7 @@
   <item>
     <name>Helm of Comprehending Languages</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this helm, you can use an action to cast the comprehend languages spell from it at will.</text>
@@ -7014,6 +7325,7 @@
   <item>
     <name>Helm of Telepathy</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -7026,6 +7338,7 @@
   <item>
     <name>Helm of Teleportation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -7056,6 +7369,7 @@
 	<item>
     <name>Heward's Handy Haversack</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -7079,6 +7393,7 @@
 	<item>
     <name>Hide Armor +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7091,6 +7406,7 @@
   <item>
     <name>Hide Armor +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Very Rare</rarity>
@@ -7103,6 +7419,7 @@
   <item>
     <name>Hide Armor +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Legendary</rarity>
@@ -7115,6 +7432,7 @@
   <item>
     <name>Hide Armor of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7127,6 +7445,7 @@
   <item>
     <name>Hide Armor of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7139,6 +7458,7 @@
   <item>
     <name>Hide Armor of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7151,6 +7471,7 @@
   <item>
     <name>Hide Armor of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7163,6 +7484,7 @@
   <item>
     <name>Hide Armor of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7175,6 +7497,7 @@
   <item>
     <name>Hide Armor of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7187,6 +7510,7 @@
   <item>
     <name>Hide Armor of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7199,6 +7523,7 @@
   <item>
     <name>Hide Armor of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7211,6 +7536,7 @@
   <item>
     <name>Hide Armor of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7223,6 +7549,7 @@
   <item>
     <name>Hide Armor of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -7235,6 +7562,7 @@
   <item>
     <name>Holy Avenger Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7257,6 +7585,7 @@
   <item>
     <name>Holy Avenger Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7278,6 +7607,7 @@
   <item>
     <name>Holy Avenger Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7298,6 +7628,7 @@
   <item>
     <name>Holy Avenger Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7320,6 +7651,7 @@
   <item>
     <name>Holy Avenger Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7374,6 +7706,7 @@
 	<item>
     <name>Holy Symbol of Ravenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This item requires attunement by a cleric or paladin of good alignment</text>
     <text />
     <text>	The Holy Symbol of Ravenkind is a unique holy symbol sacred to the good-hearted faithful of Barovia. It predates the establishment of any church in Barovia. According to legend, it was delivered to a paladin named Lugdana by a giant raven - or an angel in the form of a giant raven. Lugdana used the holy symbol to root out and destroy nests of vampires until her death. The high priests of Ravenloft kept and wore the holy symbol after Lugdana's passing.</text>
@@ -7423,6 +7756,7 @@
 	<item>
     <name>Horn of Blasting</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -7435,6 +7769,7 @@
   <item>
     <name>Horn of Valhalla, Brass</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -7448,6 +7783,7 @@
   <item>
     <name>Horn of Valhalla, Bronze</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -7461,6 +7797,7 @@
   <item>
     <name>Horn of Valhalla, Iron</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -7474,6 +7811,7 @@
   <item>
     <name>Horn of Valhalla, Silver</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -7487,6 +7825,7 @@
   <item>
     <name>Horseshoes of Speed</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they increase the creature's walking speed by 30 feet.</text>
@@ -7496,6 +7835,7 @@
   <item>
     <name>Horseshoes of a Zephyr</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above the ground. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores difficult terrain. In addition, the creature can move at normal speed for up to 12 hours a day without suffering exhaustion from a forced march.</text>
@@ -7521,6 +7861,7 @@
 	<item>
     <name>Icon of Ravenloft</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>10</weight>
     <text>This item requires attunement by a creature of good alignment</text>
     <text />
@@ -7540,6 +7881,7 @@
   <item>
     <name>Immovable Rod</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -7550,6 +7892,7 @@
   <item>
         <name>Ingot of the Skold Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -7579,6 +7922,7 @@
 	<item>
     <name>Insignia of Claws</name>
     <type>W</type>
+    <magic>1</magic>
     <text>The jewels in the insignia of the Cult of the Dragon flare with purple light when you enter combat, empowering your natural fists or natural weapons.</text>
     <text>While wearing the insignia you gain a +1 bonus to the attack rolls and the damage rolls you make with unarmed strikes and natural weapons. Such attacks are considered to be magical.</text>
     <text />
@@ -7589,6 +7933,7 @@
   <item>
     <name>Instrument of the Bards, Anstruth Harp</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -7605,6 +7950,7 @@
   <item>
     <name>Instrument of the Bards, Canaith Mandolin</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -7621,6 +7967,7 @@
   <item>
     <name>Instrument of the Bards, Cli Lyre</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -7637,6 +7984,7 @@
   <item>
     <name>Instrument of the Bards, Doss Lute</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -7653,6 +8001,7 @@
   <item>
     <name>Instrument of the Bards, Fochlucan Bandore</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -7669,6 +8018,7 @@
   <item>
     <name>Instrument of the Bards, Mac-Fuirmidh Cittern</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -7685,6 +8035,7 @@
   <item>
     <name>Instrument of the Bards, Ollamh Harp</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -7701,6 +8052,7 @@
   <item>
     <name>Ioun Stone, Absorption</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7718,6 +8070,7 @@
   <item>
     <name>Ioun Stone, Agility</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7735,6 +8088,7 @@
   <item>
     <name>Ioun Stone, Awareness</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -7751,6 +8105,7 @@
   <item>
     <name>Ioun Stone, Fortitude</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7768,6 +8123,7 @@
   <item>
     <name>Ioun Stone, Greater Absorption</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -7784,6 +8140,7 @@
   <item>
     <name>Ioun Stone, Insight</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7801,6 +8158,7 @@
   <item>
     <name>Ioun Stone, Intellect</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7818,6 +8176,7 @@
   <item>
     <name>Ioun Stone, Leadership</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7835,6 +8194,7 @@
   <item>
     <name>Ioun Stone, Mastery</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -7852,6 +8212,7 @@
   <item>
     <name>Ioun Stone, Protection</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -7869,6 +8230,7 @@
   <item>
     <name>Ioun Stone, Regeneration</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -7885,6 +8247,7 @@
   <item>
     <name>Ioun Stone, Reserve</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -7903,6 +8266,7 @@
   <item>
     <name>Ioun Stone, Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -7920,6 +8284,7 @@
   <item>
     <name>Ioun Stone, Sustenance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -7936,6 +8301,7 @@
   <item>
     <name>Iron Bands of Bilarro</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -7949,6 +8315,7 @@
   <item>
     <name>Iron Flask</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -8016,6 +8383,7 @@
 	<item>
     <name>Ironfang</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8057,6 +8425,7 @@
 	<item>
     <name>Javelin +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -8077,6 +8446,7 @@
   <item>
     <name>Javelin +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -8097,6 +8467,7 @@
   <item>
     <name>Javelin +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -8117,6 +8488,7 @@
   <item>
     <name>Javelin of Lightning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -8137,6 +8509,7 @@
   <item>
     <name>Javelin of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -8174,6 +8547,7 @@
 	<item>
     <name>Keoghtom's Ointment</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This glass jar, 3 inches in diameter, contains 1d4 + 1 doses of a thick mixture that smells faintly of aloe. The jar and its contents weigh 1/2 pound.</text>
@@ -8185,6 +8559,7 @@
   <item>
         <name>Korolnor Scepter</name>
         <type>M</type>
+    <magic>1</magic>
         <weight>2</weight>
         <dmg1>1d4</dmg1>
         <dmgType>B</dmgType>
@@ -8239,6 +8614,7 @@
 	<item>
     <name>Lance +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -8256,6 +8632,7 @@
   <item>
     <name>Lance +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -8273,6 +8650,7 @@
   <item>
     <name>Lance +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -8290,6 +8668,7 @@
   <item>
     <name>Lance of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -8306,6 +8685,7 @@
   <item>
     <name>Lantern of Revealing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8326,6 +8706,7 @@
 	<item>
     <name>Leather Armor +1</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8338,6 +8719,7 @@
   <item>
     <name>Leather Armor +2</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Very Rare</rarity>
@@ -8350,6 +8732,7 @@
   <item>
     <name>Leather Armor +3</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Legendary</rarity>
@@ -8362,6 +8745,7 @@
   <item>
     <name>Leather Armor of Acid Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8374,6 +8758,7 @@
   <item>
     <name>Leather Armor of Cold Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8386,6 +8771,7 @@
   <item>
     <name>Leather Armor of Fire Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8398,6 +8784,7 @@
   <item>
     <name>Leather Armor of Force Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8410,6 +8797,7 @@
   <item>
     <name>Leather Armor of Lightning Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8422,6 +8810,7 @@
   <item>
     <name>Leather Armor of Necrotic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8434,6 +8823,7 @@
   <item>
     <name>Leather Armor of Poison Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8446,6 +8836,7 @@
   <item>
     <name>Leather Armor of Psychic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8458,6 +8849,7 @@
   <item>
     <name>Leather Armor of Radiant Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8470,6 +8862,7 @@
   <item>
     <name>Leather Armor of Thunder Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -8512,6 +8905,7 @@
 	<item>
     <name>Light Crossbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8537,6 +8931,7 @@
   <item>
     <name>Light Crossbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8562,6 +8957,7 @@
   <item>
     <name>Light Crossbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8587,6 +8983,7 @@
   <item>
     <name>Light Crossbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8628,6 +9025,7 @@
 	<item>
     <name>Light Hammer +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -8650,6 +9048,7 @@
   <item>
     <name>Light Hammer +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -8672,6 +9071,7 @@
   <item>
     <name>Light Hammer +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -8694,6 +9094,7 @@
   <item>
     <name>Light Hammer of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -8745,6 +9146,7 @@
 	<item>
     <name>Longbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8770,6 +9172,7 @@
   <item>
     <name>Longbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8795,6 +9198,7 @@
   <item>
     <name>Longbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8820,6 +9224,7 @@
   <item>
     <name>Longbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8857,6 +9262,7 @@
 	<item>
     <name>Longsword +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8875,6 +9281,7 @@
   <item>
     <name>Longsword +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8893,6 +9300,7 @@
   <item>
     <name>Longsword +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8911,6 +9319,7 @@
   <item>
     <name>Longsword of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8928,6 +9337,7 @@
   <item>
     <name>Longsword of Sharpness</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8947,6 +9357,7 @@
   <item>
     <name>Longsword of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8970,6 +9381,7 @@
   <item>
     <name>Longsword of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8987,6 +9399,7 @@
   <item>
     <name>Longsword of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -9006,6 +9419,7 @@
   <item>
     <name>Lost Crown of Besilmer</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This dwarven battle-helm consists of a sturdy open-faced steel helmet, decorated with a golden circlet above the brow from which seven small gold spikes project upward. You gain the following benefits while wearing the crown:</text>
@@ -9019,6 +9433,7 @@
   <item>
     <name>Luck Blade Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -9044,6 +9459,7 @@
   <item>
     <name>Luck Blade Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -9068,6 +9484,7 @@
   <item>
     <name>Luck Blade Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -9091,6 +9508,7 @@
   <item>
     <name>Luck Blade Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -9116,6 +9534,7 @@
   <item>
     <name>Luck Blade Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -9176,6 +9595,7 @@
 	<item>
     <name>Mace +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -9190,6 +9610,7 @@
   <item>
     <name>Mace +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -9204,6 +9625,7 @@
   <item>
     <name>Mace +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -9218,6 +9640,7 @@
   <item>
     <name>Mace of Disruption</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -9233,6 +9656,7 @@
   <item>
     <name>Mace of Smiting</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -9248,6 +9672,7 @@
   <item>
     <name>Mace of Terror</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -9263,6 +9688,7 @@
   <item>
     <name>Mace of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -9302,6 +9728,7 @@
 	<item>
     <name>Mantle of Spell Resistance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9313,6 +9740,7 @@
   <item>
     <name>Manual of Bodily Health</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9323,6 +9751,7 @@
   <item>
     <name>Manual of Clay Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9334,6 +9763,7 @@
   <item>
     <name>Manual of Flesh Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9345,6 +9775,7 @@
   <item>
     <name>Manual of Gainful Exercise</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9355,6 +9786,7 @@
   <item>
     <name>Manual of Iron Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9366,6 +9798,7 @@
   <item>
     <name>Manual of Quickness of Action</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9376,6 +9809,7 @@
   <item>
     <name>Manual of Stone Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9396,6 +9830,7 @@
 	<item>
     <name>Mariner's Breastplate</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -9407,6 +9842,7 @@
   <item>
     <name>Mariner's Chain Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -9420,6 +9856,7 @@
   <item>
     <name>Mariner's Chain Shirt</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Uncommon</rarity>
@@ -9431,6 +9868,7 @@
   <item>
     <name>Mariner's Half Plate Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -9443,6 +9881,7 @@
   <item>
     <name>Mariner's Hide Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Uncommon</rarity>
@@ -9454,6 +9893,7 @@
   <item>
     <name>Mariner's Leather Armor</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Uncommon</rarity>
@@ -9465,6 +9905,7 @@
   <item>
     <name>Mariner's Padded Armor</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -9477,6 +9918,7 @@
   <item>
     <name>Mariner's Plate Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -9490,6 +9932,7 @@
   <item>
     <name>Mariner's Ring Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -9502,6 +9945,7 @@
   <item>
     <name>Mariner's Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -9514,6 +9958,7 @@
   <item>
     <name>Mariner's Spiked Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -9524,6 +9969,7 @@
   <item>
     <name>Mariner's Splint Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -9537,6 +9983,7 @@
   <item>
     <name>Mariner's Studded Leather Armor</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Uncommon</rarity>
@@ -9548,6 +9995,7 @@
   <item>
     <name>Mask of the Dragon Queen</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>Individually, the five dragon masks resemble the dragons they are named for. When two or more of the dragon masks are assembled, however, they transform magically into the Mask of the Dragon Queen. Each mask shrinks to become the modeled head of a chromatic dragon, appearing to roar its devotion to Tiamat where all the masks brought together are arranged crown-like on the wearer's head. Below the five masks, a new mask shapes itself, granting the wearer a draconic visage that covers the face, neck, and shoulders.</text>
@@ -9581,6 +10029,7 @@
 	<item>
     <name>Maul +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
@@ -9600,6 +10049,7 @@
   <item>
     <name>Maul +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
@@ -9619,6 +10069,7 @@
   <item>
     <name>Maul +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
@@ -9638,6 +10089,7 @@
   <item>
     <name>Maul of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmg2>2d6</dmg2>
@@ -9657,6 +10109,7 @@
   <item>
     <name>Medallion of Thoughts</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -9698,6 +10151,7 @@
 	<item>
 		<name>Mind Blade Greatsword</name>
 		<type>M</type>
+		<magic>1</magic>
 		<weight>6</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9718,6 +10172,7 @@
 	<item>
 		<name>Mind Blade Longsword</name>
 		<type>M</type>
+        <magic>1</magic>
 		<weight>3</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9736,6 +10191,7 @@
 	<item>
 		<name>Mind Blade Rapier</name>
 		<type>M</type>
+        <magic>1</magic>
 		<weight>2</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9754,6 +10210,7 @@
 	<item>
 		<name>Mind Blade Scimitar</name>
 		<type>M</type>
+        <magic>1</magic>
 		<weight>3</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9774,6 +10231,7 @@
 	<item>
 		<name>Mind Blade Shortsword</name>
 		<type>M</type>
+        <magic>1</magic>
 		<weight>2</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9794,6 +10252,7 @@
 	<item>
 		<name>Mind Carapace Chain Mail</name>
 		<type>HA</type>
+        <magic>1</magic>
 		<weight>55</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9807,6 +10266,7 @@
 	<item>
 		<name>Mind Carapace Plate Armor</name>
 		<type>HA</type>
+        <magic>1</magic>
 		<weight>65</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9820,6 +10280,7 @@
 	<item>
 		<name>Mind Carapace Ring Mail</name>
 		<type>HA</type>
+        <magic>1</magic>
 		<weight>40</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9833,6 +10294,7 @@
 	<item>
 		<name>Mind Carapace Splint Armor</name>
 		<type>HA</type>
+        <magic>1</magic>
 		<weight>60</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -9846,6 +10308,7 @@
 	<item>
 		<name>Mind Lash</name>
 		<type>M</type>
+        <magic>1</magic>
 		<weight>3</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires attunement by a mind flayer</text>
@@ -9873,6 +10336,7 @@
 	<item>
     <name>Mirror of Life Trapping</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>50</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9889,6 +10353,7 @@
   <item>
     <name>Mithral Breastplate</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -9900,6 +10365,7 @@
   <item>
     <name>Mithral Chain Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <rarity>Uncommon</rarity>
@@ -9911,6 +10377,7 @@
   <item>
     <name>Mithral Chain Shirt</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Uncommon</rarity>
@@ -9922,6 +10389,7 @@
   <item>
     <name>Mithral Half Plate Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <rarity>Uncommon</rarity>
@@ -9933,6 +10401,7 @@
   <item>
     <name>Mithral Plate Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <rarity>Uncommon</rarity>
@@ -9944,6 +10413,7 @@
   <item>
     <name>Mithral Ring Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -9955,6 +10425,7 @@
   <item>
     <name>Mithral Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -9966,6 +10437,7 @@
   <item>
     <name>Mithral Spiked Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
@@ -9975,6 +10447,7 @@
   <item>
     <name>Mithral Splint Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <rarity>Uncommon</rarity>
@@ -10009,6 +10482,7 @@
 <item>
     <name>Moonblade</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -10061,6 +10535,7 @@
 	<item>
     <name>Morningstar +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -10075,6 +10550,7 @@
   <item>
     <name>Morningstar +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -10089,6 +10565,7 @@
   <item>
     <name>Morningstar +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -10103,6 +10580,7 @@
   <item>
     <name>Morningstar of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -10116,6 +10594,7 @@
   <item>
         <name>Navigation Orb</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -10141,6 +10620,7 @@
 	<item>
     <name>Necklace of Adaptation</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10153,6 +10633,7 @@
   <item>
     <name>Necklace of Fireballs</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10165,6 +10646,7 @@
   <item>
     <name>Necklace of Prayer Beads</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10201,6 +10683,7 @@
 	<item>
     <name>Net +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -10222,6 +10705,7 @@
   <item>
     <name>Net +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -10243,6 +10727,7 @@
   <item>
     <name>Net +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -10264,6 +10749,7 @@
   <item>
     <name>Net of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -10282,6 +10768,7 @@
   <item>
     <name>Nine Lives Stealer Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -10303,6 +10790,7 @@
   <item>
     <name>Nine Lives Stealer Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -10323,6 +10811,7 @@
   <item>
     <name>Nine Lives Stealer Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -10342,6 +10831,7 @@
   <item>
     <name>Nine Lives Stealer Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -10363,6 +10853,7 @@
   <item>
     <name>Nine Lives Stealer Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -10384,6 +10875,7 @@
   <item>
     <name>Nolzur's Marvelous Pigments</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -10398,6 +10890,7 @@
   <item>
     <name>Oathbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -10434,6 +10927,7 @@
 	<item>
     <name>Oil of Etherealness</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10444,6 +10938,7 @@
   <item>
     <name>Oil of Sharpness</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -10454,6 +10949,7 @@
   <item>
     <name>Oil of Slipperiness</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10474,6 +10970,7 @@
 	<item>
         <name>Opal of the Ild Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -10500,6 +10997,7 @@
 	<item>
     <name>Orb of Dragonkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
@@ -10523,6 +11021,7 @@
   <item>
         <name>Orb of the Stein Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -10541,6 +11040,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <item>
     <name>Orcsplitter</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -10578,6 +11078,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
 	<item>
     <name>Padded Armor +1</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10591,6 +11092,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor +2</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10604,6 +11106,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor +3</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10617,6 +11120,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Acid Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10630,6 +11134,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Cold Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10643,6 +11148,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Fire Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10656,6 +11162,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Force Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10669,6 +11176,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Lightning Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10682,6 +11190,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Necrotic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10695,6 +11204,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Poison Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10708,6 +11218,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Psychic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10721,6 +11232,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Radiant Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10734,6 +11246,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
     <name>Padded Armor of Thunder Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -10791,6 +11304,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
 	<item>
     <name>Pearl of Power</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
@@ -10802,6 +11316,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
   <item>
         <name>Pennant of the Vind Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -10827,6 +11342,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Periapt of Health</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10837,6 +11353,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Periapt of Proof Against Poison</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10847,6 +11364,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Periapt of Wound Closure</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10859,6 +11377,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Philter of Love</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10885,6 +11404,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Pike +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -10906,6 +11426,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Pike +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -10927,6 +11448,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Pike +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -10948,6 +11470,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Pike of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -10968,6 +11491,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Pipes of Haunting</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10979,6 +11503,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Pipes of the Sewers</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11010,6 +11535,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Piwafwi (Cloak of Elvenkind)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text>This dark spider-silk cloak is made by drow. It is a cloak of elvenkind. It loses its magic if exposed to sunlight for 1 hour without interruption.</text>
     <text />
@@ -11020,6 +11546,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Piwafwi of Fire Resistance (Cloak of Elvenkind)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text>This dark spider-silk cloak is made by drow. It is a cloak of elvenkind. It also grants resistance to fire damage while you wear it.  It loses its magic if exposed to sunlight for 1 hour without interruption.</text>
     <text />
@@ -11042,6 +11569,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Plate Armor +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11056,6 +11584,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11070,6 +11599,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11084,6 +11614,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11098,6 +11629,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11112,6 +11644,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Etherealness</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11126,6 +11659,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11140,6 +11674,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11154,6 +11689,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11168,6 +11704,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11182,6 +11719,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11196,6 +11734,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11210,6 +11749,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11224,6 +11764,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Plate Armor of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -11281,6 +11822,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Portable Hole</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
@@ -11303,6 +11845,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Potion of Acid Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11313,6 +11856,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Animal Friendship</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11323,6 +11867,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Clairvoyance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11333,6 +11878,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Climbing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
@@ -11343,6 +11889,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Cloud Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11354,6 +11901,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Cold Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11364,6 +11912,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Diminution</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11375,6 +11924,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Fire Breath</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11386,6 +11936,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Fire Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11397,6 +11948,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Fire Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11407,6 +11959,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Flying</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11417,6 +11970,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Force Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11427,6 +11981,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Frost Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11438,6 +11993,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Gaseous Form</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11448,6 +12004,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
         <name>Potion of Giant Size</name>
         <type>P</type>
+    <magic>1</magic>
         <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
@@ -11460,6 +12017,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
     <name>Potion of Greater Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11471,6 +12029,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Growth</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11482,6 +12041,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
@@ -11493,6 +12053,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Heroism</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11503,6 +12064,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Hill Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11514,6 +12076,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Invisibility</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11524,6 +12087,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Invulnerability</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11534,6 +12098,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Lightning Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11544,6 +12109,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Longevity</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11555,6 +12121,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Mind Reading</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11565,6 +12132,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Necrotic Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11575,6 +12143,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Poison</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11589,6 +12158,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Poison Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11599,6 +12169,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Psychic Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11609,6 +12180,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Radiant Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11619,6 +12191,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Speed</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11629,6 +12202,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Stone Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11640,6 +12214,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Storm Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -11651,6 +12226,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Superior Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11662,6 +12238,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Supreme Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11673,6 +12250,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Thunder Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11683,6 +12261,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Vitality</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11693,6 +12272,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Potion of Water Breathing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11760,6 +12340,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Quaal's Feather Token, Anchor</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11771,6 +12352,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Bird</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11782,6 +12364,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Fan</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11793,6 +12376,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Swan Boat</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11804,6 +12388,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Tree</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11815,6 +12400,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quaal's Feather Token, Whip</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11842,6 +12428,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Quarterstaff +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -11860,6 +12447,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quarterstaff +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -11878,6 +12466,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quarterstaff +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -11896,6 +12485,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Quarterstaff of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -11922,6 +12512,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Quiver of Ehlonna</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11945,6 +12536,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Rapier +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -11962,6 +12554,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rapier +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -11979,6 +12572,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rapier +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -11996,6 +12590,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rapier of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -12012,6 +12607,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rapier of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -12034,6 +12630,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rapier of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -12050,6 +12647,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rapier of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -12077,6 +12675,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Red Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This mask of glossy crimson has swept-back horns and spiked cheek ridges. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -12100,6 +12699,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Red Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12126,6 +12726,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Ring Mail +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12139,6 +12740,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12152,6 +12754,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12165,6 +12768,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12178,6 +12782,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12191,6 +12796,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12204,6 +12810,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12217,6 +12824,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12230,6 +12838,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12243,6 +12852,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12256,6 +12866,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12269,6 +12880,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12282,6 +12894,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring Mail of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -12295,6 +12908,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Acid Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12306,6 +12920,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Air Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12324,6 +12939,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Animal Influence</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can use an action to expend 1 of its charges to cast one of the following spells:</text>
@@ -12337,6 +12953,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Cold Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12348,6 +12965,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Djinni Summoning</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12361,6 +12979,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Earth Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12379,6 +12998,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Evasion</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12391,6 +13011,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Feather Falling</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12402,6 +13023,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Fire Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12419,6 +13041,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Fire Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12430,6 +13053,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Force Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12441,6 +13065,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Free Action</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12452,6 +13077,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Invisibility</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12463,6 +13089,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Jumping</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -12474,6 +13101,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Lightning Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12485,6 +13113,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Mind Shielding</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -12498,6 +13127,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Necrotic Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12509,6 +13139,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Poison Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12520,6 +13151,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Protection</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12533,6 +13165,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Psychic Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12544,6 +13177,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Radiant Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12555,6 +13189,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Regeneration</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -12567,6 +13202,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Shooting Stars</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement Outdoors at Night</text>
@@ -12593,6 +13229,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Spell Storing</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12606,6 +13243,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Spell Turning</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12617,6 +13255,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Swimming</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You have a swimming speed of 40 feet while wearing this ring.</text>
@@ -12626,6 +13265,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Telekinesis</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -12637,6 +13277,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Three Wishes</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>While wearing this ring, you can use an action to expend 1 of its 3 charges to cast the wish spell from it. The ring becomes nonmagical when you use the last charge.</text>
@@ -12646,6 +13287,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Thunder Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12657,6 +13299,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Warmth</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -12668,6 +13311,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Water Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12685,6 +13329,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of Water Walking</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this ring, you can stand on and move across any liquid surface as if it were solid ground.</text>
@@ -12694,6 +13339,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of X-ray Vision</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12706,6 +13352,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Ring of the Ram</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12724,6 +13371,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Eyes</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12740,6 +13388,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Scintillating Colors</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -12750,8 +13399,9 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <roll>1d3</roll>
   </item>
   <item>
-        <name>Robe of Serpants</name>
+        <name>Robe of Serpents</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Uncommon</rarity>
         <text>Rarity: Uncommon</text>
@@ -12764,6 +13414,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
     <name>Robe of Stars</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -12779,6 +13430,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of Useful Items</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This robe has cloth patches of various shapes and colors covering it. While wearing the robe. you can use an action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.</text>
@@ -12811,6 +13463,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Robe of the Archmagi</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
@@ -12846,6 +13499,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Rod of Absorption</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12861,6 +13515,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of Alertness</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12880,6 +13535,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of Lordly Might</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -12907,6 +13563,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of Resurrection</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -12920,6 +13577,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of Rulership</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12932,6 +13590,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of Security</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12944,6 +13603,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of the Pact Keeper, +1</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12959,6 +13619,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of the Pact Keeper, +2</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12974,6 +13635,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rod of the Pact Keeper, +3</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12989,6 +13651,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
         <name>Rod of the Vonindod</name>
         <type>RD</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -13002,6 +13665,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
     <name>Rope of Climbing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -13014,6 +13678,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Rope of Entanglement</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -13035,6 +13700,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Saddle of the Cavalier</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While in this saddle on a mount, you can't be dismounted against your will if you're conscious, and attack rolls against the mount have disadvantage.</text>
@@ -13044,6 +13710,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Saint Markovia's Thighbone</name>
     <type>M</type>
+    <magic>1</magic>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
     <weight>4</weight>
@@ -13076,6 +13743,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Scale Mail +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13089,6 +13757,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13102,6 +13771,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13115,6 +13785,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13128,6 +13799,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13141,6 +13813,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13154,6 +13827,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13167,6 +13841,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13180,6 +13855,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13193,6 +13869,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13206,6 +13883,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13219,6 +13897,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13232,6 +13911,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scale Mail of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13245,6 +13925,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scarab of Protection</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -13295,6 +13976,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Scimitar +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13314,6 +13996,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13333,6 +14016,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13352,6 +14036,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13370,6 +14055,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar of Sharpness</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13390,6 +14076,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar of Speed</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13410,6 +14097,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13434,6 +14122,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13452,6 +14141,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scimitar of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -13481,6 +14171,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Beasts</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents beasts from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a beast would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -13490,6 +14181,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Celestials</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents celestials from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a celestial would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -13499,6 +14191,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Elementals</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents elementals from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an elemental would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -13508,6 +14201,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Fey</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fey from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fey would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -13517,6 +14211,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Fiends</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fiends from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fiend would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -13526,6 +14221,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Plants</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents plants from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a plant would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -13535,6 +14231,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Scroll of Protection from Undead</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents undead from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an undead would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -13550,6 +14247,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Seeker Dart</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -13571,6 +14269,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sending Stones</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Sending stones come in pairs, with each smooth stone carved to match the other so the pairing is easily recognized. While you touch one stone, you can use an action to cast the sending spell from it. The target is the bearer of the other stone. If no creature bears the other stone, you know that fact as soon as you use the stone and don't cast the spell.</text>
@@ -13581,6 +14280,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sentinel Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Uncommon</rarity>
@@ -13603,6 +14303,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
         <name>Shard of the Ise Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -13644,6 +14345,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Shield +1</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Uncommon</rarity>
@@ -13656,6 +14358,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shield +2</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Rare</rarity>
@@ -13668,6 +14371,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shield +3</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Very Rare</rarity>
@@ -13680,6 +14384,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
 		<name>Shield of Far Sight</name>
 		<type>S</type>
+    <magic>1</magic>
 		<weight>6</weight>
 		<text>Rarity: Rare</text>
 		<text>	A mind flayer skilled at crafting magic items creates a shield of far sight by harvesting an eye from an intelligent humanoid and magically implanting it on the outer surface of a nonmagical shield. The shield becomes a magic item once the eyes is implanted, whereupon the mind flayer can give the shield to a thrall or hang it on a wall in its lair. As long as the shield is on the same plane of existence as its creator, the mind flayer can see through the shield's eye, which has darkvision out to a range of 60 feet. While peering through this magical eye, the mind flayer can use its Mind Blast action as though it were standing behind the shield.</text>
@@ -13694,6 +14399,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 <item>
     <name>Shield of Missile Attraction</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Rare</rarity>
@@ -13727,6 +14433,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Shortbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13750,6 +14457,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13773,6 +14481,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13796,6 +14505,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13832,6 +14542,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Shortsword +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13851,6 +14562,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortsword +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13870,6 +14582,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortsword +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13889,6 +14602,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortsword of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13907,6 +14621,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortsword of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13931,6 +14646,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortsword of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13949,6 +14665,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Shortsword of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -13988,6 +14705,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Sickle +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -14005,6 +14723,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sickle +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -14022,6 +14741,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sickle +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -14039,6 +14759,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sickle of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -14095,6 +14816,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Silver Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14133,6 +14855,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Sling +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -14154,6 +14877,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sling +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -14175,6 +14899,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sling +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -14196,6 +14921,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sling Bullet of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -14226,6 +14952,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Sling Bullets +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -14238,6 +14965,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sling Bullets +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -14250,6 +14978,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sling Bullets +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -14262,6 +14991,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sling of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -14282,6 +15012,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Slippers of Spider Climbing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -14308,6 +15039,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Sovereign Glue</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with oil of slipperiness. When found, a container contains 1d6 + 1 ounces.</text>
@@ -14336,6 +15068,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Spear +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -14359,6 +15092,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spear +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -14382,6 +15116,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spear +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -14405,6 +15140,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spear of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -14427,6 +15163,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Amber)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>An amber spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14440,6 +15177,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Bloodstone)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A bloodstone spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14453,6 +15191,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Diamond)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A diamond spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14466,6 +15205,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Jade)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A jade spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14479,6 +15219,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Lapis lazuli)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A lapis lazuli spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14492,6 +15233,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Obsidian)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>An obsidian spell gem can contain one cantrip from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14505,6 +15247,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Quartz)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A quartz spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14518,6 +15261,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Ruby)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A ruby spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14531,6 +15275,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Star ruby)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A star ruby spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14544,6 +15289,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Gem (Topaz)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A topaz spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14557,6 +15303,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (1st Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14572,6 +15319,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (2nd Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14587,6 +15335,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (3rd Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14602,6 +15351,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (4th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14617,6 +15367,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (5th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14632,6 +15383,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (6th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14647,6 +15399,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (7th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14662,6 +15415,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (8th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14677,6 +15431,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (9th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14692,6 +15447,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spell Scroll (Cantrip)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -14716,6 +15472,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Spellguard Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Very Rare</rarity>
@@ -14728,6 +15485,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sphere of Annihilation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.</text>
@@ -14747,6 +15505,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spider Staff</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>6</weight>
     <text>Requires Attunement</text>
     <text />
@@ -14773,6 +15532,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
     <name>Spiked Armor +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14784,6 +15544,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14795,6 +15556,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14806,6 +15568,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14817,6 +15580,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14828,6 +15592,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14839,6 +15604,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14850,6 +15616,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14861,6 +15628,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14872,6 +15640,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14883,6 +15652,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14894,6 +15664,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14905,6 +15676,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Spiked Armor of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -14928,6 +15700,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Splint Armor +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -14942,6 +15715,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -14956,6 +15730,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -14970,6 +15745,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -14984,6 +15760,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -14998,6 +15775,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15012,6 +15790,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15026,6 +15805,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15040,6 +15820,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15054,6 +15835,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15068,6 +15850,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15082,6 +15865,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15096,6 +15880,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Splint Armor of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -15136,6 +15921,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Staff of Charming</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -15151,6 +15937,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Defense</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>3</weight>
     <text>Requires Attunement</text>
     <text />
@@ -15166,6 +15953,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Fire</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -15181,6 +15969,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Frost</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -15196,6 +15985,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Healing</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -15210,6 +16000,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Power</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -15240,6 +16031,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Striking</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -15257,6 +16049,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Swarming Insects</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -15274,6 +16067,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Thunder and Lightning</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -15299,6 +16093,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of Withering</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -15314,6 +16109,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of the Adder</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -15330,6 +16126,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of the Magi</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -15358,6 +16155,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of the Python</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -15372,6 +16170,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Staff of the Woodlands</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -15399,6 +16198,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Stone of Controlling Earth Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -15409,6 +16209,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Stone of Good Luck</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -15421,6 +16222,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Stonespeaker Crystal</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires attunement</text>
     <text />
     <text>Created by the stone giant librarians of Gravenhollow, this nineteen-inch-long shard of quartz grants you advantage on Intelligence (investigation) checks while it is on your person.</text>
@@ -15433,6 +16235,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Storm Boomerang</name>
     <type>R</type>
+    <magic>1</magic>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <range>60/120</range>
@@ -15457,6 +16260,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Studded Leather Armor +1</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15469,6 +16273,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor +2</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Very Rare</rarity>
@@ -15481,6 +16286,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor +3</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Legendary</rarity>
@@ -15493,6 +16299,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Acid Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15505,6 +16312,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Cold Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15517,6 +16325,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Fire Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15529,6 +16338,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Force Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15541,6 +16351,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Lightning Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15553,6 +16364,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Necrotic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15565,6 +16377,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Poison Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15577,6 +16390,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Psychic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15589,6 +16403,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Radiant Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15601,6 +16416,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Studded Leather Armor of Thunder Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -15613,6 +16429,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sun Blade</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15636,6 +16453,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sunsword</name>
     <type>M</type>
+    <magic>1</magic>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
@@ -15662,6 +16480,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
     <name>Sword of Answering (Answerer)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15683,6 +16502,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Back Talker)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15704,6 +16524,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Concluder)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15725,6 +16546,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Last Quip)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15746,6 +16568,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Rebutter)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15767,6 +16590,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Replier)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15788,6 +16612,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Retorter)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15809,6 +16634,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Scather)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15830,6 +16656,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Answering (Squelcher)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15851,6 +16678,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Sword of Kas</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -15884,6 +16712,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Talisman of Pure Good</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -15900,6 +16729,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Talisman of Ultimate Evil</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -15916,6 +16746,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Talisman of the Sphere</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -15936,6 +16767,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Tentacle Rod</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -15976,6 +16808,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Tinderstrike</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -16017,6 +16850,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Tome of Clear Thought</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -16027,6 +16861,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Tome of Leadership and Influence</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -16037,6 +16872,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Tome of Strahd</name>
     <type>G</type>
+    <magic>1</magic>
     <weight>5</weight>
     <text>The Tome of Strahd is an ancient work penned by Strahd, a tragic tale of how he came to his fallen state. The book is bound in a thick leather cover with steel hinges and fastenings. The pages are of parchment and very brittle. Most of the book is written in the curious shorthand that only Strahd employs. Stains and age have made most of the work illegible, but several paragraphs remain intact.</text>
     <text />
@@ -16045,6 +16881,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Tome of Understanding</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -16055,6 +16892,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Tome of the Stilled Tongue</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -16122,6 +16960,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Trident +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -16145,6 +16984,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Trident +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -16168,6 +17008,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Trident +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -16191,6 +17032,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Trident of Fish Command</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -16213,6 +17055,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Trident of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -16472,6 +17315,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Universal Solvent</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This tube holds milky liquid with a strong alcohol smell. You can use an action to pour the contents of the tube onto a surface within reach. The liquid instantly dissolves up to 1 square foot of adhesive it touches, including sovereign glue.</text>
@@ -16489,6 +17333,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Vicious Battleaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -16505,6 +17350,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Blowgun</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -16526,6 +17372,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Club</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -16541,6 +17388,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Dagger</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -16563,6 +17411,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Dart</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -16583,6 +17432,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Flail</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -16595,6 +17445,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Glaive</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -16614,6 +17465,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Greataxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -16631,6 +17483,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Greatclub</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -16646,6 +17499,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -16663,6 +17517,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Halberd</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -16682,6 +17537,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Hand Crossbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -16705,6 +17561,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Handaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -16725,6 +17582,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Heavy Crossbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -16750,6 +17608,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Javelin</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -16768,6 +17627,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Lance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -16783,6 +17643,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Light Crossbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -16806,6 +17667,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Light Hammer</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -16826,6 +17688,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Longbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -16849,6 +17712,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -16865,6 +17729,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Mace</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -16877,6 +17742,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Maul</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmg2>2d6</dmg2>
@@ -16895,6 +17761,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Morningstar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -16907,6 +17774,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Pike</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -16926,6 +17794,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Quarterstaff</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -16942,6 +17811,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -16957,6 +17827,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -16974,6 +17845,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Shortbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -16995,6 +17867,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -17012,6 +17885,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Sickle</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -17027,6 +17901,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Sling</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -17046,6 +17921,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Spear</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -17067,6 +17943,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Trident</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -17088,6 +17965,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious War Pick</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -17100,6 +17978,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Warhammer</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -17116,6 +17995,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vicious Whip</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -17146,6 +18026,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Vorpal Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -17168,6 +18049,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vorpal Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -17189,6 +18071,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Vorpal Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -17220,6 +18103,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Wand of Binding</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17236,6 +18120,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Enemy Detection</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17250,6 +18135,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Fear</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17267,6 +18153,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Fireballs</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17288,6 +18175,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Lightning Bolts</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17309,6 +18197,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Magic Detection</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -17320,6 +18209,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Magic Missiles</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -17339,6 +18229,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Orcus</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
@@ -17373,6 +18264,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Paralysis</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17388,6 +18280,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Polymorph</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -17402,6 +18295,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Secrets</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -17413,6 +18307,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Viscid Globs</name>
     <type>WD</type>
+    <magic>1</magic>
     <text>Requires attunement</text>
     <text />
     <text>Crafted by the drow, this slim black wand has 7 charges. While holding it, you can use an action to expend 1 of its charges to cause a small glob of viscous material to launch from the tip at one creature within 60 feet of you. Make a ranged attack roll against the target, with a bonus equal to your spellcasting modifier (or your Intelligence modifier, if you don't have a spellcasting modifier) plus your proficiency bonus. On a hit, the glob expands and dries on the target, which is restrained for 1 hour. After that time, the viscous material cracks and falls away.</text>
@@ -17426,6 +18321,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Web</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -17440,6 +18336,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Winter</name>
     <type>WD</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This wand looks and feels like an icicle. You must be attuned to the want to use it.</text>
@@ -17450,6 +18347,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of Wonder</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17490,6 +18388,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of the War Mage, +1</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -17503,6 +18402,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of the War Mage, +2</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -17516,6 +18416,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wand of the War Mage, +3</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -17538,6 +18439,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>War Pick +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -17552,6 +18454,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>War Pick +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -17566,6 +18469,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>War Pick +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -17580,6 +18484,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>War Pick of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -17606,6 +18511,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Warhammer +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -17624,6 +18530,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Warhammer +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -17642,6 +18549,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Warhammer +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -17660,6 +18568,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Warhammer of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -17686,6 +18595,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Wave</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -17722,6 +18632,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Weird Tank</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>A weird tank is a ten-gallon tank of blown glass and sculpted bronze with a backpack-like carrying harness fashioned from tough leather. A water weird (see the Monster Manual for statistics) is contained within the tank. While wearing the tank, you can use an action to open it, allowing the water weird to emerge. The water weird acts immediately after you in the initiative order, and it is bound to the tank.</text>
@@ -17734,6 +18645,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Well of Many Worlds</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
@@ -17745,6 +18657,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Whelm</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -17792,6 +18705,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
     <name>Whip +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -17811,6 +18725,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Whip +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -17830,6 +18745,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Whip +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -17849,6 +18765,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Whip of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -17867,6 +18784,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>White Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This gleaming mask is white with highlights of pale blue and is topped by a spined crest. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -17890,6 +18808,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>White Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -17905,6 +18824,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wind Fan</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While holding this fan, you can use an action to cast the gust of wind spell (save DC 13) from it. Once used, the fan shouldn't be used again until the next dawn. Each time it is used again before then, it has a cumulative 20 percent chance of not working and tearing into useless, nonmagical tatters.</text>
@@ -17914,6 +18834,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Windvane</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -17945,6 +18866,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Winged Boots</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -17957,6 +18879,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wings of Flying</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -17969,6 +18892,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
   <item>
     <name>Wingwear</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This snug uniform has symbols of air stitched into it and leathery flaps that stretch along the arms, waist, and legs to create wings for gliding. A suit of wingwear has 3 charges. While you wear the suit, you can use a bonus action and expend 1 charge to gain a flying speed of 30 feet until you land. At the end of each of your turns, your altitude drops by 5 feet. Your altitude drops instantly to 0 feet at the end of your turn if you didn't fly at least 30 feet horizontally on that turn. When your altitude drops to 0 feet, you land (or fall), and you must expend another charge to use the suit again.</text>
@@ -17997,6 +18921,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
         <name>Wyrmskull Throne</name>
         <type>W</type>
+        <magic>1</magic>
         <rarity>Artifact</rarity>
         <text>Rarity: Artifact</text>
         <text />

--- a/Items/Magic Items.xml
+++ b/Items/Magic Items.xml
@@ -4,6 +4,7 @@
   <item>
     <name>Adamantine Chain Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -17,6 +18,7 @@
   <item>
     <name>Adamantine Plate Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -30,6 +32,7 @@
   <item>
     <name>Adamantine Ring Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -42,6 +45,7 @@
   <item>
     <name>Adamantine Splint Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -55,6 +59,7 @@
   <item>
     <name>Chain Mail of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -69,6 +74,7 @@
   <item>
     <name>Chain Mail of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -83,6 +89,7 @@
   <item>
     <name>Chain Mail of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -97,6 +104,7 @@
   <item>
     <name>Chain Mail of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -111,6 +119,7 @@
   <item>
     <name>Chain Mail of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -125,6 +134,7 @@
   <item>
     <name>Chain Mail of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -139,6 +149,7 @@
   <item>
     <name>Chain Mail of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -153,6 +164,7 @@
   <item>
     <name>Chain Mail of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -167,6 +179,7 @@
   <item>
     <name>Chain Mail of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -181,6 +194,7 @@
   <item>
     <name>Chain Mail of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -195,6 +209,7 @@
   <item>
     <name>Mariner's Chain Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -208,6 +223,7 @@
   <item>
     <name>Mariner's Plate Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -221,6 +237,7 @@
   <item>
     <name>Mariner's Ring Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -233,6 +250,7 @@
   <item>
     <name>Mariner's Splint Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -246,6 +264,7 @@
   <item>
     <name>Mithral Chain Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <rarity>Uncommon</rarity>
@@ -257,6 +276,7 @@
   <item>
     <name>Mithral Plate Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <rarity>Uncommon</rarity>
@@ -268,6 +288,7 @@
   <item>
     <name>Mithral Ring Mail</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -279,6 +300,7 @@
   <item>
     <name>Mithral Splint Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <rarity>Uncommon</rarity>
@@ -290,6 +312,7 @@
   <item>
     <name>Plate Armor of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -304,6 +327,7 @@
   <item>
     <name>Plate Armor of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -318,6 +342,7 @@
   <item>
     <name>Plate Armor of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -332,6 +357,7 @@
   <item>
     <name>Plate Armor of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -346,6 +372,7 @@
   <item>
     <name>Plate Armor of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -360,6 +387,7 @@
   <item>
     <name>Plate Armor of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -374,6 +402,7 @@
   <item>
     <name>Plate Armor of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -388,6 +417,7 @@
   <item>
     <name>Plate Armor of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -402,6 +432,7 @@
   <item>
     <name>Plate Armor of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -416,6 +447,7 @@
   <item>
     <name>Plate Armor of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -430,6 +462,7 @@
   <item>
     <name>Ring Mail of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -443,6 +476,7 @@
   <item>
     <name>Ring Mail of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -456,6 +490,7 @@
   <item>
     <name>Ring Mail of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -469,6 +504,7 @@
   <item>
     <name>Ring Mail of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -482,6 +518,7 @@
   <item>
     <name>Ring Mail of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -495,6 +532,7 @@
   <item>
     <name>Ring Mail of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -508,6 +546,7 @@
   <item>
     <name>Ring Mail of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -521,6 +560,7 @@
   <item>
     <name>Ring Mail of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -534,6 +574,7 @@
   <item>
     <name>Ring Mail of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -547,6 +588,7 @@
   <item>
     <name>Ring Mail of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -560,6 +602,7 @@
   <item>
     <name>Splint Armor of Acid Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -574,6 +617,7 @@
   <item>
     <name>Splint Armor of Cold Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -588,6 +632,7 @@
   <item>
     <name>Splint Armor of Fire Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -602,6 +647,7 @@
   <item>
     <name>Splint Armor of Force Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -616,6 +662,7 @@
   <item>
     <name>Splint Armor of Lightning Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -630,6 +677,7 @@
   <item>
     <name>Splint Armor of Necrotic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -644,6 +692,7 @@
   <item>
     <name>Splint Armor of Poison Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -658,6 +707,7 @@
   <item>
     <name>Splint Armor of Psychic Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -672,6 +722,7 @@
   <item>
     <name>Splint Armor of Radiant Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -686,6 +737,7 @@
   <item>
     <name>Splint Armor of Thunder Resistance</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -700,6 +752,7 @@
   <item>
     <name>Leather Armor of Acid Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -712,6 +765,7 @@
   <item>
     <name>Leather Armor of Cold Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -724,6 +778,7 @@
   <item>
     <name>Leather Armor of Fire Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -736,6 +791,7 @@
   <item>
     <name>Leather Armor of Force Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -748,6 +804,7 @@
   <item>
     <name>Leather Armor of Lightning Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -760,6 +817,7 @@
   <item>
     <name>Leather Armor of Necrotic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -772,6 +830,7 @@
   <item>
     <name>Leather Armor of Poison Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -784,6 +843,7 @@
   <item>
     <name>Leather Armor of Psychic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -796,6 +856,7 @@
   <item>
     <name>Leather Armor of Radiant Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -808,6 +869,7 @@
   <item>
     <name>Leather Armor of Thunder Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -820,6 +882,7 @@
   <item>
     <name>Mariner's Leather Armor</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Uncommon</rarity>
@@ -831,6 +894,7 @@
   <item>
     <name>Mariner's Padded Armor</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -843,6 +907,7 @@
   <item>
     <name>Mariner's Studded Leather Armor</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Uncommon</rarity>
@@ -854,6 +919,7 @@
   <item>
     <name>Padded Armor of Acid Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -867,6 +933,7 @@
   <item>
     <name>Padded Armor of Cold Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -880,6 +947,7 @@
   <item>
     <name>Padded Armor of Fire Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -893,6 +961,7 @@
   <item>
     <name>Padded Armor of Force Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -906,6 +975,7 @@
   <item>
     <name>Padded Armor of Lightning Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -919,6 +989,7 @@
   <item>
     <name>Padded Armor of Necrotic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -932,6 +1003,7 @@
   <item>
     <name>Padded Armor of Poison Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -945,6 +1017,7 @@
   <item>
     <name>Padded Armor of Psychic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -958,6 +1031,7 @@
   <item>
     <name>Padded Armor of Radiant Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -971,6 +1045,7 @@
   <item>
     <name>Padded Armor of Thunder Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -984,6 +1059,7 @@
   <item>
     <name>Studded Leather Armor of Acid Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -996,6 +1072,7 @@
   <item>
     <name>Studded Leather Armor of Cold Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1008,6 +1085,7 @@
   <item>
     <name>Studded Leather Armor of Fire Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1020,6 +1098,7 @@
   <item>
     <name>Studded Leather Armor of Force Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1032,6 +1111,7 @@
   <item>
     <name>Studded Leather Armor of Lightning Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1044,6 +1124,7 @@
   <item>
     <name>Studded Leather Armor of Necrotic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1056,6 +1137,7 @@
   <item>
     <name>Studded Leather Armor of Poison Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1068,6 +1150,7 @@
   <item>
     <name>Studded Leather Armor of Psychic Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1080,6 +1163,7 @@
   <item>
     <name>Studded Leather Armor of Radiant Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1092,6 +1176,7 @@
   <item>
     <name>Studded Leather Armor of Thunder Resistance</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -1104,6 +1189,7 @@
   <item>
     <name>Battleaxe of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1121,6 +1207,7 @@
   <item>
     <name>Club of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -1137,6 +1224,7 @@
   <item>
     <name>Dagger of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -1160,6 +1248,7 @@
   <item>
     <name>Flail of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -1173,6 +1262,7 @@
   <item>
     <name>Glaive of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -1193,6 +1283,7 @@
   <item>
     <name>Greataxe of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -1211,6 +1302,7 @@
   <item>
     <name>Greatclub of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -1227,6 +1319,7 @@
   <item>
     <name>Greatsword of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -1245,6 +1338,7 @@
   <item>
     <name>Halberd of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -1265,6 +1359,7 @@
   <item>
     <name>Handaxe of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -1286,6 +1381,7 @@
   <item>
     <name>Javelin of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -1305,6 +1401,7 @@
   <item>
     <name>Lance of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -1321,6 +1418,7 @@
   <item>
     <name>Light Hammer of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -1342,6 +1440,7 @@
   <item>
     <name>Longsword of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1359,6 +1458,7 @@
   <item>
     <name>Mace of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -1372,6 +1472,7 @@
   <item>
     <name>Maul of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmg2>2d6</dmg2>
@@ -1391,6 +1492,7 @@
   <item>
     <name>Morningstar of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -1404,6 +1506,7 @@
   <item>
     <name>Pike of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -1424,6 +1527,7 @@
   <item>
     <name>Quarterstaff of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -1441,6 +1545,7 @@
   <item>
     <name>Rapier of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -1457,6 +1562,7 @@
   <item>
     <name>Scimitar of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -1475,6 +1581,7 @@
   <item>
     <name>Shortsword of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -1493,6 +1600,7 @@
   <item>
     <name>Sickle of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -1509,6 +1617,7 @@
   <item>
     <name>Spear of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -1531,6 +1640,7 @@
   <item>
     <name>Trident of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -1553,6 +1663,7 @@
   <item>
     <name>Vicious Battleaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1569,6 +1680,7 @@
   <item>
     <name>Vicious Club</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -1584,6 +1696,7 @@
   <item>
     <name>Vicious Dagger</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -1606,6 +1719,7 @@
   <item>
     <name>Vicious Flail</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -1618,6 +1732,7 @@
   <item>
     <name>Vicious Glaive</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -1637,6 +1752,7 @@
   <item>
     <name>Vicious Greataxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -1654,6 +1770,7 @@
   <item>
     <name>Vicious Greatclub</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -1669,6 +1786,7 @@
   <item>
     <name>Vicious Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -1686,6 +1804,7 @@
   <item>
     <name>Vicious Halberd</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -1705,6 +1824,7 @@
   <item>
     <name>Vicious Handaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -1725,6 +1845,7 @@
   <item>
     <name>Vicious Javelin</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -1743,6 +1864,7 @@
   <item>
     <name>Vicious Lance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -1758,6 +1880,7 @@
   <item>
     <name>Vicious Light Hammer</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -1778,6 +1901,7 @@
   <item>
     <name>Vicious Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -1794,6 +1918,7 @@
   <item>
     <name>Vicious Mace</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -1806,6 +1931,7 @@
   <item>
     <name>Vicious Maul</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmg2>2d6</dmg2>
@@ -1824,6 +1950,7 @@
   <item>
     <name>Vicious Morningstar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -1836,6 +1963,7 @@
   <item>
     <name>Vicious Pike</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -1855,6 +1983,7 @@
   <item>
     <name>Vicious Quarterstaff</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -1871,6 +2000,7 @@
   <item>
     <name>Vicious Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -1886,6 +2016,7 @@
   <item>
     <name>Vicious Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -1903,6 +2034,7 @@
   <item>
     <name>Vicious Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -1920,6 +2052,7 @@
   <item>
     <name>Vicious Sickle</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -1935,6 +2068,7 @@
   <item>
     <name>Vicious Spear</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -1956,6 +2090,7 @@
   <item>
     <name>Vicious Trident</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -1977,6 +2112,7 @@
   <item>
     <name>Vicious War Pick</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -1989,6 +2125,7 @@
   <item>
     <name>Vicious Warhammer</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -2005,6 +2142,7 @@
   <item>
     <name>Vicious Whip</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -2022,6 +2160,7 @@
   <item>
     <name>War Pick of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -2035,6 +2174,7 @@
   <item>
     <name>Warhammer of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -2052,6 +2192,7 @@
   <item>
     <name>Whip of Warning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -2070,6 +2211,7 @@
   <item>
     <name>Adamantine Breastplate</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -2081,6 +2223,7 @@
   <item>
     <name>Adamantine Chain Shirt</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Uncommon</rarity>
@@ -2092,6 +2235,7 @@
   <item>
     <name>Adamantine Half Plate Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2104,6 +2248,7 @@
   <item>
     <name>Adamantine Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2116,6 +2261,7 @@
   <item>
     <name>Black Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2131,6 +2277,7 @@
   <item>
     <name>Blue Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2146,6 +2293,7 @@
   <item>
     <name>Brass Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2161,6 +2309,7 @@
   <item>
     <name>Breastplate of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2173,6 +2322,7 @@
   <item>
     <name>Breastplate of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2185,6 +2335,7 @@
   <item>
     <name>Breastplate of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2197,6 +2348,7 @@
   <item>
     <name>Breastplate of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2209,6 +2361,7 @@
   <item>
     <name>Breastplate of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2221,6 +2374,7 @@
   <item>
     <name>Breastplate of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2233,6 +2387,7 @@
   <item>
     <name>Breastplate of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2245,6 +2400,7 @@
   <item>
     <name>Breastplate of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2257,6 +2413,7 @@
   <item>
     <name>Breastplate of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2269,6 +2426,7 @@
   <item>
     <name>Breastplate of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -2281,6 +2439,7 @@
   <item>
     <name>Bronze Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2296,6 +2455,7 @@
   <item>
     <name>Chain Shirt of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2308,6 +2468,7 @@
   <item>
     <name>Chain Shirt of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2320,6 +2481,7 @@
   <item>
     <name>Chain Shirt of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2332,6 +2494,7 @@
   <item>
     <name>Chain Shirt of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2344,6 +2507,7 @@
   <item>
     <name>Chain Shirt of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2356,6 +2520,7 @@
   <item>
     <name>Chain Shirt of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2368,6 +2533,7 @@
   <item>
     <name>Chain Shirt of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2380,6 +2546,7 @@
   <item>
     <name>Chain Shirt of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2392,6 +2559,7 @@
   <item>
     <name>Chain Shirt of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2404,6 +2572,7 @@
   <item>
     <name>Chain Shirt of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -2416,6 +2585,7 @@
   <item>
     <name>Copper Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2431,6 +2601,7 @@
   <item>
     <name>Gold Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2446,6 +2617,7 @@
   <item>
     <name>Green Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2461,6 +2633,7 @@
   <item>
     <name>Half Plate Armor of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2474,6 +2647,7 @@
   <item>
     <name>Half Plate Armor of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2487,6 +2661,7 @@
   <item>
     <name>Half Plate Armor of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2500,6 +2675,7 @@
   <item>
     <name>Half Plate Armor of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2513,6 +2689,7 @@
   <item>
     <name>Half Plate Armor of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2526,6 +2703,7 @@
   <item>
     <name>Half Plate Armor of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2539,6 +2717,7 @@
   <item>
     <name>Half Plate Armor of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2552,6 +2731,7 @@
   <item>
     <name>Half Plate Armor of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2565,6 +2745,7 @@
   <item>
     <name>Half Plate Armor of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2578,6 +2759,7 @@
   <item>
     <name>Half Plate Armor of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2591,6 +2773,7 @@
   <item>
     <name>Hide Armor of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2603,6 +2786,7 @@
   <item>
     <name>Hide Armor of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2615,6 +2799,7 @@
   <item>
     <name>Hide Armor of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2627,6 +2812,7 @@
   <item>
     <name>Hide Armor of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2639,6 +2825,7 @@
   <item>
     <name>Hide Armor of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2651,6 +2838,7 @@
   <item>
     <name>Hide Armor of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2663,6 +2851,7 @@
   <item>
     <name>Hide Armor of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2675,6 +2864,7 @@
   <item>
     <name>Hide Armor of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2687,6 +2877,7 @@
   <item>
     <name>Hide Armor of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2699,6 +2890,7 @@
   <item>
     <name>Hide Armor of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -2711,6 +2903,7 @@
   <item>
     <name>Mariner's Breastplate</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -2722,6 +2915,7 @@
   <item>
     <name>Mariner's Chain Shirt</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Uncommon</rarity>
@@ -2733,6 +2927,7 @@
   <item>
     <name>Mariner's Half Plate Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -2745,6 +2940,7 @@
   <item>
     <name>Mariner's Hide Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Uncommon</rarity>
@@ -2756,6 +2952,7 @@
   <item>
     <name>Mariner's Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2768,6 +2965,7 @@
   <item>
     <name>Mithral Breastplate</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -2779,6 +2977,7 @@
   <item>
     <name>Mithral Chain Shirt</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Uncommon</rarity>
@@ -2790,6 +2989,7 @@
   <item>
     <name>Mithral Half Plate Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <rarity>Uncommon</rarity>
@@ -2801,6 +3001,7 @@
   <item>
     <name>Mithral Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <rarity>Uncommon</rarity>
@@ -2812,6 +3013,7 @@
   <item>
     <name>Red Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2827,6 +3029,7 @@
   <item>
     <name>Scale Mail of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2840,6 +3043,7 @@
   <item>
     <name>Scale Mail of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2853,6 +3057,7 @@
   <item>
     <name>Scale Mail of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2866,6 +3071,7 @@
   <item>
     <name>Scale Mail of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2879,6 +3085,7 @@
   <item>
     <name>Scale Mail of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2892,6 +3099,7 @@
   <item>
     <name>Scale Mail of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2905,6 +3113,7 @@
   <item>
     <name>Scale Mail of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2918,6 +3127,7 @@
   <item>
     <name>Scale Mail of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2931,6 +3141,7 @@
   <item>
     <name>Scale Mail of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2944,6 +3155,7 @@
   <item>
     <name>Scale Mail of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2957,6 +3169,7 @@
   <item>
     <name>Silver Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2972,6 +3185,7 @@
   <item>
     <name>White Dragon Scale Mail</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -2987,6 +3201,7 @@
   <item>
     <name>Blowgun of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -3009,6 +3224,7 @@
   <item>
     <name>Dart of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3030,6 +3246,7 @@
   <item>
     <name>Hand Crossbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -3054,6 +3271,7 @@
   <item>
     <name>Heavy Crossbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -3080,6 +3298,7 @@
   <item>
     <name>Light Crossbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -3104,6 +3323,7 @@
   <item>
     <name>Longbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -3128,6 +3348,7 @@
   <item>
     <name>Net of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -3146,6 +3367,7 @@
   <item>
     <name>Shortbow of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -3168,6 +3390,7 @@
   <item>
     <name>Sling of Warning</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3188,6 +3411,7 @@
   <item>
     <name>Vicious Blowgun</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -3209,6 +3433,7 @@
   <item>
     <name>Vicious Dart</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3229,6 +3454,7 @@
   <item>
     <name>Vicious Hand Crossbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -3252,6 +3478,7 @@
   <item>
     <name>Vicious Heavy Crossbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -3277,6 +3504,7 @@
   <item>
     <name>Vicious Light Crossbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -3300,6 +3528,7 @@
   <item>
     <name>Vicious Longbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -3323,6 +3552,7 @@
   <item>
     <name>Vicious Shortbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -3344,6 +3574,7 @@
   <item>
     <name>Vicious Sling</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3363,6 +3594,7 @@
   <item>
     <name>Arrows +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -3375,6 +3607,7 @@
   <item>
     <name>Arrows +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -3387,6 +3620,7 @@
   <item>
     <name>Arrows +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -3399,6 +3633,7 @@
   <item>
     <name>Blowgun Needles +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -3411,6 +3646,7 @@
   <item>
     <name>Blowgun Needles +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -3423,6 +3659,7 @@
   <item>
     <name>Blowgun Needles +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -3435,6 +3672,7 @@
   <item>
     <name>Crossbow Bolts +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -3447,6 +3685,7 @@
   <item>
     <name>Crossbow Bolts +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -3459,6 +3698,7 @@
   <item>
     <name>Crossbow Bolts +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -3471,6 +3711,7 @@
   <item>
     <name>Sling Bullets +1</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -3483,6 +3724,7 @@
   <item>
     <name>Sling Bullets +2</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -3495,6 +3737,7 @@
   <item>
     <name>Sling Bullets +3</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -3507,6 +3750,7 @@
   <item>
     <name>Chain Mail +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -3521,6 +3765,7 @@
   <item>
     <name>Chain Mail +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -3535,6 +3780,7 @@
   <item>
     <name>Chain Mail +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -3549,6 +3795,7 @@
   <item>
     <name>Plate Armor +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -3563,6 +3810,7 @@
   <item>
     <name>Plate Armor +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -3577,6 +3825,7 @@
   <item>
     <name>Plate Armor +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -3591,6 +3840,7 @@
   <item>
     <name>Ring Mail +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -3604,6 +3854,7 @@
   <item>
     <name>Ring Mail +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -3617,6 +3868,7 @@
   <item>
     <name>Ring Mail +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -3630,6 +3882,7 @@
   <item>
     <name>Splint Armor +1</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -3644,6 +3897,7 @@
   <item>
     <name>Splint Armor +2</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -3658,6 +3912,7 @@
   <item>
     <name>Splint Armor +3</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>60</weight>
     <ac>17</ac>
     <strength>15</strength>
@@ -3672,6 +3927,7 @@
   <item>
     <name>Leather Armor +1</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Rare</rarity>
@@ -3684,6 +3940,7 @@
   <item>
     <name>Leather Armor +2</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Very Rare</rarity>
@@ -3696,6 +3953,7 @@
   <item>
     <name>Leather Armor +3</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>10</weight>
     <ac>11</ac>
     <rarity>Legendary</rarity>
@@ -3708,6 +3966,7 @@
   <item>
     <name>Padded Armor +1</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -3721,6 +3980,7 @@
   <item>
     <name>Padded Armor +2</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -3734,6 +3994,7 @@
   <item>
     <name>Padded Armor +3</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>8</weight>
     <ac>11</ac>
     <stealth>YES</stealth>
@@ -3747,6 +4008,7 @@
   <item>
     <name>Studded Leather Armor +1</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -3759,6 +4021,7 @@
   <item>
     <name>Studded Leather Armor +2</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Very Rare</rarity>
@@ -3771,6 +4034,7 @@
   <item>
     <name>Studded Leather Armor +3</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>12</ac>
     <rarity>Legendary</rarity>
@@ -3783,6 +4047,7 @@
   <item>
     <name>Battleaxe +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -3801,6 +4066,7 @@
   <item>
     <name>Battleaxe +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -3819,6 +4085,7 @@
   <item>
     <name>Battleaxe +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -3837,6 +4104,7 @@
   <item>
     <name>Club +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3854,6 +4122,7 @@
   <item>
     <name>Club +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3871,6 +4140,7 @@
   <item>
     <name>Club +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -3888,6 +4158,7 @@
   <item>
     <name>Dagger +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3912,6 +4183,7 @@
   <item>
     <name>Dagger +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3936,6 +4208,7 @@
   <item>
     <name>Dagger +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -3960,6 +4233,7 @@
   <item>
     <name>Flail +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -3974,6 +4248,7 @@
   <item>
     <name>Flail +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -3988,6 +4263,7 @@
   <item>
     <name>Flail +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -4002,6 +4278,7 @@
   <item>
     <name>Glaive +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -4023,6 +4300,7 @@
   <item>
     <name>Glaive +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -4044,6 +4322,7 @@
   <item>
     <name>Glaive +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -4065,6 +4344,7 @@
   <item>
     <name>Greataxe +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -4084,6 +4364,7 @@
   <item>
     <name>Greataxe +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -4103,6 +4384,7 @@
   <item>
     <name>Greataxe +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -4122,6 +4404,7 @@
   <item>
     <name>Greatclub +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -4139,6 +4422,7 @@
   <item>
     <name>Greatclub +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -4156,6 +4440,7 @@
   <item>
     <name>Greatclub +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>1d8</dmg1>
     <dmgType>B</dmgType>
@@ -4173,6 +4458,7 @@
   <item>
     <name>Greatsword +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -4192,6 +4478,7 @@
   <item>
     <name>Greatsword +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -4211,6 +4498,7 @@
   <item>
     <name>Greatsword +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -4230,6 +4518,7 @@
   <item>
     <name>Halberd +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -4251,6 +4540,7 @@
   <item>
     <name>Halberd +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -4272,6 +4562,7 @@
   <item>
     <name>Halberd +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d10</dmg1>
     <dmgType>S</dmgType>
@@ -4293,6 +4584,7 @@
   <item>
     <name>Handaxe +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4315,6 +4607,7 @@
   <item>
     <name>Handaxe +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4337,6 +4630,7 @@
   <item>
     <name>Handaxe +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4359,6 +4653,7 @@
   <item>
     <name>Javelin +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -4379,6 +4674,7 @@
   <item>
     <name>Javelin +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -4399,6 +4695,7 @@
   <item>
     <name>Javelin +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -4419,6 +4716,7 @@
   <item>
     <name>Lance +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -4436,6 +4734,7 @@
   <item>
     <name>Lance +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -4453,6 +4752,7 @@
   <item>
     <name>Lance +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>1d12</dmg1>
     <dmgType>P</dmgType>
@@ -4470,6 +4770,7 @@
   <item>
     <name>Light Hammer +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -4492,6 +4793,7 @@
   <item>
     <name>Light Hammer +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -4514,6 +4816,7 @@
   <item>
     <name>Light Hammer +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -4536,6 +4839,7 @@
   <item>
     <name>Longsword +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -4554,6 +4858,7 @@
   <item>
     <name>Longsword +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -4572,6 +4877,7 @@
   <item>
     <name>Longsword +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -4590,6 +4896,7 @@
   <item>
     <name>Mace +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -4604,6 +4911,7 @@
   <item>
     <name>Mace +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -4618,6 +4926,7 @@
   <item>
     <name>Mace +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -4632,6 +4941,7 @@
   <item>
     <name>Maul +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
@@ -4651,6 +4961,7 @@
   <item>
     <name>Maul +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
@@ -4670,6 +4981,7 @@
   <item>
     <name>Maul +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmgType>B</dmgType>
@@ -4689,6 +5001,7 @@
   <item>
     <name>Morningstar +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4703,6 +5016,7 @@
   <item>
     <name>Morningstar +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4717,6 +5031,7 @@
   <item>
     <name>Morningstar +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4731,6 +5046,7 @@
   <item>
     <name>Pike +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -4752,6 +5068,7 @@
   <item>
     <name>Pike +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -4773,6 +5090,7 @@
   <item>
     <name>Pike +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -4794,6 +5112,7 @@
   <item>
     <name>Quarterstaff +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -4812,6 +5131,7 @@
   <item>
     <name>Quarterstaff +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -4830,6 +5150,7 @@
   <item>
     <name>Quarterstaff +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -4848,6 +5169,7 @@
   <item>
     <name>Rapier +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4865,6 +5187,7 @@
   <item>
     <name>Rapier +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4882,6 +5205,7 @@
   <item>
     <name>Rapier +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -4899,6 +5223,7 @@
   <item>
     <name>Scimitar +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4918,6 +5243,7 @@
   <item>
     <name>Scimitar +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4937,6 +5263,7 @@
   <item>
     <name>Scimitar +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -4956,6 +5283,7 @@
   <item>
     <name>Shortsword +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -4975,6 +5303,7 @@
   <item>
     <name>Shortsword +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -4994,6 +5323,7 @@
   <item>
     <name>Shortsword +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -5013,6 +5343,7 @@
   <item>
     <name>Sickle +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -5030,6 +5361,7 @@
   <item>
     <name>Sickle +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -5047,6 +5379,7 @@
   <item>
     <name>Sickle +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -5064,6 +5397,7 @@
   <item>
     <name>Spear +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -5087,6 +5421,7 @@
   <item>
     <name>Spear +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -5110,6 +5445,7 @@
   <item>
     <name>Spear +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -5133,6 +5469,7 @@
   <item>
     <name>Trident +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -5156,6 +5493,7 @@
   <item>
     <name>Trident +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -5179,6 +5517,7 @@
   <item>
     <name>Trident +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -5202,6 +5541,7 @@
   <item>
     <name>War Pick +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5216,6 +5556,7 @@
   <item>
     <name>War Pick +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5230,6 +5571,7 @@
   <item>
     <name>War Pick +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5244,6 +5586,7 @@
   <item>
     <name>Warhammer +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -5262,6 +5605,7 @@
   <item>
     <name>Warhammer +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -5280,6 +5624,7 @@
   <item>
     <name>Warhammer +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -5298,6 +5643,7 @@
   <item>
     <name>Whip +1</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -5317,6 +5663,7 @@
   <item>
     <name>Whip +2</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -5336,6 +5683,7 @@
   <item>
     <name>Whip +3</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d4</dmg1>
     <dmgType>S</dmgType>
@@ -5355,6 +5703,7 @@
   <item>
     <name>Breastplate +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Rare</rarity>
@@ -5367,6 +5716,7 @@
   <item>
     <name>Breastplate +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Very Rare</rarity>
@@ -5379,6 +5729,7 @@
   <item>
     <name>Breastplate +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>14</ac>
     <rarity>Legendary</rarity>
@@ -5391,6 +5742,7 @@
   <item>
     <name>Chain Shirt +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -5403,6 +5755,7 @@
   <item>
     <name>Chain Shirt +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Very Rare</rarity>
@@ -5415,6 +5768,7 @@
   <item>
     <name>Chain Shirt +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Legendary</rarity>
@@ -5427,6 +5781,7 @@
   <item>
     <name>Half Plate Armor +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -5440,6 +5795,7 @@
   <item>
     <name>Half Plate Armor +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -5453,6 +5809,7 @@
   <item>
     <name>Half Plate Armor +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>40</weight>
     <ac>15</ac>
     <stealth>YES</stealth>
@@ -5466,6 +5823,7 @@
   <item>
     <name>Hide Armor +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Rare</rarity>
@@ -5478,6 +5836,7 @@
   <item>
     <name>Hide Armor +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Very Rare</rarity>
@@ -5490,6 +5849,7 @@
   <item>
     <name>Hide Armor +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>12</weight>
     <ac>12</ac>
     <rarity>Legendary</rarity>
@@ -5502,6 +5862,7 @@
   <item>
     <name>Scale Mail +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -5515,6 +5876,7 @@
   <item>
     <name>Scale Mail +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -5528,6 +5890,7 @@
   <item>
     <name>Scale Mail +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -5541,6 +5904,7 @@
   <item>
     <name>Blowgun +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -5564,6 +5928,7 @@
   <item>
     <name>Blowgun +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -5587,6 +5952,7 @@
   <item>
     <name>Blowgun +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1</dmg1>
     <dmgType>P</dmgType>
@@ -5610,6 +5976,7 @@
   <item>
     <name>Dart +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -5632,6 +5999,7 @@
   <item>
     <name>Dart +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -5654,6 +6022,7 @@
   <item>
     <name>Dart +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -5676,6 +6045,7 @@
   <item>
     <name>Hand Crossbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -5701,6 +6071,7 @@
   <item>
     <name>Hand Crossbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -5726,6 +6097,7 @@
   <item>
     <name>Hand Crossbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -5751,6 +6123,7 @@
   <item>
     <name>Heavy Crossbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -5778,6 +6151,7 @@
   <item>
     <name>Heavy Crossbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -5805,6 +6179,7 @@
   <item>
     <name>Heavy Crossbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>18</weight>
     <dmg1>1d10</dmg1>
     <dmgType>P</dmgType>
@@ -5832,6 +6207,7 @@
   <item>
     <name>Light Crossbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5857,6 +6233,7 @@
   <item>
     <name>Light Crossbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5882,6 +6259,7 @@
   <item>
     <name>Light Crossbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>5</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5907,6 +6285,7 @@
   <item>
     <name>Longbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5932,6 +6311,7 @@
   <item>
     <name>Longbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5957,6 +6337,7 @@
   <item>
     <name>Longbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -5982,6 +6363,7 @@
   <item>
     <name>Net +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -6003,6 +6385,7 @@
   <item>
     <name>Net +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -6024,6 +6407,7 @@
   <item>
     <name>Net +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>0</dmg1>
     <property>S,T</property>
@@ -6045,6 +6429,7 @@
   <item>
     <name>Shortbow +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6068,6 +6453,7 @@
   <item>
     <name>Shortbow +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6091,6 +6477,7 @@
   <item>
     <name>Shortbow +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6114,6 +6501,7 @@
   <item>
     <name>Sling +1</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -6135,6 +6523,7 @@
   <item>
     <name>Sling +2</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -6156,6 +6545,7 @@
   <item>
     <name>Sling +3</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0</weight>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
@@ -6177,6 +6567,7 @@
   <item>
     <name>Shield +1</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Uncommon</rarity>
@@ -6189,6 +6580,7 @@
   <item>
     <name>Shield +2</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Rare</rarity>
@@ -6201,6 +6593,7 @@
   <item>
     <name>Shield +3</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Very Rare</rarity>
@@ -6213,6 +6606,7 @@
   <item>
     <name>Arrow of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.05</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -6225,6 +6619,7 @@
   <item>
     <name>Blowgun Needle of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.02</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -6237,6 +6632,7 @@
   <item>
     <name>Crossbow Bolt of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -6249,6 +6645,7 @@
   <item>
     <name>Sling Bullet of Slaying</name>
     <type>A</type>
+    <magic>1</magic>
     <weight>0.075</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -6261,6 +6658,7 @@
   <item>
     <name>Armor of Invulnerability</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -6275,6 +6673,7 @@
   <item>
     <name>Armor of Vulnerability (Bludgeoning)</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -6291,6 +6690,7 @@
   <item>
     <name>Armor of Vulnerability (Piercing)</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -6307,6 +6707,7 @@
   <item>
     <name>Armor of Vulnerability (Slashing)</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -6323,6 +6724,7 @@
   <item>
     <name>Demon Armor</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -6340,6 +6742,7 @@
   <item>
     <name>Dwarven Plate</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -6354,6 +6757,7 @@
   <item>
     <name>Efreeti Chain</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>55</weight>
     <ac>16</ac>
     <strength>13</strength>
@@ -6369,6 +6773,7 @@
   <item>
     <name>Plate Armor of Etherealness</name>
     <type>HA</type>
+    <magic>1</magic>
     <weight>65</weight>
     <ac>18</ac>
     <strength>15</strength>
@@ -6383,6 +6788,7 @@
   <item>
     <name>Glamoured Studded Leather</name>
     <type>LA</type>
+    <magic>1</magic>
     <weight>13</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -6395,6 +6801,7 @@
   <item>
     <name>Berserker Battleaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -6417,6 +6824,7 @@
   <item>
     <name>Berserker Greataxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -6440,6 +6848,7 @@
   <item>
     <name>Berserker Handaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6466,6 +6875,7 @@
   <item>
     <name>Dagger of Venom</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -6492,6 +6902,7 @@
   <item>
     <name>Dancing Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6512,6 +6923,7 @@
   <item>
     <name>Dancing Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -6531,6 +6943,7 @@
   <item>
     <name>Dancing Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -6549,6 +6962,7 @@
   <item>
     <name>Dancing Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6569,6 +6983,7 @@
   <item>
     <name>Dancing Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6589,6 +7004,7 @@
   <item>
     <name>Defender Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6610,6 +7026,7 @@
   <item>
     <name>Defender Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -6630,6 +7047,7 @@
   <item>
     <name>Defender Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -6649,6 +7067,7 @@
   <item>
     <name>Defender Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6670,6 +7089,7 @@
   <item>
     <name>Defender Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6691,6 +7111,7 @@
   <item>
     <name>Dragon Slayer Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6712,6 +7133,7 @@
   <item>
     <name>Dragon Slayer Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -6732,6 +7154,7 @@
   <item>
     <name>Dragon Slayer Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -6751,6 +7174,7 @@
   <item>
     <name>Dragon Slayer Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6772,6 +7196,7 @@
   <item>
     <name>Dragon Slayer Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6793,6 +7218,7 @@
   <item>
     <name>Dwarven Thrower</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -6819,6 +7245,7 @@
   <item>
     <name>Flame Tongue Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6838,6 +7265,7 @@
   <item>
     <name>Flame Tongue Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -6856,6 +7284,7 @@
   <item>
     <name>Flame Tongue Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -6873,6 +7302,7 @@
   <item>
     <name>Flame Tongue Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6892,6 +7322,7 @@
   <item>
     <name>Flame Tongue Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -6911,6 +7342,7 @@
   <item>
     <name>Frost Brand Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -6932,6 +7364,7 @@
   <item>
     <name>Frost Brand Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -6952,6 +7385,7 @@
   <item>
     <name>Frost Brand Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -6971,6 +7405,7 @@
   <item>
     <name>Frost Brand Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -6992,6 +7427,7 @@
   <item>
     <name>Frost Brand Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7013,6 +7449,7 @@
   <item>
     <name>Giant Slayer Battleaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7033,6 +7470,7 @@
   <item>
     <name>Giant Slayer Greataxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -7054,6 +7492,7 @@
   <item>
     <name>Giant Slayer Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7075,6 +7514,7 @@
   <item>
     <name>Giant Slayer Handaxe</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7099,6 +7539,7 @@
   <item>
     <name>Giant Slayer Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7119,6 +7560,7 @@
   <item>
     <name>Giant Slayer Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7138,6 +7580,7 @@
   <item>
     <name>Giant Slayer Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7159,6 +7602,7 @@
   <item>
     <name>Giant Slayer Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7178,6 +7622,7 @@
   <item>
     <name>Greatsword of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7196,6 +7641,7 @@
   <item>
     <name>Greatsword of Sharpness</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7216,6 +7662,7 @@
   <item>
     <name>Greatsword of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7240,6 +7687,7 @@
   <item>
     <name>Greatsword of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7260,6 +7708,7 @@
   <item>
     <name>Hammer of Thunderbolts</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>10</weight>
     <dmg1>2d6</dmg1>
     <dmg2>2d6</dmg2>
@@ -7285,6 +7734,7 @@
   <item>
     <name>Holy Avenger Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7307,6 +7757,7 @@
   <item>
     <name>Holy Avenger Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7328,6 +7779,7 @@
   <item>
     <name>Holy Avenger Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7348,6 +7800,7 @@
   <item>
     <name>Holy Avenger Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7370,6 +7823,7 @@
   <item>
     <name>Holy Avenger Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7392,6 +7846,7 @@
   <item>
     <name>Javelin of Lightning</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7412,6 +7867,7 @@
   <item>
     <name>Longsword of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7429,6 +7885,7 @@
   <item>
     <name>Longsword of Sharpness</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7448,6 +7905,7 @@
   <item>
     <name>Longsword of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7471,6 +7929,7 @@
   <item>
     <name>Longsword of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7490,6 +7949,7 @@
   <item>
     <name>Luck Blade Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7515,6 +7975,7 @@
   <item>
     <name>Luck Blade Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7539,6 +8000,7 @@
   <item>
     <name>Luck Blade Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7562,6 +8024,7 @@
   <item>
     <name>Luck Blade Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7587,6 +8050,7 @@
   <item>
     <name>Luck Blade Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7612,6 +8076,7 @@
   <item>
     <name>Mace of Disruption</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -7627,6 +8092,7 @@
   <item>
     <name>Mace of Smiting</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -7642,6 +8108,7 @@
   <item>
     <name>Mace of Terror</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
@@ -7657,6 +8124,7 @@
   <item>
     <name>Nine Lives Stealer Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -7678,6 +8146,7 @@
   <item>
     <name>Nine Lives Stealer Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -7698,6 +8167,7 @@
   <item>
     <name>Nine Lives Stealer Rapier</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7717,6 +8187,7 @@
   <item>
     <name>Nine Lives Stealer Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7738,6 +8209,7 @@
   <item>
     <name>Nine Lives Stealer Shortsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7759,6 +8231,7 @@
   <item>
     <name>Rapier of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7775,6 +8248,7 @@
   <item>
     <name>Rapier of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7797,6 +8271,7 @@
   <item>
     <name>Rapier of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -7815,6 +8290,7 @@
   <item>
     <name>Scimitar of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7833,6 +8309,7 @@
   <item>
     <name>Scimitar of Sharpness</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7853,6 +8330,7 @@
   <item>
     <name>Scimitar of Speed</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7873,6 +8351,7 @@
   <item>
     <name>Scimitar of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7897,6 +8376,7 @@
   <item>
     <name>Scimitar of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -7917,6 +8397,7 @@
   <item>
     <name>Shortsword of Life Stealing</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7935,6 +8416,7 @@
   <item>
     <name>Shortsword of Vengeance</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7959,6 +8441,7 @@
   <item>
     <name>Shortsword of Wounding</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d6</dmg1>
     <dmgType>P</dmgType>
@@ -7979,6 +8462,7 @@
   <item>
     <name>Sun Blade</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8002,6 +8486,7 @@
   <item>
     <name>Sword of Answering (Answerer)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8023,6 +8508,7 @@
   <item>
     <name>Sword of Answering (Back Talker)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8044,6 +8530,7 @@
   <item>
     <name>Sword of Answering (Concluder)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8065,6 +8552,7 @@
   <item>
     <name>Sword of Answering (Last Quip)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8086,6 +8574,7 @@
   <item>
     <name>Sword of Answering (Rebutter)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8107,6 +8596,7 @@
   <item>
     <name>Sword of Answering (Replier)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8128,6 +8618,7 @@
   <item>
     <name>Sword of Answering (Retorter)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8149,6 +8640,7 @@
   <item>
     <name>Sword of Answering (Scather)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8170,6 +8662,7 @@
   <item>
     <name>Sword of Answering (Squelcher)</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8191,6 +8684,7 @@
   <item>
     <name>Trident of Fish Command</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -8213,6 +8707,7 @@
   <item>
     <name>Vorpal Greatsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -8235,6 +8730,7 @@
   <item>
     <name>Vorpal Longsword</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -8256,6 +8752,7 @@
   <item>
     <name>Vorpal Scimitar</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmgType>S</dmgType>
@@ -8278,6 +8775,7 @@
   <item>
     <name>Elven Chain</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>20</weight>
     <ac>13</ac>
     <rarity>Rare</rarity>
@@ -8290,6 +8788,7 @@
   <item>
     <name>Oathbow</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -8317,6 +8816,7 @@
   <item>
     <name>Animated Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Very Rare</rarity>
@@ -8329,6 +8829,7 @@
   <item>
     <name>Arrow-Catching Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Rare</rarity>
@@ -8341,6 +8842,7 @@
   <item>
     <name>Sentinel Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Uncommon</rarity>
@@ -8353,6 +8855,7 @@
   <item>
     <name>Shield of Missile Attraction</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Rare</rarity>
@@ -8367,6 +8870,7 @@
   <item>
     <name>Spellguard Shield</name>
     <type>S</type>
+    <magic>1</magic>
     <weight>6</weight>
     <ac>2</ac>
     <rarity>Very Rare</rarity>
@@ -8379,6 +8883,7 @@
   <item>
     <name>Elixir of Health</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8389,6 +8894,7 @@
   <item>
     <name>Oil of Etherealness</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8399,6 +8905,7 @@
   <item>
     <name>Oil of Sharpness</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8409,6 +8916,7 @@
   <item>
     <name>Oil of Slipperiness</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8420,6 +8928,7 @@
   <item>
     <name>Philter of Love</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8430,6 +8939,7 @@
   <item>
     <name>Potion of Acid Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8440,6 +8950,7 @@
   <item>
     <name>Potion of Animal Friendship</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8450,6 +8961,7 @@
   <item>
     <name>Potion of Clairvoyance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8460,6 +8972,7 @@
   <item>
     <name>Potion of Climbing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
@@ -8470,6 +8983,7 @@
   <item>
     <name>Potion of Cloud Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8481,6 +8995,7 @@
   <item>
     <name>Potion of Cold Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8491,6 +9006,7 @@
   <item>
     <name>Potion of Diminution</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8502,6 +9018,7 @@
   <item>
     <name>Potion of Fire Breath</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8513,6 +9030,7 @@
   <item>
     <name>Potion of Fire Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8524,6 +9042,7 @@
   <item>
     <name>Potion of Fire Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8534,6 +9053,7 @@
   <item>
     <name>Potion of Flying</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8544,6 +9064,7 @@
   <item>
     <name>Potion of Force Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8554,6 +9075,7 @@
   <item>
     <name>Potion of Frost Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8565,6 +9087,7 @@
   <item>
     <name>Potion of Gaseous Form</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8575,6 +9098,7 @@
   <item>
     <name>Potion of Greater Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8586,6 +9110,7 @@
   <item>
     <name>Potion of Growth</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8597,6 +9122,7 @@
   <item>
     <name>Potion of Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
@@ -8608,6 +9134,7 @@
   <item>
     <name>Potion of Heroism</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8618,6 +9145,7 @@
   <item>
     <name>Potion of Hill Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8629,6 +9157,7 @@
   <item>
     <name>Potion of Invisibility</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8639,6 +9168,7 @@
   <item>
     <name>Potion of Invulnerability</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8649,6 +9179,7 @@
   <item>
     <name>Potion of Lightning Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8659,6 +9190,7 @@
   <item>
     <name>Potion of Longevity</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8670,6 +9202,7 @@
   <item>
     <name>Potion of Mind Reading</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8680,6 +9213,7 @@
   <item>
     <name>Potion of Necrotic Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8690,6 +9224,7 @@
   <item>
     <name>Potion of Poison</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8704,6 +9239,7 @@
   <item>
     <name>Potion of Poison Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8714,6 +9250,7 @@
   <item>
     <name>Potion of Psychic Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8724,6 +9261,7 @@
   <item>
     <name>Potion of Radiant Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8734,6 +9272,7 @@
   <item>
     <name>Potion of Speed</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8744,6 +9283,7 @@
   <item>
     <name>Potion of Stone Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8755,6 +9295,7 @@
   <item>
     <name>Potion of Storm Giant Strength</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -8766,6 +9307,7 @@
   <item>
     <name>Potion of Superior Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8777,6 +9319,7 @@
   <item>
     <name>Potion of Supreme Healing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8788,6 +9331,7 @@
   <item>
     <name>Potion of Thunder Resistance</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8798,6 +9342,7 @@
   <item>
     <name>Potion of Vitality</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8808,6 +9353,7 @@
   <item>
     <name>Potion of Water Breathing</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8818,6 +9364,7 @@
   <item>
     <name>Immovable Rod</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8828,6 +9375,7 @@
   <item>
     <name>Rod of Absorption</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8843,6 +9391,7 @@
   <item>
     <name>Rod of Alertness</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8862,6 +9411,7 @@
   <item>
     <name>Rod of Lordly Might</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -8889,6 +9439,7 @@
   <item>
     <name>Rod of Resurrection</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -8902,6 +9453,7 @@
   <item>
     <name>Rod of Rulership</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8914,6 +9466,7 @@
   <item>
     <name>Rod of Security</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8926,6 +9479,7 @@
   <item>
     <name>Rod of the Pact Keeper, +1</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -8941,6 +9495,7 @@
   <item>
     <name>Rod of the Pact Keeper, +2</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8956,6 +9511,7 @@
   <item>
     <name>Rod of the Pact Keeper, +3</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -8971,6 +9527,7 @@
   <item>
     <name>Tentacle Rod</name>
     <type>RD</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -8985,6 +9542,7 @@
   <item>
     <name>Ring of Acid Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -8996,6 +9554,7 @@
   <item>
     <name>Ring of Air Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -9014,6 +9573,7 @@
   <item>
     <name>Ring of Animal Influence</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can use an action to expend 1 of its charges to cast one of the following spells:</text>
@@ -9027,6 +9587,7 @@
   <item>
     <name>Ring of Cold Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9038,6 +9599,7 @@
   <item>
     <name>Ring of Djinni Summoning</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -9051,6 +9613,7 @@
   <item>
     <name>Ring of Earth Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -9069,6 +9632,7 @@
   <item>
     <name>Ring of Evasion</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9081,6 +9645,7 @@
   <item>
     <name>Ring of Feather Falling</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9092,6 +9657,7 @@
   <item>
     <name>Ring of Fire Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -9109,6 +9675,7 @@
   <item>
     <name>Ring of Fire Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9120,6 +9687,7 @@
   <item>
     <name>Ring of Force Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9131,6 +9699,7 @@
   <item>
     <name>Ring of Free Action</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9142,6 +9711,7 @@
   <item>
     <name>Ring of Invisibility</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -9153,6 +9723,7 @@
   <item>
     <name>Ring of Jumping</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -9164,6 +9735,7 @@
   <item>
     <name>Ring of Lightning Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9175,6 +9747,7 @@
   <item>
     <name>Ring of Mind Shielding</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -9188,6 +9761,7 @@
   <item>
     <name>Ring of Necrotic Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9199,6 +9773,7 @@
   <item>
     <name>Ring of Poison Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9210,6 +9785,7 @@
   <item>
     <name>Ring of Protection</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9223,6 +9799,7 @@
   <item>
     <name>Ring of Psychic Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9234,6 +9811,7 @@
   <item>
     <name>Ring of Radiant Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9245,6 +9823,7 @@
   <item>
     <name>Ring of Regeneration</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -9257,6 +9836,7 @@
   <item>
     <name>Ring of Shooting Stars</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement Outdoors at Night</text>
@@ -9283,6 +9863,7 @@
   <item>
     <name>Ring of Spell Storing</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9296,6 +9877,7 @@
   <item>
     <name>Ring of Spell Turning</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -9307,6 +9889,7 @@
   <item>
     <name>Ring of Swimming</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>You have a swimming speed of 40 feet while wearing this ring.</text>
@@ -9316,6 +9899,7 @@
   <item>
     <name>Ring of Telekinesis</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -9327,6 +9911,7 @@
   <item>
     <name>Ring of the Ram</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9345,6 +9930,7 @@
   <item>
     <name>Ring of Three Wishes</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>While wearing this ring, you can use an action to expend 1 of its 3 charges to cast the wish spell from it. The ring becomes nonmagical when you use the last charge.</text>
@@ -9354,6 +9940,7 @@
   <item>
     <name>Ring of Thunder Resistance</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9365,6 +9952,7 @@
   <item>
     <name>Ring of Warmth</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -9376,6 +9964,7 @@
   <item>
     <name>Ring of Water Elemental Command</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -9393,6 +9982,7 @@
   <item>
     <name>Ring of Water Walking</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this ring, you can stand on and move across any liquid surface as if it were solid ground.</text>
@@ -9402,6 +9992,7 @@
   <item>
     <name>Ring of X-ray Vision</name>
     <type>RG</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -9414,6 +10005,7 @@
   <item>
     <name>Scroll of Protection from Aberrations</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents aberrations from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an aberration would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9423,6 +10015,7 @@
   <item>
     <name>Scroll of Protection from Beasts</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents beasts from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a beast would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9432,6 +10025,7 @@
   <item>
     <name>Scroll of Protection from Celestials</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents celestials from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a celestial would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9441,6 +10035,7 @@
   <item>
     <name>Scroll of Protection from Elementals</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents elementals from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an elemental would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9450,6 +10045,7 @@
   <item>
     <name>Scroll of Protection from Fey</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fey from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fey would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9459,6 +10055,7 @@
   <item>
     <name>Scroll of Protection from Fiends</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents fiends from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a fiend would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9468,6 +10065,7 @@
   <item>
     <name>Scroll of Protection from Plants</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents plants from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that a plant would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9477,6 +10075,7 @@
   <item>
     <name>Scroll of Protection from Undead</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Using an action to read the scroll encloses you in an invisible barrier that extends from you to form a 5-foot-radius, 10-foot-high cylinder. For 5 minutes, this barrier prevents undead from entering or affecting anything within the cylinder. The cylinder moves with you and remains centered on you. However, if you move in such a way that an undead would be inside the cylinder, the effect ends. A creature can attempt to overcome the barrier by using an action to make a DC 15 Charisma check. On a success, the creature ceases to be affected by the barrier.</text>
@@ -9486,6 +10085,7 @@
   <item>
     <name>Spell Scroll (1st Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9501,6 +10101,7 @@
   <item>
     <name>Spell Scroll (2nd Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9516,6 +10117,7 @@
   <item>
     <name>Spell Scroll (3rd Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9531,6 +10133,7 @@
   <item>
     <name>Spell Scroll (4th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9546,6 +10149,7 @@
   <item>
     <name>Spell Scroll (5th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9561,6 +10165,7 @@
   <item>
     <name>Spell Scroll (6th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9576,6 +10181,7 @@
   <item>
     <name>Spell Scroll (7th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9591,6 +10197,7 @@
   <item>
     <name>Spell Scroll (8th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9606,6 +10213,7 @@
   <item>
     <name>Spell Scroll (9th Level)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9621,6 +10229,7 @@
   <item>
     <name>Spell Scroll (Cantrip)</name>
     <type>SC</type>
+    <magic>1</magic>
     <rarity>Common</rarity>
     <text>Rarity: Common</text>
     <text>A spell scroll bears the words of a single spell, written as a mystical cipher. If the spell is on your class's spell list, you can read the scroll and cast its spell without having to provide any of the spell's components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the words on the scroll fade, and it crumbles to dust. If the casting is interrupted, the scroll is not lost.</text>
@@ -9636,6 +10245,7 @@
   <item>
     <name>Staff of Charming</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -9651,6 +10261,7 @@
   <item>
     <name>Staff of Fire</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9666,6 +10277,7 @@
   <item>
     <name>Staff of Frost</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9681,6 +10293,7 @@
   <item>
     <name>Staff of Healing</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -9695,6 +10308,7 @@
   <item>
     <name>Staff of Power</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9725,6 +10339,7 @@
   <item>
     <name>Staff of Striking</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9742,6 +10357,7 @@
   <item>
     <name>Staff of Swarming Insects</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -9759,6 +10375,7 @@
   <item>
     <name>Staff of the Adder</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -9775,6 +10392,7 @@
   <item>
     <name>Staff of the Magi</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -9803,6 +10421,7 @@
   <item>
     <name>Staff of the Python</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -9817,6 +10436,7 @@
   <item>
     <name>Staff of the Woodlands</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -9837,6 +10457,7 @@
   <item>
     <name>Staff of Thunder and Lightning</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9862,6 +10483,7 @@
   <item>
     <name>Staff of Withering</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -9877,6 +10499,7 @@
   <item>
     <name>Alchemy Jug</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>12</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -9901,6 +10524,7 @@
   <item>
     <name>Amulet of Health</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -9913,6 +10537,7 @@
   <item>
     <name>Amulet of Proof Against Detection and Location</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -9925,6 +10550,7 @@
   <item>
     <name>Amulet of the Planes</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -9937,6 +10563,7 @@
   <item>
     <name>Apparatus of Kwalish</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>500</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -9980,6 +10607,7 @@
   <item>
     <name>Bag of Beans</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10008,6 +10636,7 @@
   <item>
     <name>Bag of Devouring</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -10021,6 +10650,7 @@
   <item>
     <name>Bag of Holding</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>15</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10033,6 +10663,7 @@
   <item>
     <name>Bag of Tricks, Gray</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10057,6 +10688,7 @@
   <item>
     <name>Bag of Tricks, Rust</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10082,6 +10714,7 @@
   <item>
     <name>Bag of Tricks, Tan</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10106,6 +10739,7 @@
   <item>
     <name>Bead of Force</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>0.0625</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10119,6 +10753,7 @@
   <item>
     <name>Belt of Cloud Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -10130,6 +10765,7 @@
   <item>
     <name>Belt of Dwarvenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10149,6 +10785,7 @@
   <item>
     <name>Belt of Fire Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -10160,6 +10797,7 @@
   <item>
     <name>Belt of Frost Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -10171,6 +10809,7 @@
   <item>
     <name>Belt of Hill Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10182,6 +10821,7 @@
   <item>
     <name>Belt of Stone Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -10193,6 +10833,7 @@
   <item>
     <name>Belt of Storm Giant Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -10204,6 +10845,7 @@
   <item>
     <name>Boots of Elvenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have advantage on Dexterity (Stealth) checks that rely on moving silently.</text>
@@ -10213,6 +10855,7 @@
   <item>
     <name>Boots of Levitation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10224,6 +10867,7 @@
   <item>
     <name>Boots of Speed</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10236,6 +10880,7 @@
   <item>
     <name>Boots of Striding and Springing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10247,6 +10892,7 @@
   <item>
     <name>Boots of the Winterlands</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10261,6 +10907,7 @@
   <item>
     <name>Bowl of Commanding Water Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10272,6 +10919,7 @@
   <item>
     <name>Bracers of Archery</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10283,6 +10931,7 @@
   <item>
     <name>Bracers of Defense</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10295,6 +10944,7 @@
   <item>
     <name>Brazier of Commanding Fire Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10306,6 +10956,7 @@
   <item>
     <name>Brooch of Shielding</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10317,6 +10968,7 @@
   <item>
     <name>Broom of Flying</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10328,6 +10980,7 @@
   <item>
     <name>Candle of Invocation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -10354,6 +11007,7 @@
   <item>
     <name>Cap of Water Breathing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cap underwater, you can speak its command word as an action to create a bubble of air around your head. It allows you to breathe normally underwater. This bubble stays with you until you speak the command word again, the cap is removed, or you are no longer underwater.</text>
@@ -10363,6 +11017,7 @@
   <item>
     <name>Cape of the Mountebank</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This cape smells faintly of brimstone. While wearing it, you can use it to cast the dimension door spell as an action. This property of the cape can't be used again until the next dawn.</text>
@@ -10373,6 +11028,7 @@
   <item>
     <name>Carpet of Flying, 3 ft. x 5 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -10383,6 +11039,7 @@
   <item>
     <name>Carpet of Flying, 4 ft. x 6 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -10393,6 +11050,7 @@
   <item>
     <name>Carpet of Flying, 5 ft. x 7 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -10403,6 +11061,7 @@
   <item>
     <name>Carpet of Flying, 6 ft. x 9 ft.</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.</text>
@@ -10413,6 +11072,7 @@
   <item>
     <name>Censer of Controlling Air Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10424,6 +11084,7 @@
   <item>
     <name>Chime of Opening</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -10435,6 +11096,7 @@
   <item>
     <name>Circlet of Blasting</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this circlet, you can use an action to cast the scorching ray spell with it. When you make the spell's attacks, you do so with an attack bonus of +5. The circlet can't be used this way again until the next dawn.</text>
@@ -10445,6 +11107,7 @@
   <item>
     <name>Cloak of Arachnida</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -10461,6 +11124,7 @@
   <item>
     <name>Cloak of Displacement</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10472,6 +11136,7 @@
   <item>
     <name>Cloak of Elvenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10483,6 +11148,7 @@
   <item>
     <name>Cloak of Invisibility</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -10494,6 +11160,7 @@
   <item>
     <name>Cloak of Protection</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10507,6 +11174,7 @@
   <item>
     <name>Cloak of the Bat</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10519,6 +11187,7 @@
   <item>
     <name>Cloak of the Manta Ray</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this cloak with its hood up, you can breathe underwater, and you have a swimming speed of 60 feet. Pulling the hood up or down requires an action.</text>
@@ -10528,6 +11197,7 @@
   <item>
     <name>Crystal Ball</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -10540,6 +11210,7 @@
   <item>
     <name>Crystal Ball of Mind Reading</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -10553,6 +11224,7 @@
   <item>
     <name>Crystal Ball of Telepathy</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -10566,6 +11238,7 @@
   <item>
     <name>Crystal Ball of True Seeing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -10579,6 +11252,7 @@
   <item>
     <name>Cube of Force</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -10610,6 +11284,7 @@
   <item>
     <name>Cubic Gate</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the DM.</text>
@@ -10622,6 +11297,7 @@
   <item>
     <name>Daern's Instant Fortress</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place this 1-inch metal cube on the ground and speak its command word. The cube rapidly grows into a fortress that remains until you use an action to speak the command word that dismisses it, which works only if the fortress is empty.</text>
@@ -10635,6 +11311,7 @@
   <item>
     <name>Decanter of Endless Water</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10650,6 +11327,7 @@
   <item>
     <name>Deck of Illusions</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This box contains a set of parchment cards. A full deck has 34 cards. A deck found as treasure is usually missing 1d20 - 1 cards.</text>
@@ -10697,6 +11375,7 @@
   <item>
     <name>Deck of Many Things</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have only thirteen cards, but the rest have twenty-two.</text>
@@ -10758,6 +11437,7 @@
   <item>
     <name>Dimensional Shackles</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>You can use an action to place these shackles on an incapacitated creature. The shackles adjust to fit a creature of Small to Large size. In addition to serving as mundane manacles, the shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing-through an interdimensional portal.</text>
@@ -10768,6 +11448,7 @@
   <item>
     <name>Driftglobe</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10779,6 +11460,7 @@
   <item>
     <name>Dust of Disappearance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small packet, this powder resembles very fine sand. There is enough of it for one use. When you use an action to throw the dust into the air, you and each creature and object within 10 feet of you become invisible for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. If a creature affected by the dust attacks or casts a spell, the invisibility ends for that creature.</text>
@@ -10788,6 +11470,7 @@
   <item>
     <name>Dust of Dryness</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This small packet contains 1d6 + 4 pinches of dust. You can use an action to sprinkle a pinch of it over water. The dust turns a cube of water 15 feet on a side into one marble-sized pellet, which floats or rests near where the dust was sprinkled. The pellet's weight is negligible.</text>
@@ -10800,6 +11483,7 @@
   <item>
     <name>Dust of Sneezing and Choking</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Found in a small container, this powder resembles very fine sand. It appears to be dust of disappearance, and an identify spell reveals it to be such. There is enough of it for one use.</text>
@@ -10810,6 +11494,7 @@
   <item>
     <name>Efreeti Bottle</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -10826,6 +11511,7 @@
   <item>
     <name>Elemental Gem, Blue Sapphire</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, an air elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
@@ -10835,6 +11521,7 @@
   <item>
     <name>Elemental Gem, Emerald</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, a water elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
     <text>Source: </text>
@@ -10842,6 +11529,7 @@
   <item>
     <name>Elemental Gem, Red Corundum</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, a fire elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
     <text>Source: </text>
@@ -10849,6 +11537,7 @@
   <item>
     <name>Elemental Gem, Yellow Diamond</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This gem contains a mote of elemental energy. When you use an action to break the gem, an earth elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost.</text>
     <text />
     <text>Source: </text>
@@ -10856,6 +11545,7 @@
   <item>
     <name>Eversmoking Bottle</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -10867,6 +11557,7 @@
   <item>
     <name>Eyes of Charming</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10878,6 +11569,7 @@
   <item>
     <name>Eyes of Minute Seeing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These crystal lenses fit over the eyes. While wearing them, you can see much better than normal out to a range of 1 foot. You have advantage on Intelligence (Investigation) checks that rely on sight while searching an area or studying an object within that range.</text>
@@ -10887,6 +11579,7 @@
   <item>
     <name>Eyes of the Eagle</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -10898,6 +11591,7 @@
   <item>
     <name>Figurine of Wondrous Power, Bronze Griffon</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -10912,6 +11606,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ebony Fly</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -10926,6 +11621,7 @@
   <item>
     <name>Figurine of Wondrous Power, Golden Lions</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -10940,6 +11636,7 @@
   <item>
     <name>Figurine of Wondrous Power, Ivory Goats</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -10957,6 +11654,7 @@
   <item>
     <name>Figurine of Wondrous Power, Marble Elephant</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -10971,6 +11669,7 @@
   <item>
     <name>Figurine of Wondrous Power, Obsidian Steed</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -10986,6 +11685,7 @@
   <item>
     <name>Figurine of Wondrous Power, Onyx Dog</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -11000,6 +11700,7 @@
   <item>
     <name>Figurine of Wondrous Power, Serpentine Owl</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -11014,6 +11715,7 @@
   <item>
     <name>Figurine of Wondrous Power, Silver Raven</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>A figurine of wondrous power is a statuette of a beast small enough to fit in a pocket. If you use an action to speak the command word and throw the figurine to a point on the ground within 60 feet of you, the figurine becomes a living creature. If the space where the creature would appear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.</text>
@@ -11028,6 +11730,7 @@
   <item>
     <name>Folding Boat</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11042,6 +11745,7 @@
   <item>
     <name>Gauntlets of Ogre Power</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -11053,6 +11757,7 @@
   <item>
     <name>Gem of Brightness</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11067,6 +11772,7 @@
   <item>
     <name>Gem of Seeing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11081,6 +11787,7 @@
   <item>
     <name>Gloves of Missile Snaring</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -11093,6 +11800,7 @@
   <item>
     <name>Gloves of Swimming and Climbing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -11104,6 +11812,7 @@
   <item>
     <name>Gloves of Thievery</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>These gloves are invisible while worn. While wearing them, you gain a +5 bonus to Dexterity (Sleight of Hand) checks and Dexterity checks made to pick locks.</text>
@@ -11113,6 +11822,7 @@
   <item>
     <name>Goggles of Night</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing these dark lenses, you have darkvision out to a range of 60 feet. If you already have darkvision. wearing the goggles increases its range by 60 feet.</text>
@@ -11122,6 +11832,7 @@
   <item>
     <name>Hat of Disguise</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -11133,6 +11844,7 @@
   <item>
     <name>Headband of Intellect</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -11144,6 +11856,7 @@
   <item>
     <name>Helm of Brilliance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11162,6 +11875,7 @@
   <item>
     <name>Helm of Comprehending Languages</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While wearing this helm, you can use an action to cast the comprehend languages spell from it at will.</text>
@@ -11171,6 +11885,7 @@
   <item>
     <name>Helm of Telepathy</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -11183,6 +11898,7 @@
   <item>
     <name>Helm of Teleportation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -11195,6 +11911,7 @@
   <item>
     <name>Heward's Handy Haversack</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11208,6 +11925,7 @@
   <item>
     <name>Horn of Blasting</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11220,6 +11938,7 @@
   <item>
     <name>Horn of Valhalla, Brass</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11233,6 +11952,7 @@
   <item>
     <name>Horn of Valhalla, Bronze</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11246,6 +11966,7 @@
   <item>
     <name>Horn of Valhalla, Iron</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -11259,6 +11980,7 @@
   <item>
     <name>Horn of Valhalla, Silver</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11272,6 +11994,7 @@
   <item>
     <name>Horseshoes of a Zephyr</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above the ground. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores difficult terrain. In addition, the creature can move at normal speed for up to 12 hours a day without suffering exhaustion from a forced march.</text>
@@ -11281,6 +12004,7 @@
   <item>
     <name>Horseshoes of Speed</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>These iron horseshoes come in a set of four. While all four shoes are affixed to the hooves of a horse or similar creature, they increase the creature's walking speed by 30 feet.</text>
@@ -11290,6 +12014,7 @@
   <item>
     <name>Instrument of the Bards, Anstruth Harp</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11306,6 +12031,7 @@
   <item>
     <name>Instrument of the Bards, Canaith Mandolin</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11322,6 +12048,7 @@
   <item>
     <name>Instrument of the Bards, Cli Lyre</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11338,6 +12065,7 @@
   <item>
     <name>Instrument of the Bards, Doss Lute</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11354,6 +12082,7 @@
   <item>
     <name>Instrument of the Bards, Fochlucan Bandore</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11370,6 +12099,7 @@
   <item>
     <name>Instrument of the Bards, Mac-Fuirmidh Cittern</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11386,6 +12116,7 @@
   <item>
     <name>Instrument of the Bards, Ollamh Harp</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -11402,6 +12133,7 @@
   <item>
     <name>Ioun Stone, Absorption</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11419,6 +12151,7 @@
   <item>
     <name>Ioun Stone, Agility</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11436,6 +12169,7 @@
   <item>
     <name>Ioun Stone, Awareness</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -11452,6 +12186,7 @@
   <item>
     <name>Ioun Stone, Fortitude</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11469,6 +12204,7 @@
   <item>
     <name>Ioun Stone, Greater Absorption</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -11485,6 +12221,7 @@
   <item>
     <name>Ioun Stone, Insight</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11502,6 +12239,7 @@
   <item>
     <name>Ioun Stone, Intellect</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11519,6 +12257,7 @@
   <item>
     <name>Ioun Stone, Leadership</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11536,6 +12275,7 @@
   <item>
     <name>Ioun Stone, Mastery</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -11553,6 +12293,7 @@
   <item>
     <name>Ioun Stone, Protection</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -11570,6 +12311,7 @@
   <item>
     <name>Ioun Stone, Regeneration</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -11586,6 +12328,7 @@
   <item>
     <name>Ioun Stone, Reserve</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -11604,6 +12347,7 @@
   <item>
     <name>Ioun Stone, Strength</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -11621,6 +12365,7 @@
   <item>
     <name>Ioun Stone, Sustenance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -11637,6 +12382,7 @@
   <item>
     <name>Iron Bands of Bilarro</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11650,6 +12396,7 @@
   <item>
     <name>Iron Flask</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -11694,6 +12441,7 @@
   <item>
     <name>Keoghtom's Ointment</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This glass jar, 3 inches in diameter, contains 1d4 + 1 doses of a thick mixture that smells faintly of aloe. The jar and its contents weigh 1/2 pound.</text>
@@ -11705,6 +12453,7 @@
   <item>
     <name>Lantern of Revealing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11715,6 +12464,7 @@
   <item>
     <name>Mantle of Spell Resistance</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -11726,6 +12476,7 @@
   <item>
     <name>Manual of Bodily Health</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11736,6 +12487,7 @@
   <item>
     <name>Manual of Clay Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11747,6 +12499,7 @@
   <item>
     <name>Manual of Flesh Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11758,6 +12511,7 @@
   <item>
     <name>Manual of Gainful Exercise</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11768,6 +12522,7 @@
   <item>
     <name>Manual of Iron Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11779,6 +12534,7 @@
   <item>
     <name>Manual of Quickness of Action</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11789,6 +12545,7 @@
   <item>
     <name>Manual of Stone Golems</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11800,6 +12557,7 @@
   <item>
     <name>Medallion of Thoughts</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11813,6 +12571,7 @@
   <item>
     <name>Mirror of Life Trapping</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>50</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11829,6 +12588,7 @@
   <item>
     <name>Necklace of Adaptation</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11841,6 +12601,7 @@
   <item>
     <name>Necklace of Fireballs</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11853,6 +12614,7 @@
   <item>
     <name>Necklace of Prayer Beads</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11874,6 +12636,7 @@
   <item>
     <name>Nolzur's Marvelous Pigments</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -11888,6 +12651,7 @@
   <item>
     <name>Pearl of Power</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement by a Spellcaster</text>
@@ -11899,6 +12663,7 @@
   <item>
     <name>Periapt of Health</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11909,6 +12674,7 @@
   <item>
     <name>Periapt of Proof Against Poison</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -11919,6 +12685,7 @@
   <item>
     <name>Periapt of Wound Closure</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11931,6 +12698,7 @@
   <item>
     <name>Pipes of Haunting</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11942,6 +12710,7 @@
   <item>
     <name>Pipes of the Sewers</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -11957,6 +12726,7 @@
   <item>
     <name>Portable Hole</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
@@ -11970,6 +12740,7 @@
   <item>
     <name>Quaal's Feather Token, Anchor</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11981,6 +12752,7 @@
   <item>
     <name>Quaal's Feather Token, Bird</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -11992,6 +12764,7 @@
   <item>
     <name>Quaal's Feather Token, Fan</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -12003,6 +12776,7 @@
   <item>
     <name>Quaal's Feather Token, Swan Boat</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -12014,6 +12788,7 @@
   <item>
     <name>Quaal's Feather Token, Tree</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -12025,6 +12800,7 @@
   <item>
     <name>Quaal's Feather Token, Whip</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>This tiny object looks like a feather.</text>
@@ -12039,6 +12815,7 @@
   <item>
     <name>Quiver of Ehlonna</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>2</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12050,6 +12827,7 @@
   <item>
     <name>Robe of Eyes</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12066,6 +12844,7 @@
   <item>
     <name>Robe of Scintillating Colors</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -12078,6 +12857,7 @@
   <item>
     <name>Robe of Stars</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
     <text>Requires Attunement</text>
@@ -12093,6 +12873,7 @@
   <item>
     <name>Robe of the Archmagi</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement by a Sorcerer, Warlock, or Wizard</text>
@@ -12112,6 +12893,7 @@
   <item>
     <name>Robe of Useful Items</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>This robe has cloth patches of various shapes and colors covering it. While wearing the robe. you can use an action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.</text>
@@ -12144,6 +12926,7 @@
   <item>
     <name>Rope of Climbing</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12156,6 +12939,7 @@
   <item>
     <name>Rope of Entanglement</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>3</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12168,6 +12952,7 @@
   <item>
     <name>Saddle of the Cavalier</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While in this saddle on a mount, you can't be dismounted against your will if you're conscious, and attack rolls against the mount have disadvantage.</text>
@@ -12177,6 +12962,7 @@
   <item>
     <name>Scarab of Protection</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>Requires Attunement</text>
@@ -12190,6 +12976,7 @@
   <item>
     <name>Sending Stones</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Sending stones come in pairs, with each smooth stone carved to match the other so the pairing is easily recognized. While you touch one stone, you can use an action to cast the sending spell from it. The target is the bearer of the other stone. If no creature bears the other stone, you know that fact as soon as you use the stone and don't cast the spell.</text>
@@ -12200,6 +12987,7 @@
   <item>
     <name>Slippers of Spider Climbing</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -12211,6 +12999,7 @@
   <item>
     <name>Sovereign Glue</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with oil of slipperiness. When found, a container contains 1d6 + 1 ounces.</text>
@@ -12221,6 +13010,7 @@
   <item>
     <name>Sphere of Annihilation</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.</text>
@@ -12240,6 +13030,7 @@
   <item>
     <name>Stone of Controlling Earth Elementals</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12250,6 +13041,7 @@
   <item>
     <name>Stone of Good Luck</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -12262,6 +13054,7 @@
   <item>
     <name>Talisman of Pure Good</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -12278,6 +13071,7 @@
   <item>
     <name>Talisman of the Sphere</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -12290,6 +13084,7 @@
   <item>
     <name>Talisman of Ultimate Evil</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -12306,6 +13101,7 @@
   <item>
     <name>Tome of Clear Thought</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12316,6 +13112,7 @@
   <item>
     <name>Tome of Leadership and Influence</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12326,6 +13123,7 @@
   <item>
     <name>Tome of the Stilled Tongue</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
@@ -12341,6 +13139,7 @@
   <item>
     <name>Tome of Understanding</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12351,6 +13150,7 @@
   <item>
     <name>Universal Solvent</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This tube holds milky liquid with a strong alcohol smell. You can use an action to pour the contents of the tube onto a surface within reach. The liquid instantly dissolves up to 1 square foot of adhesive it touches, including sovereign glue.</text>
@@ -12360,6 +13160,7 @@
   <item>
     <name>Well of Many Worlds</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Legendary</rarity>
     <text>Rarity: Legendary</text>
     <text>This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.</text>
@@ -12371,6 +13172,7 @@
   <item>
     <name>Wind Fan</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>While holding this fan, you can use an action to cast the gust of wind spell (save DC 13) from it. Once used, the fan shouldn't be used again until the next dawn. Each time it is used again before then, it has a cumulative 20 percent chance of not working and tearing into useless, nonmagical tatters.</text>
@@ -12380,6 +13182,7 @@
   <item>
     <name>Winged Boots</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
     <text>Requires Attunement</text>
@@ -12392,6 +13195,7 @@
   <item>
     <name>Wings of Flying</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
     <text>Requires Attunement</text>
@@ -12404,6 +13208,7 @@
   <item>
     <name>Wand of Binding</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12420,6 +13225,7 @@
   <item>
     <name>Wand of Enemy Detection</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12434,6 +13240,7 @@
   <item>
     <name>Wand of Fear</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12451,6 +13258,7 @@
   <item>
     <name>Wand of Fireballs</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12472,6 +13280,7 @@
   <item>
     <name>Wand of Lightning Bolts</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12493,6 +13302,7 @@
   <item>
     <name>Wand of Magic Detection</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12504,6 +13314,7 @@
   <item>
     <name>Wand of Magic Missiles</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12523,6 +13334,7 @@
   <item>
     <name>Wand of Paralysis</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12538,6 +13350,7 @@
   <item>
     <name>Wand of Polymorph</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12552,6 +13365,7 @@
   <item>
     <name>Wand of Secrets</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12563,6 +13377,7 @@
   <item>
     <name>Wand of the War Mage, +1</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12576,6 +13391,7 @@
   <item>
     <name>Wand of the War Mage, +2</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12589,6 +13405,7 @@
   <item>
     <name>Wand of the War Mage, +3</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Very Rare</rarity>
     <text>Rarity: Very Rare</text>
@@ -12602,6 +13419,7 @@
   <item>
     <name>Wand of Web</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Uncommon</rarity>
     <text>Rarity: Uncommon</text>
@@ -12616,6 +13434,7 @@
   <item>
     <name>Wand of Wonder</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>1</weight>
     <rarity>Rare</rarity>
     <text>Rarity: Rare</text>
@@ -12656,6 +13475,7 @@
   <item>
     <name>Axe of the Dwarvish Lords</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -12691,6 +13511,7 @@
   <item>
     <name>Blackrazor</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -12721,6 +13542,7 @@
   <item>
     <name>Moonblade</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -12764,6 +13586,7 @@
   <item>
     <name>Sword of Kas</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -12797,6 +13620,7 @@
   <item>
     <name>Wave</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -12824,6 +13648,7 @@
   <item>
     <name>Whelm</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -12850,6 +13675,7 @@
   <item>
     <name>Book of Exalted Deeds</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
@@ -12873,6 +13699,7 @@
   <item>
     <name>Book of Vile Darkness</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>5</weight>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
@@ -12905,6 +13732,7 @@
   <item>
     <name>Eye of Vecna</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
@@ -12937,6 +13765,7 @@
   <item>
     <name>Hand of Vecna</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
@@ -12969,6 +13798,7 @@
   <item>
     <name>Orb of Dragonkind</name>
     <type>W</type>
+    <magic>1</magic>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
     <text>Requires attunement</text>
@@ -12992,6 +13822,7 @@
   <item>
     <name>Wand of Orcus</name>
     <type>WD</type>
+    <magic>1</magic>
     <weight>4</weight>
     <rarity>Artifact</rarity>
     <text>Rarity: Artifact</text>
@@ -13026,6 +13857,7 @@
   <item>
     <name>Dragontooth Dagger</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -13051,6 +13883,7 @@
   <item>
     <name>Drown</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>4</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -13082,6 +13915,7 @@
   <item>
     <name>Hazirawn</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>6</weight>
     <dmg1>2d6</dmg1>
     <dmgType>S</dmgType>
@@ -13110,6 +13944,7 @@
   <item>
     <name>Ironfang</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>2</weight>
     <dmg1>1d8</dmg1>
     <dmgType>P</dmgType>
@@ -13136,6 +13971,7 @@
   <item>
     <name>Orcsplitter</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>7</weight>
     <dmg1>1d12</dmg1>
     <dmgType>S</dmgType>
@@ -13162,6 +13998,7 @@
   <item>
     <name>Tinderstrike</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>1</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -13194,6 +14031,7 @@
   <item>
     <name>Windvane</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
@@ -13225,6 +14063,7 @@
   <item>
     <name>Bottled Breath</name>
     <type>P</type>
+    <magic>1</magic>
     <weight>0.5</weight>
     <text>This bottle contains a breath of elemental air. When you inhale it, you either exhale it or hold it.</text>
     <text>If you inhale the breath, you gain the effect of the gust of wind spell. If you hold the breath, you don't need to breathe for 1 hour, though you can end this benefit early (for example, to speak). Ending it early doesn't give you the benefit of exhaling the breath.</text>
@@ -13234,6 +14073,7 @@
   <item>
     <name>Seeker Dart</name>
     <type>R</type>
+    <magic>1</magic>
     <weight>0.25</weight>
     <dmg1>1d4</dmg1>
     <dmgType>P</dmgType>
@@ -13255,6 +14095,7 @@
   <item>
     <name>Storm Boomerang</name>
     <type>R</type>
+    <magic>1</magic>
     <dmg1>1d4</dmg1>
     <dmgType>B</dmgType>
     <range>60/120</range>
@@ -13269,6 +14110,7 @@
   <item>
     <name>Spider Staff</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>6</weight>
     <text>Requires Attunement</text>
     <text />
@@ -13282,6 +14124,7 @@
   <item>
     <name>Staff of Defense</name>
     <type>ST</type>
+    <magic>1</magic>
     <weight>3</weight>
     <text>Requires Attunement</text>
     <text />
@@ -13297,6 +14140,7 @@
   <item>
     <name>Balloon Pack</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This backpack contains the spirit of an air elemental and a compact leather balloon. While you're wearing the backpack, you can deploy the balloon as an action and gain the effect of the levitate spell for 10 minutes, targeting yourself and requiring no concentration. Alternatively, you can use a reaction to deploy the balloon when you're falling and gain the effect of the feather fall spell for yourself.</text>
     <text>When either spell ends, the balloon slowly deflates as the elemental spirit escapes and returns to the Elemental Plane of Air. As the balloon deflates, you descend gently toward the ground for up to 60 feet. IF you are still in the air at the end of this distance, you fall if you have no other means of staying aloft.</text>
     <text>After the spirit departs, the backpack's property is unusable unless the backpack is recharged for 1 hour in an elemental air node, which binds another spirit to the backpack.</text>
@@ -13306,6 +14150,7 @@
   <item>
     <name>Black Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This horned mask of glossy ebony has horns and a skull-like mien. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -13329,6 +14174,7 @@
   <item>
     <name>Blue Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This mask of glossy azure has spikes around its edges and a ridged horn in its center. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -13352,6 +14198,7 @@
   <item>
     <name>Claws of the Umber Hulk</name>
     <type>W</type>
+    <magic>1</magic>
     <text>These heavy gauntlets of brown iron are forged in the shape an umber hulk's claws, and they fit the wearer's hands and forearms all the way up to the elbow. While wearing both claws, you gain a burrowing speed of 20 feet, and you can tunnel through solid rock at a rate of 1 foot per round.</text>
     <text>You can use a claw as a melee weapon while wearing it. You have proficiency with it, and it deals 1d8 slashing damage on a hit (your Strength modifier applies to the attack and damage rolls, as normal)</text>
     <text>While wearing the claws, you can't manipulate objects or cast spells with somatic components</text>
@@ -13361,6 +14208,7 @@
   <item>
     <name>Devastation Orb of Air</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -13373,6 +14221,7 @@
   <item>
     <name>Devastation Orb of Earth</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -13384,6 +14233,7 @@
   <item>
     <name>Devastation Orb of Fire</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -13396,6 +14246,7 @@
   <item>
     <name>Devastation Orb of Water</name>
     <type>W</type>
+    <magic>1</magic>
     <text>A devastation orb is an elemental bomb that can be created at the site of an elemental node by performing a ritual with an elemental weapon. The type of orb created depends on the node used. For example, an air node creates a devastation orb of air. The ritual takes 1 hour to complete and requires 2,000 gp worth of special components, which are consumed.</text>
     <text>A devastation orb measures 12 inches in diameter, weighs 10 pounds, and has a solid outer shell. The orb detonates 1d100 hours after its creation, releasing the elemental energy it contains. The orb gives no outward sign of how much time remains before it will detonate. Spells such as identify and divination can be used to ascertain when the orb will explode. An orb has AC 10, 15 hit points, and immunity to poison and psychic damage. Reducing it to 0 hit points causes it to explode instantly.</text>
     <text>A special container can be crafted to contain a devastation orb and prevent it from detonating. The container must be inscribed with symbols of the orb's opposing element. For example, a case inscribed with earth symbols can be used to contain a devastation orb of air and keep it from detonating. While in the container, the orb thrums. If it is removed from the container after the time when it was supposed to detonate, it explodes 1d6 rounds later, unless it is returned to the container.</text>
@@ -13407,6 +14258,7 @@
   <item>
     <name>Draakhorn</name>
     <type>W</type>
+    <magic>1</magic>
     <text>The Draakhorn was a gift from Tiamat in the war between dragons and giants. It was once the horn of her ancient red dragon consort, Ephelomon, that she gave to dragonkind to help them in their war against the giants. The Draakhorn is a signaling device, and it is so large that it requires two Medium creatures (or one Large or larger) to hold it while a third creature sounds it, making the earth resonate to its call. The horn has been blasted with fire into a dark ebony hue and is wrapped in bands of bronze with draconic runes that glow with purple eldritch fire.</text>
     <text>The low, moaning drone of the Draakhorn discomfits normal animals within a few miles, and it alerts all dragons within two thousand miles to rise and be wary, for great danger is at hand. Coded blasts were once used to signal specific messages. Knowledge of those codes has been lost to the ages.</text>
     <text>Those with knowledge of the Draakhorn's history know that it was first built to signal danger to chromatic dragons — a purpose the Cult of the Dragon has corrupted to call chromatic dragons to the Well of Dragons from across the North.</text>
@@ -13420,6 +14272,7 @@
   <item>
     <name>Green Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This mottled green mask is surmounted by a frilled crest and has leathery spiked plates along its jaw. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties</text>
@@ -13443,6 +14296,7 @@
   <item>
     <name>Insignia of Claws</name>
     <type>W</type>
+    <magic>1</magic>
     <text>The jewels in the insignia of the Cult of the Dragon flare with purple light when you enter combat, empowering your natural fists or natural weapons.</text>
     <text>While wearing the insignia you gain a +1 bonus to the attack rolls and the damage rolls you make with unarmed strikes and natural weapons. Such attacks are considered to be magical.</text>
     <text />
@@ -13453,6 +14307,7 @@
   <item>
     <name>Lost Crown of Besilmer</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This dwarven battle-helm consists of a sturdy open-faced steel helmet, decorated with a golden circlet above the brow from which seven small gold spikes project upward. You gain the following benefits while wearing the crown:</text>
@@ -13466,6 +14321,7 @@
   <item>
     <name>Mask of the Dragon Queen</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>Individually, the five dragon masks resemble the dragons they are named for. When two or more of the dragon masks are assembled, however, they transform magically into the Mask of the Dragon Queen. Each mask shrinks to become the modeled head of a chromatic dragon, appearing to roar its devotion to Tiamat where all the masks brought together are arranged crown-like on the wearer's head. Below the five masks, a new mask shapes itself, granting the wearer a draconic visage that covers the face, neck, and shoulders.</text>
@@ -13476,6 +14332,7 @@
   <item>
     <name>Red Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This mask of glossy crimson has swept-back horns and spiked cheek ridges. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -13499,6 +14356,7 @@
   <item>
     <name>Weird Tank</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>A weird tank is a ten-gallon tank of blown glass and sculpted bronze with a backpack-like carrying harness fashioned from tough leather. A water weird (see the Monster Manual for statistics) is contained within the tank. While wearing the tank, you can use an action to open it, allowing the water weird to emerge. The water weird acts immediately after you in the initiative order, and it is bound to the tank.</text>
@@ -13511,6 +14369,7 @@
   <item>
     <name>White Dragon Mask</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This gleaming mask is white with highlights of pale blue and is topped by a spined crest. The mask reshapes to fit a wearer attuned to it. While you are wearing the mask and attuned to it, you can access the following properties.</text>
@@ -13534,6 +14393,7 @@
   <item>
     <name>Wingwear</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This snug uniform has symbols of air stitched into it and leathery flaps that stretch along the arms, waist, and legs to create wings for gliding. A suit of wingwear has 3 charges. While you wear the suit, you can use a bonus action and expend 1 charge to gain a flying speed of 30 feet until you land. At the end of each of your turns, your altitude drops by 5 feet. Your altitude drops instantly to 0 feet at the end of your turn if you didn't fly at least 30 feet horizontally on that turn. When your altitude drops to 0 feet, you land (or fall), and you must expend another charge to use the suit again.</text>
@@ -13544,6 +14404,7 @@
   <item>
     <name>Wand of Winter</name>
     <type>WD</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text />
     <text>This wand looks and feels like an icicle. You must be attuned to the want to use it.</text>
@@ -13554,6 +14415,7 @@
   <item>
     <name>Dawnbringer</name>
     <type>M</type>
+    <magic>1</magic>
     <weight>3</weight>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
@@ -13585,6 +14447,7 @@
   <item>
     <name>Piwafwi (Cloak of Elvenkind)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text>This dark spider-silk cloak is made by drow. It is a cloak of elvenkind. It loses its magic if exposed to sunlight for 1 hour without interruption.</text>
     <text />
@@ -13595,6 +14458,7 @@
   <item>
     <name>Piwafwi of Fire Resistance (Cloak of Elvenkind)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires Attunement</text>
     <text>This dark spider-silk cloak is made by drow. It is a cloak of elvenkind. It also grants resistance to fire damage while you wear it.  It loses its magic if exposed to sunlight for 1 hour without interruption.</text>
     <text />
@@ -13605,6 +14469,7 @@
   <item>
     <name>Spell Gem (Obsidian)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>An obsidian spell gem can contain one cantrip from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13618,6 +14483,7 @@
   <item>
     <name>Spell Gem (Lapis lazuli)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A lapis lazuli spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13631,6 +14497,7 @@
   <item>
     <name>Spell Gem (Quartz)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A quartz spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13644,6 +14511,7 @@
   <item>
     <name>Spell Gem (Bloodstone)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A bloodstone spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13657,6 +14525,7 @@
   <item>
     <name>Spell Gem (Amber)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>An amber spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13670,6 +14539,7 @@
   <item>
     <name>Spell Gem (Jade)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A jade spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13683,6 +14553,7 @@
   <item>
     <name>Spell Gem (Topaz)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A topaz spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13696,6 +14567,7 @@
   <item>
     <name>Spell Gem (Star ruby)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A star ruby spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13709,6 +14581,7 @@
   <item>
     <name>Spell Gem (Ruby)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A ruby spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13722,6 +14595,7 @@
   <item>
     <name>Spell Gem (Diamond)</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Attunement Optional</text>
     <text />
     <text>A diamond spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -13735,6 +14609,7 @@
   <item>
     <name>Stonespeaker Crystal</name>
     <type>W</type>
+    <magic>1</magic>
     <text>Requires attunement</text>
     <text />
     <text>Created by the stone giant librarians of Gravenhollow, this nineteen-inch-long shard of quartz grants you advantage on Intelligence (investigation) checks while it is on your person.</text>
@@ -13747,6 +14622,7 @@
   <item>
     <name>Wand of Viscid Globs</name>
     <type>WD</type>
+    <magic>1</magic>
     <text>Requires attunement</text>
     <text />
     <text>Crafted by the drow, this slim black wand has 7 charges. While holding it, you can use an action to expend 1 of its charges to cause a small glob of viscous material to launch from the tip at one creature within 60 feet of you. Make a ranged attack roll against the target, with a bonus equal to your spellcasting modifier (or your Intelligence modifier, if you don't have a spellcasting modifier) plus your proficiency bonus. On a hit, the glob expands and dries on the target, which is restrained for 1 hour. After that time, the viscous material cracks and falls away.</text>
@@ -13760,6 +14636,7 @@
   <item>
     <name>Adamantine Spiked Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13770,6 +14647,7 @@
   <item>
     <name>Spiked Armor +1</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13781,6 +14659,7 @@
   <item>
     <name>Spiked Armor +2</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13792,6 +14671,7 @@
   <item>
     <name>Spiked Armor +3</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13803,6 +14683,7 @@
   <item>
     <name>Spiked Armor of Acid Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13814,6 +14695,7 @@
   <item>
     <name>Spiked Armor of Cold Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13825,6 +14707,7 @@
   <item>
     <name>Spiked Armor of Fire Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13836,6 +14719,7 @@
   <item>
     <name>Spiked Armor of Force Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13847,6 +14731,7 @@
   <item>
     <name>Spiked Armor of Lightning Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13858,6 +14743,7 @@
   <item>
     <name>Spiked Armor of Necrotic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13869,6 +14755,7 @@
   <item>
     <name>Spiked Armor of Poison Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13880,6 +14767,7 @@
   <item>
     <name>Spiked Armor of Psychic Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13891,6 +14779,7 @@
   <item>
     <name>Spiked Armor of Radiant Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13902,6 +14791,7 @@
   <item>
     <name>Spiked Armor of Thunder Resistance</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13913,6 +14803,7 @@
   <item>
     <name>Mariner's Spiked Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <stealth>YES</stealth>
@@ -13923,6 +14814,7 @@
   <item>
     <name>Mithral Spiked Armor</name>
     <type>MA</type>
+    <magic>1</magic>
     <weight>45</weight>
     <ac>14</ac>
     <text>	Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.</text>
@@ -13932,6 +14824,7 @@
   <item>
     <name>Tome of Strahd</name>
     <type>G</type>
+    <magic>1</magic>
     <weight>5</weight>
     <text>The Tome of Strahd is an ancient work penned by Strahd, a tragic tale of how he came to his fallen state. The book is bound in a thick leather cover with steel hinges and fastenings. The pages are of parchment and very brittle. Most of the book is written in the curious shorthand that only Strahd employs. Stains and age have made most of the work illegible, but several paragraphs remain intact.</text>
     <text />
@@ -13940,6 +14833,7 @@
   <item>
     <name>Blood Spear</name>
     <type>M</type>
+    <magic>1</magic>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
     <dmgType>P</dmgType>
@@ -13956,6 +14850,7 @@
   <item>
     <name>Saint Markovia's Thighbone</name>
     <type>M</type>
+    <magic>1</magic>
     <dmg1>1d6</dmg1>
     <dmgType>B</dmgType>
     <weight>4</weight>
@@ -13977,6 +14872,7 @@
   <item>
     <name>Holy Symbol of Ravenkind</name>
     <type>W</type>
+    <magic>1</magic>
     <text>This item requires attunement by a cleric or paladin of good alignment</text>
     <text />
     <text>	The Holy Symbol of Ravenkind is a unique holy symbol sacred to the good-hearted faithful of Barovia. It predates the establishment of any church in Barovia. According to legend, it was delivered to a paladin named Lugdana by a giant raven - or an angel in the form of a giant raven. Lugdana used the holy symbol to root out and destroy nests of vampires until her death. The high priests of Ravenloft kept and wore the holy symbol after Lugdana's passing.</text>
@@ -13995,6 +14891,7 @@
   <item>
     <name>Icon of Ravenloft</name>
     <type>W</type>
+    <magic>1</magic>
     <weight>10</weight>
     <text>This item requires attunement by a creature of good alignment</text>
     <text />
@@ -14014,6 +14911,7 @@
   <item>
     <name>Gulthias Staff</name>
     <type>ST</type>
+    <magic>1</magic>
     <dmg1>1d6</dmg1>
     <dmg2>1d8</dmg2>
     <dmgType>B</dmgType>
@@ -14034,6 +14932,7 @@
   <item>
     <name>Sunsword</name>
     <type>M</type>
+    <magic>1</magic>
     <dmg1>1d8</dmg1>
     <dmg2>1d10</dmg2>
     <dmgType>S</dmgType>
@@ -14060,6 +14959,7 @@
     <item>
         <name>Banner of the Krig Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -14076,6 +14976,7 @@
     <item>
         <name>Blod Stone</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -14088,6 +14989,7 @@
     <item>
         <name>Claw of the Wyrm Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -14103,6 +15005,7 @@
     <item>
         <name>Conch of Teleportation</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -14115,6 +15018,7 @@
     <item>
         <name>Gavel of the Venn Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -14130,6 +15034,7 @@
     <item>
         <name>Gurt's Greataxe</name>
         <type>M</type>
+    <magic>1</magic>
         <weight>14</weight>
         <dmg1>3d12</dmg1>
         <dmgType>S</dmgType>
@@ -14149,6 +15054,7 @@
     <item>
         <name>Ingot of the Skold Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -14166,6 +15072,7 @@
     <item>
         <name>Korolnor Scepter</name>
         <type>M</type>
+    <magic>1</magic>
         <weight>2</weight>
         <dmg1>1d4</dmg1>
         <dmgType>B</dmgType>
@@ -14190,6 +15097,7 @@
     <item>
         <name>Navigation Orb</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -14206,6 +15114,7 @@
     <item>
         <name>Opal of the Ild Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -14223,6 +15132,7 @@
     <item>
         <name>Orb of the Stein Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -14241,6 +15151,7 @@ tance to all damage dealt by ranged weapon attacks.</text>
     <item>
         <name>Pennant of the Vind Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -14260,6 +15171,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
         <name>Potion of Giant Size</name>
         <type>P</type>
+    <magic>1</magic>
         <rarity>Legendary</rarity>
         <text>Rarity: Legendary</text>
         <text />
@@ -14272,6 +15184,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
         <name>Robe of Serpants</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Uncommon</rarity>
         <text>Rarity: Uncommon</text>
@@ -14284,6 +15197,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
         <name>Rod of the Vonindod</name>
         <type>RD</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Rare</rarity>
         <text>Rarity: Rare</text>
@@ -14297,6 +15211,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
         <name>Shard of the Ise Rune</name>
         <type>W</type>
+    <magic>1</magic>
         <text>This item requires attunement</text>
         <rarity>Very Rare</rarity>
         <text>Rarity: Very Rare</text>
@@ -14315,6 +15230,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
     <item>
         <name>Wyrmskull Throne</name>
         <type>W</type>
+    <magic>1</magic>
         <rarity>Artifact</rarity>
         <text>Rarity: Artifact</text>
         <text />
@@ -14336,6 +15252,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Carapace Chain Mail</name>
 		<type>HA</type>
+    <magic>1</magic>
 		<weight>55</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14349,6 +15266,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Carapace Plate Armor</name>
 		<type>HA</type>
+    <magic>1</magic>
 		<weight>65</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14362,6 +15280,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Carapace Ring Mail</name>
 		<type>HA</type>
+    <magic>1</magic>
 		<weight>40</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14375,6 +15294,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Carapace Splint Armor</name>
 		<type>HA</type>
+    <magic>1</magic>
 		<weight>60</weight>
 		<text>Rarity: Uncommon</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14388,6 +15308,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Blade Greatsword</name>
 		<type>M</type>
+    <magic>1</magic>
 		<weight>6</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14408,6 +15329,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Blade Longsword</name>
 		<type>M</type>
+    <magic>1</magic>
 		<weight>3</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14426,6 +15348,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Blade Rapier</name>
 		<type>M</type>
+    <magic>1</magic>
 		<weight>2</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14444,6 +15367,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Blade Scimitar</name>
 		<type>M</type>
+    <magic>1</magic>
 		<weight>3</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14464,6 +15388,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Blade Shortsword</name>
 		<type>M</type>
+    <magic>1</magic>
 		<weight>2</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires Attunement by a specific individual</text>
@@ -14484,6 +15409,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Mind Lash</name>
 		<type>M</type>
+    <magic>1</magic>
 		<weight>3</weight>
 		<text>Rarity: Rare</text>
 		<text>Requires attunement by a mind flayer</text>
@@ -14504,6 +15430,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 	<item>
 		<name>Shield of Far Sight</name>
 		<type>S</type>
+    <magic>1</magic>
 		<weight>6</weight>
 		<text>Rarity: Rare</text>
 		<text>	A mind flayer skilled at crafting magic items creates a shield of far sight by harvesting an eye from an intelligent humanoid and magically implanting it on the outer surface of a nonmagical shield. The shield becomes a magic item once the eyes is implanted, whereupon the mind flayer can give the shield to a thrall or hang it on a wall in its lair. As long as the shield is on the same plane of existence as its creator, the mind flayer can see through the shield's eye, which has darkvision out to a range of 60 feet. While peering through this magical eye, the mind flayer can use its Mind Blast action as though it were standing behind the shield.</text>

--- a/Items/Mundane Items.xml
+++ b/Items/Mundane Items.xml
@@ -3,6 +3,7 @@
 	<item>
 		<name>Copper (cp)</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1cp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
@@ -22,6 +23,7 @@
 	<item>
 		<name>Electrum (ep)</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1ep</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
@@ -41,6 +43,7 @@
 	<item>
 		<name>Gold (gp)</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
@@ -60,6 +63,7 @@
 	<item>
 		<name>Platinum (pp)</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1pp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
@@ -79,6 +83,7 @@
 	<item>
 		<name>Silver (sp)</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1sp</value>
 		<weight>0.02</weight>
 		<text>Common coins come in several different denominations based on the relative worth of the metal from which they are made. The three most common coins are the gold piece (gp), the silver piece (sp), and the copper piece (cp).</text>
@@ -98,6 +103,7 @@
 	<item>
 		<name>Arrows</name>
 		<type>A</type>
+        <magic></magic>
 		<value>5cp</value>
 		<weight>0.05</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -107,6 +113,7 @@
 	<item>
 		<name>Arrows (20)</name>
 		<type>A</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>1</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -116,6 +123,7 @@
 	<item>
 		<name>Blowgun Needles</name>
 		<type>A</type>
+        <magic></magic>
 		<value>2cp</value>
 		<weight>0.02</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -125,6 +133,7 @@
 	<item>
 		<name>Blowgun Needles (50)</name>
 		<type>A</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>1</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -134,6 +143,7 @@
 	<item>
 		<name>Crossbow Bolts</name>
 		<type>A</type>
+        <magic></magic>
 		<value>5cp</value>
 		<weight>0.075</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -143,6 +153,7 @@
 	<item>
 		<name>Crossbow Bolts (20)</name>
 		<type>A</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>1.5</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -152,6 +163,7 @@
 	<item>
 		<name>Sling Bullets</name>
 		<type>A</type>
+        <magic></magic>
 		<value>0.2cp</value>
 		<weight>0.075</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -161,6 +173,7 @@
 	<item>
 		<name>Sling Bullets (20)</name>
 		<type>A</type>
+        <magic></magic>
 		<value>4cp</value>
 		<weight>1.5</weight>
 		<text>Ammunition: You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack. At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.</text>
@@ -170,6 +183,7 @@
 	<item>
 		<name>Abacus</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>2</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -177,6 +191,7 @@
 	<item>
 		<name>Acid (vial)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>1</weight>
 		<text>As an action, you can splash the contents of this vial onto a creature within 5 feet of you or throw the vial up to 20 feet, shattering it on impact. In either case, make a ranged attack against a creature or object, treating the acid as an improvised weapon. On a hit, the target takes 2d6 acid damage.</text>
@@ -186,6 +201,7 @@
 	<item>
 		<name>Alchemist's Fire (flask)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>1</weight>
 		<text>This sticky, adhesive fluid ignites when exposed to air. As an action, you can throw this flask up to 20 feet, shattering it on impact. Make a ranged attack against a creature or object, treating the alchemist's fire as an improvised weapon. On a hit, the target takes 1d4 fire damage at the start of each of its turns. A creature can end this damage by using its action to make a DC 10 Dexterity check to extinguish the flames.</text>
@@ -195,6 +211,7 @@
 	<item>
 		<name>Alchemist's Supplies</name>
 		<type>G</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -204,6 +221,7 @@
 	<item>
 		<name>Antitoxin</name>
 		<type>G</type>
+        <magic></magic>
 		<value>50gp</value>
 		<text>A creature that drinks this vial of liquid gains advantage on saving throws against poison for 1 hour. It confers no benefit to undead or constructs.</text>
 		<text />
@@ -212,6 +230,7 @@
 	<item>
 		<name>Backpack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>5</weight>
 		<text>A backpack can hold one cubic foot or 30 pounds of gear. You can also strap items, such as a bedroll or a coil of rope, to the outside of a backpack.</text>
@@ -221,6 +240,7 @@
 	<item>
 		<name>Bagpipes</name>
 		<type>G</type>
+        <magic></magic>
 		<value>30gp</value>
 		<weight>6</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -234,6 +254,7 @@
 	<item>
 		<name>Ball Bearings</name>
 		<type>G</type>
+        <magic></magic>
 		<value>0.1cp</value>
 		<weight>0.002</weight>
 		<text>As an action, you can spill these tiny metal balls from their pouch to cover a level area 10 feet square. A creature moving across the covered area must succeed on a DC 10 Dexterity saving throw or fall prone. A creature moving through the area at half speed doesn't need to make the saving throw.</text>
@@ -243,6 +264,7 @@
 	<item>
 		<name>Barrel</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>70</weight>
 		<text>A barrel can hold 40 gallons of liquid or 4 cubic feet of solids.</text>
@@ -252,6 +274,7 @@
 	<item>
 		<name>Basic Poison (vial)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>100gp</value>
 		<text>You can use the poison in this vial to coat one slashing or piercing weapon or up to three pieces of ammunition. Applying the poison takes an action. A creature hit by the poisoned weapon or ammunition must make a DC 10 Constitution saving throw or take 1d4 poison damage. Once applied, the poison retains potency for 1 minute before drying.</text>
 		<text />
@@ -260,6 +283,7 @@
 	<item>
 		<name>Basket</name>
 		<type>G</type>
+        <magic></magic>
 		<value>4sp</value>
 		<weight>2</weight>
 		<text>A basket holds 2 cubic feet or 40 pounds of gear.</text>
@@ -269,6 +293,7 @@
 	<item>
 		<name>Bedroll</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>7</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -276,12 +301,14 @@
 	<item>
 		<name>Bell</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Blanket</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5sp</value>
 		<weight>3</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -289,6 +316,7 @@
 	<item>
 		<name>Block and Tackle</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>5</weight>
 		<text>A set of pulleys with a cable threaded through them and a hook to attach to objects, a block and tackle allows you to hoist up to four times the weight you can normally lift.</text>
@@ -298,6 +326,7 @@
 	<item>
 		<name>Book</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>5</weight>
 		<text>A book might contain poetry, historical accounts, information pertaining to a particular field of lore, diagrams and notes on gnomish contraptions, or just about anything else that can be represented using text or pictures. A book of spells is a spellbook (described later in this section).</text>
@@ -307,6 +336,7 @@
 	<item>
 		<name>Brewer's Supplies</name>
 		<type>G</type>
+        <magic></magic>
 		<value>20gp</value>
 		<weight>9</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -316,6 +346,7 @@
 	<item>
 		<name>Bucket</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5cp</value>
 		<weight>2</weight>
 		<text>A bucket holds 3 gallons of liquid or 1/2 cubic foot of solids.</text>
@@ -325,6 +356,7 @@
 	<item>
 		<name>Bullseye Lantern</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>2</weight>
 		<text>A bullseye lantern casts bright light in a 60-foot cone and dim light for an additional 60 feet. Once lit, it burns for 6 hours on a flask (1 pint) of oil.</text>
@@ -334,6 +366,7 @@
 	<item>
 		<name>Burglar's Pack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>16gp</value>
 		<weight>44.5</weight>
 		<text>Includes:</text>
@@ -371,6 +404,7 @@
 	<item>
 		<name>Calligrapher's Supplies</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -380,6 +414,7 @@
 	<item>
 		<name>Caltrops</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5cp</value>
 		<weight>0.1</weight>
 		<text>As an action, you can spread a single bag of caltrops to cover a 5-foot-square area. Any creature that enters the area must succeed on a DC 15 Dexterity saving throw or stop moving and take 1 piercing damage. Until the creature regains at least 1 hit point, its walking speed is reduced by 10 feet. A creature moving through the area at half speed doesn't need to make the saving throw.</text>
@@ -389,6 +424,7 @@
 	<item>
 		<name>Caltrops (20)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>2</weight>
 		<text>As an action, you can spread a single bag of caltrops to cover a 5-foot-square area. Any creature that enters the area must succeed on a DC 15 Dexterity saving throw or stop moving and take 1 piercing damage. Until the creature regains at least 1 hit point, its walking speed is reduced by 10 feet. A creature moving through the area at half speed doesn't need to make the saving throw.</text>
@@ -398,6 +434,7 @@
 	<item>
 		<name>Candle</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1cp</value>
 		<text>For 1 hour, a candle sheds bright light in a 5-foot radius and dim light for an additional 5 feet.</text>
 		<text />
@@ -406,6 +443,7 @@
 	<item>
 		<name>Carpenter's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>8gp</value>
 		<weight>6</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -415,6 +453,7 @@
 	<item>
 		<name>Cartographer's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>15gp</value>
 		<weight>6</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -424,6 +463,7 @@
 	<item>
 		<name>Chain (10 feet)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>10</weight>
 		<text>A chain has 10 hit points. It can be burst with a successful DC 20 Strength check.</text>
@@ -433,12 +473,14 @@
 	<item>
 		<name>Chalk (1 piece)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1cp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Chest</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>25</weight>
 		<text>A chest holds 12 cubic feet or 300 pounds of gear.</text>
@@ -448,6 +490,7 @@
 	<item>
 		<name>Climber's Kit</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>12</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -457,6 +500,7 @@
 	<item>
 		<name>Cobbler's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -466,6 +510,7 @@
 	<item>
 		<name>Common Clothes</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5sp</value>
 		<weight>3</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -473,6 +518,7 @@
 	<item>
 		<name>Component Pouch</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>2</weight>
 		<text>A component pouch is a small, watertight leather belt pouch that has compartments to hold all the material components and other special items you need to cast your spells, except for those components that have a specific cost (as indicated in a spell's description).</text>
@@ -482,6 +528,7 @@
 	<item>
 		<name>Cook's Utensils</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -491,6 +538,7 @@
 	<item>
 		<name>Costume Clothes</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -498,6 +546,7 @@
 	<item>
 		<name>Crossbow Bolt Case</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>1</weight>
 		<text>This wooden case can hold up to twenty crossbow bolts.</text>
@@ -507,6 +556,7 @@
 	<item>
 		<name>Crowbar</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>5</weight>
 		<text>Using a crowbar grants advantage to Strength checks where the crowbar's leverage can be applied.</text>
@@ -516,6 +566,7 @@
 	<item>
 		<name>Crystal</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>1</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
@@ -525,6 +576,7 @@
 	<item>
 		<name>Dice Set</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1sp</value>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
 		<text />
@@ -533,6 +585,7 @@
 	<item>
 		<name>Diplomat's Pack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>39gp</value>
 		<weight>36</weight>
 		<text>Includes:</text>
@@ -564,6 +617,7 @@
 	<item>
 		<name>Disguise Kit</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>3</weight>
 		<text>This pouch of cosmetics, hair dye, and small props lets you create disguises that change your physical appearance. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to create a visual disguise.</text>
@@ -573,6 +627,7 @@
 	<item>
 		<name>Dragonchess Set</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>0.5</weight>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
@@ -582,6 +637,7 @@
 	<item>
 		<name>Drum</name>
 		<type>G</type>
+        <magic></magic>
 		<value>6gp</value>
 		<weight>3</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -595,6 +651,7 @@
 	<item>
 		<name>Dulcimer</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>10</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -608,6 +665,7 @@
 	<item>
 		<name>Dungeoneer's Pack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>12gp</value>
 		<weight>61.5</weight>
 		<text>Includes:</text>
@@ -635,6 +693,7 @@
 	<item>
 		<name>Entertainer's Pack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>40gp</value>
 		<weight>38</weight>
 		<text>Includes:</text>
@@ -658,6 +717,7 @@
 	<item>
 		<name>Explorer's Pack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>59</weight>
 		<text>Includes:</text>
@@ -683,6 +743,7 @@
 	<item>
 		<name>Fine Clothes</name>
 		<type>G</type>
+        <magic></magic>
 		<value>15gp</value>
 		<weight>6</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -690,6 +751,7 @@
 	<item>
 		<name>Fishing Tackle</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>4</weight>
 		<text>This kit includes a wooden rod, silken line, corkwood bobbers, steel hooks, lead sinkers, velvet lures, and narrow netting.</text>
@@ -699,6 +761,7 @@
 	<item>
 		<name>Flask</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1cp</value>
 		<weight>1</weight>
 		<text>A flask holds 1 pint of liquid.</text>
@@ -708,6 +771,7 @@
 	<item>
 		<name>Flute</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>1</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -721,6 +785,7 @@
 	<item>
 		<name>Forgery Kit</name>
 		<type>G</type>
+        <magic></magic>
 		<value>15gp</value>
 		<weight>5</weight>
 		<text>This small box contains a variety of papers and parchments, pens and inks, seals and sealing wax, gold and silver leaf, and other supplies necessary to create convincing forgeries of physical documents. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to create a physical forgery of a document.</text>
@@ -730,6 +795,7 @@
 	<item>
 		<name>Glass Bottle</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>2</weight>
 		<text>A bottle holds 1 1/2 pints of liquid.</text>
@@ -739,6 +805,7 @@
 	<item>
 		<name>Glassblower's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>30gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -748,6 +815,7 @@
 	<item>
 		<name>Grappling Hook</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -755,6 +823,7 @@
 	<item>
 		<name>Hammer</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>3</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -762,6 +831,7 @@
 	<item>
 		<name>Healer's Kit</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>3</weight>
 		<text>This kit is a leather pouch containing bandages, salves, and splints. The kit has ten uses. As an action, you can expend one use of the kit to stabilize a creature that has 0 hit points, without needing to make a Wisdom (Medicine) check.</text>
@@ -771,6 +841,7 @@
 	<item>
 		<name>Hempen Rope (50 feet)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>10</weight>
 		<text>Rope, whether made of hemp or silk, has 2 hit points and can be burst with a DC 17 Strength check.</text>
@@ -780,6 +851,7 @@
 	<item>
 		<name>Herbalism Kit</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>3</weight>
 		<text>This kit contains a variety of instruments such as clippers, mortar and pestle, and pouches and vials used by herbalists to create remedies and potions. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to identify or apply herbs. Also, proficiency with this kit is required to create antitoxin and potions of healing.</text>
@@ -789,6 +861,7 @@
 	<item>
 		<name>Holy Symbol (Amulet)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>1</weight>
 		<text>A holy symbol is a representation of a god or pantheon</text>
@@ -800,6 +873,7 @@
 	<item>
 		<name>Holy Symbol (Emblem)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<text>A holy symbol is a representation of a god or pantheon</text>
 		<text />
@@ -810,6 +884,7 @@
 	<item>
 		<name>Holy Symbol (Reliquary)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>2</weight>
 		<text>A holy symbol is a representation of a god or pantheon</text>
@@ -821,6 +896,7 @@
 	<item>
 		<name>Holy Water (flask)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>1</weight>
 		<text>As an action, you can splash the contents of this flask onto a creature within 5 feet of you or throw it up to 20 feet, shattering it on impact. In either case, make a ranged attack against a target creature, treating the holy water as an improvised weapon. If the target is a fiend or undead, it takes 2d6 radiant damage.\n\tA cleric or paladin may create holy water by performing a special ritual. The ritual takes 1 hour to perform, uses 25 gp worth of powdered silver, and requires the caster to expend a 1st-level spell slot.</text>
@@ -830,6 +906,7 @@
 	<item>
 		<name>Hooded Lantern</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>2</weight>
 		<text>A hooded lantern casts bright light in a 30-foot radius and dim light for an additional 30 feet. Once lit, it burns for 6 hours on a flask (1 pint) of oil. As an action, you can lower the hood, reducing the light to dim light in a 5-foot radius.</text>
@@ -839,6 +916,7 @@
 	<item>
 		<name>Horn</name>
 		<type>G</type>
+        <magic></magic>
 		<value>3gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -852,6 +930,7 @@
 	<item>
 		<name>Hourglass</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>1</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -859,6 +938,7 @@
 	<item>
 		<name>Hunting Trap</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>25</weight>
 		<text>When you use your action to set it, this trap forms a saw-toothed steel ring that snaps shut when a creature steps on a pressure plate in the center. The trap is affixed by a heavy chain to an immobile object, such as a tree or a spike driven into the ground. A creature that steps on the plate must succeed on a DC 13 Dexterity saving throw or take 1d4 piercing damage and stop moving. Thereafter, until the creature breaks free of the trap, its movement is limited by the length of the chain (typically 3 feet long). A creature can use its action to make a DC 13 Strength check, freeing itself or another creature within its reach on a success. Each failed check deals 1 piercing damage to the trapped creature.</text>
@@ -869,17 +949,20 @@
 		<name>Ink (1 ounce bottle)</name>
 		<value>10gp</value>
 		<type>G</type>
+        <magic></magic>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Ink Pen</name>
 		<value>2cp</value>
 		<type>G</type>
+        <magic></magic>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Iron Pot</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>10</weight>
 		<text>An iron pot holds 1 gallon of liquid.</text>
@@ -889,6 +972,7 @@
 	<item>
 		<name>Iron Spikes</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1sp</value>
 		<weight>0.5</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -896,6 +980,7 @@
 	<item>
 		<name>Iron Spikes (10)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>5</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -903,6 +988,7 @@
 	<item>
 		<name>Jeweler's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>2</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -912,6 +998,7 @@
 	<item>
 		<name>Jug</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2cp</value>
 		<weight>4</weight>
 		<text>A jug holds 1 gallon of liquid.</text>
@@ -921,6 +1008,7 @@
 	<item>
 		<name>Ladder (10-foot)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1sp</value>
 		<weight>25</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -928,6 +1016,7 @@
 	<item>
 		<name>Lamp</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5sp</value>
 		<weight>1</weight>
 		<text>A lamp casts bright light in a 15-foot radius and dim light for an additional 30 feet. Once lit, it burns for 6 hours on a flask (1 pint) of oil.</text>
@@ -937,6 +1026,7 @@
 	<item>
 		<name>Leatherworker's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -946,6 +1036,7 @@
 	<item>
 		<name>Lock</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>1</weight>
 		<text>A key is provided with the lock. Without the key, a creature proficient with thieves' tools can pick this lock with a successful DC 15 Dexterity check. Your DM may decide that better locks are available for higher prices.</text>
@@ -955,6 +1046,7 @@
 	<item>
 		<name>Lute</name>
 		<type>G</type>
+        <magic></magic>
 		<value>35gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -968,6 +1060,7 @@
 	<item>
 		<name>Lyre</name>
 		<type>G</type>
+        <magic></magic>
 		<value>30gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -981,6 +1074,7 @@
 	<item>
 		<name>Magnifying Glass</name>
 		<type>G</type>
+        <magic></magic>
 		<value>100gp</value>
 		<text>This lens allows a closer look at small objects. It is also useful as a substitute for flint and steel when starting fires. Lighting a fire with a magnifying glass requires light as bright as sunlight to focus, tinder to ignite, and about 5 minutes for the fire to ignite. A magnifying glass grants advantage on any ability check made to appraise or inspect an item that is small or highly detailed.</text>
 		<text />
@@ -989,6 +1083,7 @@
 	<item>
 		<name>Manacles</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>6</weight>
 		<text>These metal restraints can bind a Small or Medium creature. Escaping the manacles requires a successful DC 20 Dexterity check. Breaking them requires a successful DC 20 Strength check. Each set of manacles comes with one key. Without the key, a creature proficient with thieves' tools can pick the manacles' lock with a successful DC 15 Dexterity check. Manacles have 15 hit points.</text>
@@ -998,6 +1093,7 @@
 	<item>
 		<name>Map or Scroll Case</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>1</weight>
 		<text>This cylindrical leather case can hold up to ten rolled-up sheets of paper or five rolled-up sheets of parchment.</text>
@@ -1007,6 +1103,7 @@
 	<item>
 		<name>Mason's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -1016,6 +1113,7 @@
 	<item>
 		<name>Merchant's Scale</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>3</weight>
 		<text>A scale includes a small balance, pans, and a suitable assortment of weights up to 2 pounds. With it, you can measure the exact weight of small objects, such as raw precious metals or trade goods, to help determine their worth.</text>
@@ -1025,6 +1123,7 @@
 	<item>
 		<name>Mess Kit</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2sp</value>
 		<weight>1</weight>
 		<text>This tin box contains a cup and simple cutlery. The box clamps together, and one side can be used as a cooking pan and the other as a plate or shallow bowl.</text>
@@ -1034,6 +1133,7 @@
 	<item>
 		<name>Miner's Pick</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>10</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1041,6 +1141,7 @@
 	<item>
 		<name>Navigator's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>2</weight>
 		<text>This set of instruments is used for navigation at sea. Proficiency with navigator's tools lets you chart a ship's course and follow navigation charts. In addition, these tools allow you to add your proficiency bonus to any ability check you make to avoid getting lost at sea.</text>
@@ -1050,6 +1151,7 @@
 	<item>
 		<name>Oil (flask)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1sp</value>
 		<weight>1</weight>
 		<text>Oil usually comes in a clay flask that holds 1 pint. As an action, you can splash the oil in this flask onto a creature within 5 feet of you or throw it up to 20 feet, shattering it on impact. Make a ranged attack against a target creature or object, treating the oil as an improvised weapon. On a hit, the target is covered in oil. If the target takes any fire damage before the oil dries (after 1 minute), the target takes an additional 5 fire damage from the burning oil. You can also pour a flask of oil on the ground to cover a 5-foot-square area, provided that the surface is level. If lit, the oil burns for 2 rounds and deals 5 fire damage to any creature that enters the area or ends its turn in the area. A creature can take this damage only once per turn.</text>
@@ -1059,6 +1161,7 @@
 	<item>
 		<name>Orb</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>3</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
@@ -1068,6 +1171,7 @@
 	<item>
 		<name>Painter's Supplies</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -1077,6 +1181,7 @@
 	<item>
 		<name>Pan Flute</name>
 		<type>G</type>
+        <magic></magic>
 		<value>12gp</value>
 		<weight>2</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -1090,24 +1195,28 @@
 	<item>
 		<name>Paper (one sheet)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2sp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Parchment (one sheet)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1sp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Perfume (vial)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Pitcher</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2cp</value>
 		<weight>4</weight>
 		<text>A pitcher holds 1 gallon of liquid.</text>
@@ -1117,6 +1226,7 @@
 	<item>
 		<name>Piton</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5cp</value>
 		<weight>0.25</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1124,6 +1234,7 @@
 	<item>
 		<name>Playing Card Set</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5sp</value>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
 		<text />
@@ -1132,6 +1243,7 @@
 	<item>
 		<name>Poisoner's Kit</name>
 		<type>G</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>2</weight>
 		<text>A poisoner's kit includes the vials, chemicals, and other equipment necessary for the creation of poisons. Proficiency with this kit lets you add your proficiency bonus to any ability checks you make to craft or use poisons.</text>
@@ -1141,6 +1253,7 @@
 	<item>
 		<name>Pole (10-foot)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5cp</value>
 		<weight>7</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1148,6 +1261,7 @@
 	<item>
 		<name>Portable Ram</name>
 		<type>G</type>
+        <magic></magic>
 		<value>4gp</value>
 		<weight>35</weight>
 		<text>You can use a portable ram to break down doors. When doing so, you gain a +4 bonus on the Strength check. One other character can help you use the ram, giving you advantage on this check.</text>
@@ -1157,6 +1271,7 @@
 	<item>
 		<name>Potter's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>3</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -1166,6 +1281,7 @@
 	<item>
 		<name>Pouch</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5sp</value>
 		<weight>1</weight>
 		<text>A cloth or leather pouch can hold up to 20 sling bullets or 50 blowgun needles, among other things. A compartmentalized pouch for holding spell components is called a component pouch. A pouch can hold up to 1/5 cubic foot or 6 pounds of gear.</text>
@@ -1175,6 +1291,7 @@
 	<item>
 		<name>Priest's Pack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>19gp</value>
 		<weight>24</weight>
 		<text>Includes:</text>
@@ -1204,6 +1321,7 @@
 	<item>
 		<name>Quiver</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>1</weight>
 		<text>A quiver can hold up to 20 arrows.</text>
@@ -1213,6 +1331,7 @@
 	<item>
 		<name>Rations (1 day)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5sp</value>
 		<weight>2</weight>
 		<text>Rations consist of dry foods suitable for extended travel, including jerky, dried fruit, hardtack, and nuts.</text>
@@ -1222,6 +1341,7 @@
 	<item>
 		<name>Robes</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1229,6 +1349,7 @@
 	<item>
 		<name>Rod</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>2</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
@@ -1238,6 +1359,7 @@
 	<item>
 		<name>Sack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1cp</value>
 		<weight>0.5</weight>
 		<text>A sack can hold up to 1 cubic foot or 30 pounds of gear.</text>
@@ -1247,6 +1369,7 @@
 	<item>
 		<name>Scholar's Pack</name>
 		<type>G</type>
+        <magic></magic>
 		<value>40gp</value>
 		<weight>10</weight>
 		<text>Includes:</text>
@@ -1271,11 +1394,13 @@
 		<name>Sealing Wax</name>
 		<value>5sp</value>
 		<type>G</type>
+        <magic></magic>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Shawm</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>1</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -1289,6 +1414,7 @@
 	<item>
 		<name>Shovel</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>5</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1297,17 +1423,20 @@
 		<name>Signal Whistle</name>
 		<value>5cp</value>
 		<type>G</type>
+        <magic></magic>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Signet Ring</name>
 		<value>5gp</value>
 		<type>G</type>
+        <magic></magic>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Silk Rope (50 feet)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>5</weight>
 		<text>Rope, whether made of hemp or silk, has 2 hit points and can be burst with a DC 17 Strength check.</text>
@@ -1318,12 +1447,14 @@
 		<name>Sledge Hammer</name>
 		<value>2gp</value>
 		<type>G</type>
+        <magic></magic>
 		<weight>10</weight>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Smith's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>20gp</value>
 		<weight>8</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -1333,12 +1464,14 @@
 	<item>
 		<name>Soap</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2cp</value>
 		<text>Source: Player's Handbook, page 150</text>
 	</item>
 	<item>
 		<name>Spellbook</name>
 		<type>G</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>3</weight>
 		<text>Essential for wizards, a spellbook is a leather-bound tome with 100 blank vellum pages suitable for recording spells.</text>
@@ -1348,6 +1481,7 @@
 	<item>
 		<name>Sprig of Mistletoe</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
 		<text />
@@ -1356,6 +1490,7 @@
 	<item>
 		<name>Spyglass</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>1</weight>
 		<text>Objects viewed through a spyglass are magnified to twice their size.</text>
@@ -1365,6 +1500,7 @@
 	<item>
 		<name>Staff</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>4</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
@@ -1374,6 +1510,7 @@
 	<item>
 		<name>Steel Mirror</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>0.5</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1381,6 +1518,7 @@
 	<item>
 		<name>Tankard</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1cp</value>
 		<text>A tankard holds 1 pint of liquid.</text>
 		<text />
@@ -1389,6 +1527,7 @@
 	<item>
 		<name>Thieves' Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>1</weight>
 		<text>This set of tools includes a small file, a set of lock picks, a small mirror mounted on a metal handle, a set of narrow-bladed scissors, and a pair of pliers. Proficiency with these tools lets you add your proficiency bonus to any ability checks you make to disarm traps or open locks.</text>
@@ -1398,6 +1537,7 @@
 	<item>
 		<name>Three-Dragon Ante Set</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<text>If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency.</text>
 		<text />
@@ -1406,6 +1546,7 @@
 	<item>
 		<name>Tinderbox</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5sp</value>
 		<weight>1</weight>
 		<text>This small container holds flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a torch - or anything else with abundant, exposed fuel - takes an action. Lighting any other fire takes 1 minute.</text>
@@ -1415,6 +1556,7 @@
 	<item>
 		<name>Tinker's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>10</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -1424,6 +1566,7 @@
 	<item>
 		<name>Torch</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1cp</value>
 		<weight>1</weight>
 		<text>A torch burns for 1 hour, providing bright light in a 20-foot radius and dim light for an additional 20 feet. If you make a melee attack with a burning torch and hit, it deals 1 fire damage.</text>
@@ -1433,6 +1576,7 @@
 	<item>
 		<name>Totem</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
 		<text />
@@ -1441,6 +1585,7 @@
 	<item>
 		<name>Traveler's Clothes</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>4</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1448,6 +1593,7 @@
 	<item>
 		<name>Two-Person Tent</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>20</weight>
 		<text>A simple and portable canvas shelter, a tent sleeps two.</text>
@@ -1457,6 +1603,7 @@
 	<item>
 		<name>Vial</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<text>A vial can hold up to 4 ounces of liquid.</text>
 		<text />
@@ -1465,6 +1612,7 @@
 	<item>
 		<name>Viol</name>
 		<type>G</type>
+        <magic></magic>
 		<value>30gp</value>
 		<weight>1</weight>
 		<text>If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument.</text>
@@ -1478,6 +1626,7 @@
 	<item>
 		<name>Wand</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>1</weight>
 		<text>An arcane focus is a special item designed to channel the power of arcane spells. A sorcerer, warlock, or wizard can use such an item as a spellcasting focus, using it in place of any material component which does not list a cost.</text>
@@ -1487,6 +1636,7 @@
 	<item>
 		<name>Waterskin</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2sp</value>
 		<weight>5</weight>
 		<text>A waterskin can hold up to 4 pints of liquid.</text>
@@ -1496,6 +1646,7 @@
 	<item>
 		<name>Weaver's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -1505,6 +1656,7 @@
 	<item>
 		<name>Whetstone</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1cp</value>
 		<weight>1</weight>
 		<text>Source: Player's Handbook, page 150</text>
@@ -1512,6 +1664,7 @@
 	<item>
 		<name>Woodcarver's Tools</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>5</weight>
 		<text>These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency.</text>
@@ -1521,6 +1674,7 @@
 	<item>
 		<name>Wooden Staff</name>
 		<type>G</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>4</weight>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
@@ -1530,6 +1684,7 @@
 	<item>
 		<name>Yew Wand</name>
 		<type>G</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>1</weight>
 		<text>A druid can use such a druidic focus as a spellcasting focus, using it in place of any material component that does not have a cost.</text>
@@ -1539,6 +1694,7 @@
 	<item>
 		<name>Chain Mail</name>
 		<type>HA</type>
+        <magic></magic>
 		<value>75gp</value>
 		<weight>55</weight>
 		<ac>16</ac>
@@ -1551,6 +1707,7 @@
 	<item>
 		<name>Plate Armor</name>
 		<type>HA</type>
+        <magic></magic>
 		<value>1500gp</value>
 		<weight>65</weight>
 		<ac>18</ac>
@@ -1563,6 +1720,7 @@
 	<item>
 		<name>Ring Mail</name>
 		<type>HA</type>
+        <magic></magic>
 		<value>30gp</value>
 		<weight>40</weight>
 		<ac>14</ac>
@@ -1574,6 +1732,7 @@
 	<item>
 		<name>Splint Armor</name>
 		<type>HA</type>
+        <magic></magic>
 		<value>200gp</value>
 		<weight>60</weight>
 		<ac>17</ac>
@@ -1586,6 +1745,7 @@
 	<item>
 		<name>Leather Armor</name>
 		<type>LA</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>10</weight>
 		<ac>11</ac>
@@ -1596,6 +1756,7 @@
 	<item>
 		<name>Padded Armor</name>
 		<type>LA</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>8</weight>
 		<ac>11</ac>
@@ -1607,6 +1768,7 @@
 	<item>
 		<name>Studded Leather Armor</name>
 		<type>LA</type>
+        <magic></magic>
 		<value>45gp</value>
 		<weight>13</weight>
 		<ac>12</ac>
@@ -1617,6 +1779,7 @@
 	<item>
 		<name>Battleaxe</name>
 		<type>M</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>4</weight>
 		<dmg1>1d8</dmg1>
@@ -1630,6 +1793,7 @@
 	<item>
 		<name>Club</name>
 		<type>M</type>
+        <magic></magic>
 		<value>1sp</value>
 		<weight>2</weight>
 		<dmg1>1d4</dmg1>
@@ -1642,6 +1806,7 @@
 	<item>
 		<name>Dagger</name>
 		<type>M</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>1</weight>
 		<dmg1>1d4</dmg1>
@@ -1661,6 +1826,7 @@
 	<item>
 		<name>Flail</name>
 		<type>M</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
@@ -1670,6 +1836,7 @@
 	<item>
 		<name>Glaive</name>
 		<type>M</type>
+        <magic></magic>
 		<value>20gp</value>
 		<weight>6</weight>
 		<dmg1>1d10</dmg1>
@@ -1686,6 +1853,7 @@
 	<item>
 		<name>Greataxe</name>
 		<type>M</type>
+        <magic></magic>
 		<value>30gp</value>
 		<weight>7</weight>
 		<dmg1>1d12</dmg1>
@@ -1700,6 +1868,7 @@
 	<item>
 		<name>Greatclub</name>
 		<type>M</type>
+        <magic></magic>
 		<value>2sp</value>
 		<weight>10</weight>
 		<dmg1>1d8</dmg1>
@@ -1712,6 +1881,7 @@
 	<item>
 		<name>Greatsword</name>
 		<type>M</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>6</weight>
 		<dmg1>2d6</dmg1>
@@ -1726,6 +1896,7 @@
 	<item>
 		<name>Halberd</name>
 		<type>M</type>
+        <magic></magic>
 		<value>20gp</value>
 		<weight>6</weight>
 		<dmg1>1d10</dmg1>
@@ -1740,6 +1911,7 @@
 	<item>
 		<name>Handaxe</name>
 		<type>M</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
@@ -1757,6 +1929,7 @@
 	<item>
 		<name>Javelin</name>
 		<type>M</type>
+        <magic></magic>
 		<value>2sp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
@@ -1772,6 +1945,7 @@
 	<item>
 		<name>Lance</name>
 		<type>M</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>6</weight>
 		<dmg1>1d12</dmg1>
@@ -1786,6 +1960,7 @@
 	<item>
 		<name>Light Hammer</name>
 		<type>M</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>2</weight>
 		<dmg1>1d4</dmg1>
@@ -1803,6 +1978,7 @@
 	<item>
 		<name>Longsword</name>
 		<type>M</type>
+        <magic></magic>
 		<value>15gp</value>
 		<weight>3</weight>
 		<dmg1>1d8</dmg1>
@@ -1816,6 +1992,7 @@
 	<item>
 		<name>Mace</name>
 		<type>M</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>4</weight>
 		<dmg1>1d6</dmg1>
@@ -1825,6 +2002,7 @@
 	<item>
 		<name>Maul</name>
 		<type>M</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>10</weight>
 		<dmg1>2d6</dmg1>
@@ -1839,6 +2017,7 @@
 	<item>
 		<name>Morningstar</name>
 		<type>M</type>
+        <magic></magic>
 		<value>15gp</value>
 		<weight>4</weight>
 		<dmg1>1d8</dmg1>
@@ -1848,6 +2027,7 @@
 	<item>
 		<name>Pike</name>
 		<type>M</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>18</weight>
 		<dmg1>1d10</dmg1>
@@ -1864,6 +2044,7 @@
 	<item>
 		<name>Quarterstaff</name>
 		<type>M</type>
+        <magic></magic>
 		<value>2sp</value>
 		<weight>4</weight>
 		<dmg1>1d6</dmg1>
@@ -1877,6 +2058,7 @@
 	<item>
 		<name>Rapier</name>
 		<type>M</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
@@ -1889,6 +2071,7 @@
 	<item>
 		<name>Scimitar</name>
 		<type>M</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>3</weight>
 		<dmg1>1d6</dmg1>
@@ -1903,6 +2086,7 @@
 	<item>
 		<name>Shortsword</name>
 		<type>M</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
@@ -1917,6 +2101,7 @@
 	<item>
 		<name>Sickle</name>
 		<type>M</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>2</weight>
 		<dmg1>1d4</dmg1>
@@ -1929,6 +2114,7 @@
 	<item>
 		<name>Spear</name>
 		<type>M</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>3</weight>
 		<dmg1>1d6</dmg1>
@@ -1947,6 +2133,7 @@
 	<item>
 		<name>Trident</name>
 		<type>M</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>4</weight>
 		<dmg1>1d6</dmg1>
@@ -1965,6 +2152,7 @@
 	<item>
 		<name>War Pick</name>
 		<type>M</type>
+        <magic></magic>
 		<value>5gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
@@ -1974,6 +2162,7 @@
 	<item>
 		<name>Warhammer</name>
 		<type>M</type>
+        <magic></magic>
 		<value>15gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
@@ -1987,6 +2176,7 @@
 	<item>
 		<name>Whip</name>
 		<type>M</type>
+        <magic></magic>
 		<value>2gp</value>
 		<weight>3</weight>
 		<dmg1>1d4</dmg1>
@@ -2001,6 +2191,7 @@
 	<item>
 		<name>Breastplate</name>
 		<type>MA</type>
+        <magic></magic>
 		<value>400gp</value>
 		<weight>20</weight>
 		<ac>14</ac>
@@ -2011,6 +2202,7 @@
 	<item>
 		<name>Chain Shirt</name>
 		<type>MA</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>20</weight>
 		<ac>13</ac>
@@ -2021,6 +2213,7 @@
 	<item>
 		<name>Half Plate</name>
 		<type>MA</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>40</weight>
 		<ac>15</ac>
@@ -2032,6 +2225,7 @@
 	<item>
 		<name>Hide Armor</name>
 		<type>MA</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>12</weight>
 		<ac>12</ac>
@@ -2042,6 +2236,7 @@
 	<item>
 		<name>Scale Mail</name>
 		<type>MA</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>45</weight>
 		<ac>14</ac>
@@ -2053,6 +2248,7 @@
 	<item>
 		<name>Blowgun</name>
 		<type>R</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>1</weight>
 		<dmg1>1</dmg1>
@@ -2072,6 +2268,7 @@
 	<item>
 		<name>Dart</name>
 		<type>R</type>
+        <magic></magic>
 		<value>5cp</value>
 		<weight>0.25</weight>
 		<dmg1>1d4</dmg1>
@@ -2089,6 +2286,7 @@
 	<item>
 		<name>Hand Crossbow</name>
 		<type>R</type>
+        <magic></magic>
 		<value>75gp</value>
 		<weight>3</weight>
 		<dmg1>1d6</dmg1>
@@ -2110,6 +2308,7 @@
 	<item>
 		<name>Heavy Crossbow</name>
 		<type>R</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>18</weight>
 		<dmg1>1d10</dmg1>
@@ -2133,6 +2332,7 @@
 	<item>
 		<name>Light Crossbow</name>
 		<type>R</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>5</weight>
 		<dmg1>1d8</dmg1>
@@ -2154,6 +2354,7 @@
 	<item>
 		<name>Longbow</name>
 		<type>R</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>2</weight>
 		<dmg1>1d8</dmg1>
@@ -2175,6 +2376,7 @@
 	<item>
 		<name>Net</name>
 		<type>R</type>
+        <magic></magic>
 		<value>1gp</value>
 		<weight>3</weight>
 		<property>S,T</property>
@@ -2190,6 +2392,7 @@
 	<item>
 		<name>Shortbow</name>
 		<type>R</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>2</weight>
 		<dmg1>1d6</dmg1>
@@ -2209,6 +2412,7 @@
 	<item>
 		<name>Sling</name>
 		<type>R</type>
+        <magic></magic>
 		<value>1sp</value>
 		<dmg1>1d4</dmg1>
 		<dmgType>B</dmgType>
@@ -2225,6 +2429,7 @@
 	<item>
 		<name>Shield</name>
 		<type>S</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>6</weight>
 		<ac>2</ac>
@@ -2235,6 +2440,7 @@
 	<item>
 		<name>Assassin's Blood (Ingested)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>150gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must make a DC 10 Constitution saving throw. On a failed save, it takes 6 (1d12) poison damage and is poisoned for 24 hours. On a successful save, the creature takes half damage and isn't poisoned.</text>
@@ -2245,6 +2451,7 @@
 	<item>
 		<name>Burnt Othur Fumes (Inhaled)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>500gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or take 10 (3d6) poison damage, and must repeat the saving throw at the start of each of its turns. On each successive failed save, the character takes 3 (1d6) poison damage. After three successful saves, the poison ends.</text>
@@ -2256,6 +2463,7 @@
 	<item>
 		<name>Carrion Crawler Mucus (Contact)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>200gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated carrion crawler. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. The poisoned creature is paralyzed. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</text>
@@ -2265,6 +2473,7 @@
 	<item>
 		<name>Drow Poison (Injury)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>200gp</value>
 		<weight>0</weight>
 		<text>This poison is typically made only by the draw, and only in a place far removed from sunlight. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the creature is also unconscious while poisoned in this way. The creature wakes up if it takes damage or if another creature takes an action to shake it awake.</text>
@@ -2274,6 +2483,7 @@
 	<item>
 		<name>Essence of Ether (Inhaled)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>300gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 15 Constitution saving throw or become poisoned for 8 hours. The poisoned creature is unconscious. The creature wakes up if it takes damage or if another creature takes an action to shake it awake.</text>
@@ -2283,6 +2493,7 @@
 	<item>
 		<name>Malice (Inhaled)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 15 Constitution saving throw or become poisoned for 1 hour. The poisoned creature is blinded.</text>
@@ -2292,6 +2503,7 @@
 	<item>
 		<name>Midnight Tears (Ingested)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1500gp</value>
 		<weight>0</weight>
 		<text>A creature that ingests this poison suffers no effect until the stroke of midnight. If the poison has not been neutralized before then, the creature must succeed on a DC 17 Constitution saving throw, taking 31 (9d6) poison damage on a failed save, or half as much damage on a successful one.</text>
@@ -2302,6 +2514,7 @@
 	<item>
 		<name>Oil of Taggit (Contact)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>400gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or become poisoned for 24 hours. The poisoned creature is unconscious. The creature wakes up if it takes damage.</text>
@@ -2311,6 +2524,7 @@
 	<item>
 		<name>Pale Tincture (Ingested)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 16 Constitution saving throw or take 3 (1d6) poison damage and become poisoned. The poisoned creature must repeat the saving throw every 24 hours, taking 3 (1d6) poison damage on a failed save. Until this poison ends, the damage the poison deals can't be healed by any means. After seven successful saving throws, the effect ends and the creature can heal normally.</text>
@@ -2321,6 +2535,7 @@
 	<item>
 		<name>Purple Worm Poison (Injury)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>2000gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated purple worm. A creature subjected to this poison must make a DC 19 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one.</text>
@@ -2331,6 +2546,7 @@
 	<item>
 		<name>Serpent Venom (Injury)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>200gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated giant poisonous snake. A creature subjected to this poison must succeed on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one.</text>
@@ -2341,6 +2557,7 @@
 	<item>
 		<name>Torpor (Ingested)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>600gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to this poison must succeed on a DC 15 Constitution saving throw or become poisoned for 4d6 hours. The poisoned creature is incapacitated.</text>
@@ -2351,6 +2568,7 @@
 	<item>
 		<name>Truth Serum (Ingested)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>150gp</value>
 		<weight>0</weight>
 		<text>A creature subjected to thi poison must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. The poisoned creature can't knowingly speak a lie, as if under the effect of a zone of truth spell.</text>
@@ -2360,6 +2578,7 @@
 	<item>
 		<name>Wyvern Poison (Injury)</name>
 		<type>G</type>
+        <magic></magic>
 		<value>1200gp</value>
 		<weight>0</weight>
 		<text>This poison must be harvested from a dead or incapacitated wyvern. A creature subjected to this poison must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one.</text>
@@ -2370,6 +2589,7 @@
 	<item>
 		<name>Trinket</name>
 		<type>G</type>
+        <magic></magic>
 		<weight>0</weight>
 		<text>When you make your character, you can roll once on the Trinkets table to gain a trinket, a simple item lightly touched by mystery. The DM might also use this table. It can help stock a room in a dungeon or fill a creatures pockets.</text>
 		<text />
@@ -2589,6 +2809,7 @@
 	<item>
 		<name>Spiked Armor</name>
 		<type>MA</type>
+        <magic></magic>
 		<value>75gp</value>
 		<weight>45</weight>
 		<ac>14</ac>
@@ -2602,6 +2823,7 @@
     <item>
         <name>Monster Hunter's Pack</name>
         <type>G</type>
+        <magic></magic>
         <value>33gp</value>
 		<weight>48.5</weight>
         <text>Includes:</text>

--- a/Items/Valuable Items.xml
+++ b/Items/Valuable Items.xml
@@ -3,6 +3,7 @@
 	<item>
 		<name>10 GP - Azurite</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>An opaque mottled deep blue gemstone worth 10 gp.</text>
@@ -12,6 +13,7 @@
 	<item>
 		<name>10 GP - Banded Agate</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>A translucent striped brown, blue, white, or red gemstone worth 10 gp.</text>
@@ -21,6 +23,7 @@
 	<item>
 		<name>10 GP - Blue Quartz</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>A transparent pale blue gemstone worth 10 gp.</text>
@@ -30,6 +33,7 @@
 	<item>
 		<name>10 GP - Eye Agate</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>A translucent circles of gray, white, brown, blue, or green gemstone worth 10 gp.</text>
@@ -39,6 +43,7 @@
 	<item>
 		<name>10 GP - Hematite</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>An opaque gray-black gemstone worth 10 gp.</text>
@@ -48,6 +53,7 @@
 	<item>
 		<name>10 GP - Lapis Lazuli</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>An opaque light and dark blue with yellow flecks gemstone worth 10 gp.</text>
@@ -57,6 +63,7 @@
 	<item>
 		<name>10 GP - Malachite</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>An opaque striated light and dark green gemstone worth 10 gp.</text>
@@ -66,6 +73,7 @@
 	<item>
 		<name>10 GP - Moss Agate</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>A translucent pink or yellow-white with mossy gray or green markings gemstone worth 10 gp.</text>
@@ -75,6 +83,7 @@
 	<item>
 		<name>10 GP - Obsidian</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>An opaque black gemstone worth 10 gp.</text>
@@ -84,6 +93,7 @@
 	<item>
 		<name>10 GP - Rhodochrosite</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>An opaque light pink gemstone worth 10 gp.</text>
@@ -93,6 +103,7 @@
 	<item>
 		<name>10 GP - Tiger Eye</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>A translucent brown with golden center gemstone worth 10 gp.</text>
@@ -102,6 +113,7 @@
 	<item>
 		<name>10 GP - Turquoise</name>
 		<type>$</type>
+        <magic></magic>
 		<value>10gp</value>
 		<weight>0</weight>
 		<text>An opaque light blue-green gemstone worth 10 gp.</text>
@@ -111,6 +123,7 @@
 	<item>
 		<name>50 GP - Bloodstone</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>An opaque dark gray with red flecks gemstone worth 50 gp.</text>
@@ -120,6 +133,7 @@
 	<item>
 		<name>50 GP - Carnelian</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>An opaque orange to red-brown gemstone worth 50 gp.</text>
@@ -129,6 +143,7 @@
 	<item>
 		<name>50 GP - Chalcedony</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>An opaque white gemstone worth 50 gp.</text>
@@ -138,6 +153,7 @@
 	<item>
 		<name>50 GP - Chrysoprase</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>A translucent green gemstone worth 50 gp.</text>
@@ -147,6 +163,7 @@
 	<item>
 		<name>50 GP - Citrine</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>A transparent pale yellow-brown gemstone worth 50 gp.</text>
@@ -156,6 +173,7 @@
 	<item>
 		<name>50 GP - Jasper</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>An opaque blue, black, or brown gemstone worth 50 gp.</text>
@@ -165,6 +183,7 @@
 	<item>
 		<name>50 GP - Moonstone</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>A translucent white with pale blue glow gemstone worth 50 gp.</text>
@@ -174,6 +193,7 @@
 	<item>
 		<name>50 GP - Onyx</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>An opaque bands of black and white, or pure black or white gemstone worth 50 gp.</text>
@@ -183,6 +203,7 @@
 	<item>
 		<name>50 GP - Quartz</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>A transparent white, smoky gray, or yellow gemstone worth 50 gp.</text>
@@ -192,6 +213,7 @@
 	<item>
 		<name>50 GP - Sardonyx</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>An opaque bands of red and white gemstone worth 50 gp.</text>
@@ -201,6 +223,7 @@
 	<item>
 		<name>50 GP - Star rose quartz</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>A translucent rosy stone with white star-shaped center gemstone worth 50 gp.</text>
@@ -210,6 +233,7 @@
 	<item>
 		<name>50 GP - Zircon</name>
 		<type>$</type>
+        <magic></magic>
 		<value>50gp</value>
 		<weight>0</weight>
 		<text>A transparent pale blue-green gemstone worth 50 gp.</text>
@@ -219,6 +243,7 @@
 	<item>
 		<name>100 GP - Amber</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>A transparent watery gold to rich gold gemstone worth 100 gp.</text>
@@ -228,6 +253,7 @@
 	<item>
 		<name>100 GP - Amethyst</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>A transparent deep purple gemstone worth 100 gp.</text>
@@ -237,6 +263,7 @@
 	<item>
 		<name>100 GP - Chrysoberyl</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>A transparent yellow-green to pale green gemstone worth 100 gp.</text>
@@ -246,6 +273,7 @@
 	<item>
 		<name>100 GP - Coral</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>An opaque crimson gemstone worth 100 gp.</text>
@@ -255,6 +283,7 @@
 	<item>
 		<name>100 GP - Garnet</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>A transparent red, brown-green, or violet gemstone worth 100 gp.</text>
@@ -264,6 +293,7 @@
 	<item>
 		<name>100 GP - Jade</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>A translucent light green, deep green, or white gemstone worth 100 gp.</text>
@@ -273,6 +303,7 @@
 	<item>
 		<name>100 GP - Jet</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>An opaque deep black gemstone worth 100 gp.</text>
@@ -282,6 +313,7 @@
 	<item>
 		<name>100 GP - Pearl</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>An opaque lustrous white, yellow, or pink gemstone worth 100 gp.</text>
@@ -291,6 +323,7 @@
 	<item>
 		<name>100 GP - Spinel</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>A transparent red, red-brown, or deep green gemstone worth 100 gp.</text>
@@ -300,6 +333,7 @@
 	<item>
 		<name>100 GP - Tourmaline</name>
 		<type>$</type>
+        <magic></magic>
 		<value>100gp</value>
 		<weight>0</weight>
 		<text>A transparent pale green, blue, brown, or red gemstone worth 100 gp.</text>
@@ -309,6 +343,7 @@
 	<item>
 		<name>500 GP - Alexandrite</name>
 		<type>$</type>
+        <magic></magic>
 		<value>500gp</value>
 		<weight>0</weight>
 		<text>A transparent dark green gemstone worth 500 gp.</text>
@@ -318,6 +353,7 @@
 	<item>
 		<name>500 GP - Aquamarine</name>
 		<type>$</type>
+        <magic></magic>
 		<value>500gp</value>
 		<weight>0</weight>
 		<text>A transparent pale blue-green gemstone worth 500 gp.</text>
@@ -327,6 +363,7 @@
 	<item>
 		<name>500 GP - Black Pearl</name>
 		<type>$</type>
+        <magic></magic>
 		<value>500gp</value>
 		<weight>0</weight>
 		<text>An opaque pure black gemstone worth 500 gp.</text>
@@ -336,6 +373,7 @@
 	<item>
 		<name>500 GP - Blue Spinel</name>
 		<type>$</type>
+        <magic></magic>
 		<value>500gp</value>
 		<weight>0</weight>
 		<text>A transparent deep blue gemstone worth 500 gp.</text>
@@ -345,6 +383,7 @@
 	<item>
 		<name>500 GP - Peridot</name>
 		<type>$</type>
+        <magic></magic>
 		<value>500gp</value>
 		<weight>0</weight>
 		<text>A transparent rich olive green gemstone worth 500 gp.</text>
@@ -354,6 +393,7 @@
 	<item>
 		<name>500 GP - Topaz</name>
 		<type>$</type>
+        <magic></magic>
 		<value>500gp</value>
 		<weight>0</weight>
 		<text>A transparent golden yellow gemstone worth 500 gp.</text>
@@ -363,6 +403,7 @@
 	<item>
 		<name>1000 GP - Black Opal</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A translucent dark green with black mottling and golden flecks gemstone worth 1000 gp.</text>
@@ -372,6 +413,7 @@
 	<item>
 		<name>1000 GP - Blue Sapphire</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A transparent blue-white to medium blue gemstone worth 1000 gp.</text>
@@ -381,6 +423,7 @@
 	<item>
 		<name>1000 GP - Emerald</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A transparent deep bright green gemstone worth 1000 gp.</text>
@@ -390,6 +433,7 @@
 	<item>
 		<name>1000 GP - Fire Opal</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A translucent fiery red gemstone worth 1000 gp.</text>
@@ -399,6 +443,7 @@
 	<item>
 		<name>1000 GP - Opal</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A translucent pale blue with green and golden mottling gemstone worth 1000 gp.</text>
@@ -408,6 +453,7 @@
 	<item>
 		<name>1000 GP - Star Ruby</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A translucent ruby with white star-shaped center gemstone worth 1000 gp.</text>
@@ -417,6 +463,7 @@
 	<item>
 		<name>1000 GP - Star Sapphire</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A translucent blue sapphire with white star-shaped center gemstone worth 1000 gp.</text>
@@ -426,6 +473,7 @@
 	<item>
 		<name>1000 GP - Yellow Sapphire</name>
 		<type>$</type>
+        <magic></magic>
 		<value>1000gp</value>
 		<weight>0</weight>
 		<text>A transparent fiery yellow or yellow-green gemstone worth 1000 gp.</text>
@@ -435,6 +483,7 @@
 	<item>
 		<name>5000 GP - Black Sapphire</name>
 		<type>$</type>
+        <magic></magic>
 		<value>5000gp</value>
 		<weight>0</weight>
 		<text>A translucent lustrous black with glowing highlights gemstone worth 5000 gp.</text>
@@ -444,6 +493,7 @@
 	<item>
 		<name>5000 GP - Diamond</name>
 		<type>$</type>
+        <magic></magic>
 		<value>5000gp</value>
 		<weight>0</weight>
 		<text>A transparent blue-white, canary, pink, brown, or blue gemstone worth 5000 gp.</text>
@@ -453,6 +503,7 @@
 	<item>
 		<name>5000 GP - Jacinth</name>
 		<type>$</type>
+        <magic></magic>
 		<value>5000gp</value>
 		<weight>0</weight>
 		<text>A transparent fiery orange gemstone worth 5000 gp.</text>
@@ -462,6 +513,7 @@
 	<item>
 		<name>5000 GP - Ruby</name>
 		<type>$</type>
+        <magic></magic>
 		<value>5000gp</value>
 		<weight>0</weight>
 		<text>A transparent clear red to deep crimson gemstone worth 5000 gp.</text>
@@ -471,6 +523,7 @@
 	<item>
 		<name>25 GP - Silver ewer</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -480,6 +533,7 @@
 	<item>
 		<name>25 GP - Carved bone statuette</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -489,6 +543,7 @@
 	<item>
 		<name>25 GP - Small gold bracelet</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -498,6 +553,7 @@
 	<item>
 		<name>25 GP - Cloth-of-gold vestments</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -507,6 +563,7 @@
 	<item>
 		<name>25 GP - Black velvet mask stitched with silver thread</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -516,6 +573,7 @@
 	<item>
 		<name>25 GP - Copper chalice with silver filigree</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -525,6 +583,7 @@
 	<item>
 		<name>25 GP - Pair of engraved bone dice</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -534,6 +593,7 @@
 	<item>
 		<name>25 GP - Small mirror set in a painted wooden frame</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -543,6 +603,7 @@
 	<item>
 		<name>25 GP - Embroidered silk handkerchief</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -552,6 +613,7 @@
 	<item>
 		<name>25 GP - Gold locket with a painted portrait inside</name>
 		<type>$</type>
+        <magic></magic>
 		<value>25gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 25 gp.</text>
@@ -561,6 +623,7 @@
 	<item>
 		<name>250 GP - Gold ring set with bloodstones</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -570,6 +633,7 @@
 	<item>
 		<name>250 GP - Carved ivory statuette</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -579,6 +643,7 @@
 	<item>
 		<name>250 GP - Large gold bracelet</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -588,6 +653,7 @@
 	<item>
 		<name>250 GP - Silver necklace with a gemstone pendant</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -597,6 +663,7 @@
 	<item>
 		<name>250 GP - Bronze crown</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -606,6 +673,7 @@
 	<item>
 		<name>250 GP - Silk robe with gold embroidery</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -615,6 +683,7 @@
 	<item>
 		<name>250 GP - Large well-made tapestry</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -624,6 +693,7 @@
 	<item>
 		<name>250 GP - Brass mug with jade inlay</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -633,6 +703,7 @@
 	<item>
 		<name>250 GP - Box of turquoise animal figurines</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -642,6 +713,7 @@
 	<item>
 		<name>250 GP - Gold bird cage with electrum filigree</name>
 		<type>$</type>
+        <magic></magic>
 		<value>250gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 250 gp.</text>
@@ -651,6 +723,7 @@
 	<item>
 		<name>750 GP - Silver chalice set with moonstones</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -660,6 +733,7 @@
 	<item>
 		<name>750 GP - Silver-plated steel longsword with jet set in hilt</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -669,6 +743,7 @@
 	<item>
 		<name>750 GP - Carved harp of exotic wood with ivory inlay and zircon gems</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -678,6 +753,7 @@
 	<item>
 		<name>750 GP - Small gold idol</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -687,6 +763,7 @@
 	<item>
 		<name>750 GP - Gold dragon comb set with red garnets as eyes</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -696,6 +773,7 @@
 	<item>
 		<name>750 GP - Bottle stopper cork embossed with gold leaf and set with amethysts</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -705,6 +783,7 @@
 	<item>
 		<name>750 GP - Ceremonial electrum dagger with a black pearl in the pommel</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -714,6 +793,7 @@
 	<item>
 		<name>750 GP - Silver and gold brooch</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -723,6 +803,7 @@
 	<item>
 		<name>750 GP - Obsidian statuette with gold fittings and inlay</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -732,6 +813,7 @@
 	<item>
 		<name>750 GP - Painted gold war mask</name>
 		<type>$</type>
+        <magic></magic>
 		<value>750gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 750 gp.</text>
@@ -741,6 +823,7 @@
 	<item>
 		<name>2500 GP - Fine gold chain set with a fire opal</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -750,6 +833,7 @@
 	<item>
 		<name>2500 GP - Old masterpiece painting</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -759,6 +843,7 @@
 	<item>
 		<name>2500 GP - Embroidered silk and velvet mantle set with numerous moonstones</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -768,6 +853,7 @@
 	<item>
 		<name>2500 GP - Platinum bracelet set with a sapphire</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -777,6 +863,7 @@
 	<item>
 		<name>2500 GP - Embroidered glove set with jewel chips</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -786,6 +873,7 @@
 	<item>
 		<name>2500 GP - Jeweled anklet</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -795,6 +883,7 @@
 	<item>
 		<name>2500 GP - Gold music box</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -804,6 +893,7 @@
 	<item>
 		<name>2500 GP - Gold circlet set with four aquamarines</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -813,6 +903,7 @@
 	<item>
 		<name>2500 GP - Eye patch with a mock eye set in blue sapphire and moonstone</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -822,6 +913,7 @@
 	<item>
 		<name>2500 GP - A necklace string of small pink pearls</name>
 		<type>$</type>
+        <magic></magic>
 		<value>2500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 2500 gp.</text>
@@ -831,6 +923,7 @@
 	<item>
 		<name>7500 GP - Jeweled gold crown</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>
@@ -840,6 +933,7 @@
 	<item>
 		<name>7500 GP - Jeweled platinum ring</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>
@@ -849,6 +943,7 @@
 	<item>
 		<name>7500 GP - Small gold statuette set with rubies</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>
@@ -858,6 +953,7 @@
 	<item>
 		<name>7500 GP - Gold cup set with emeralds</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>
@@ -867,6 +963,7 @@
 	<item>
 		<name>7500 GP - Gold jewelry box with platinum filigree</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>
@@ -876,6 +973,7 @@
 	<item>
 		<name>7500 GP - Painted gold child's sarcophagus</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>
@@ -885,6 +983,7 @@
 	<item>
 		<name>7500 GP - Jade game board with solid gold playing pieces</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>
@@ -894,6 +993,7 @@
 	<item>
 		<name>7500 GP - Bejeweled ivory drinking horn with gold filigree</name>
 		<type>$</type>
+        <magic></magic>
 		<value>7500gp</value>
 		<weight>0</weight>
 		<text>This art object is worth 7500 gp.</text>

--- a/Templates.xml
+++ b/Templates.xml
@@ -75,6 +75,7 @@
 <item>
 	<name></name>
 	<type></type>
+	<magic></magic>
 	<weight></weight>
 	<ac></ac>
 	<strength></strength>


### PR DESCRIPTION
Magic tags have been available for a while now, and the core templates in the dropbox folder weren't using them. SO I went through and both added them to all items, as well as updated the magic items with a value of 1 each, to set the flag to true.

The resulting imports are much more nicely sorted into the compendium, placing all magic items in a Magical sub-category of the main, making it a LOT easier to differentiate between mundane and magical versions.

I manually added the 1 tags into the combined compendium, but then gave up after realizing that you probably have a much more nicely automated method for generating those.