### PR TITLE
Fixes bad comment tag oppening in classes xml

### DIFF
--- a/Character/Classes.xml
+++ b/Character/Classes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <compendium version="5">
-   
+
 	<class>
 		<name>Artificer</name>
 		<hd>8</hd>
@@ -89,7 +89,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<name>Alchemical Formula: Healing Draught</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a vial of healing liquid. A creature can drink it as an action to regain 1d8 hit points. The vial then disappears. Once a creature regains hit points from this alchemical formula, the creature can’t do so again until it finishes a long rest. If not used, the vial and its contents disappear after 1 hour. While the vial exists, you can’t use this formula.</text>
 				<text>This formula’s healing increases by 1d8 when you reach certain levels in this class: 3rd level (2d8), 5th level (3d8), 7th level (4d8), 9th level (5d8), 11th level (6d8), 13th level (7d8), 15th level (8d8), 17th level (9d8), and 19th level (10d8).</text>
-			</feature>				
+			</feature>
 			<feature optional="YES">
 				<name>Alchemical Formula: Smoke Stick</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a stick that produces a thick plume of smoke. You can hold on to the stick or throw it to a point up to 30 feet away as part of the action used to produce it. The area in a 10-foot radius around the stick is filled with thick smoke that blocks vision, including darkvision. The stick and smoke persist for 1 minute and then disappear. After using this formula, you can’t do so again for 1 minute.</text>
@@ -122,7 +122,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<text>At 1st level, you craft a leather bag used to carry your tools and ammunition for your Thunder Cannon. Your Arcane Magazine includes the powders, lead shot, and other materials needed to keep that weapon functioning.</text>
 				<text>You can use the Arcane Magazine to produce ammunition for your gun. At the end of each long rest, you can magically produce 40 rounds of ammunition with this magazine. After each short rest, you can produce 10 rounds.</text>
 				<text>If you lose your Arcane Magazine, you can create a new one as part of a long rest, using 25 gp of leather and other raw materials.</text>
-			</feature>		
+			</feature>
 		</autolevel>
 
 		<autolevel level="2">
@@ -259,7 +259,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<name>Alchemical Formula: Healing Draught</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a vial of healing liquid. A creature can drink it as an action to regain 1d8 hit points. The vial then disappears. Once a creature regains hit points from this alchemical formula, the creature can’t do so again until it finishes a long rest. If not used, the vial and its contents disappear after 1 hour. While the vial exists, you can’t use this formula.</text>
 				<text>This formula’s healing increases by 1d8 when you reach certain levels in this class: 3rd level (2d8), 5th level (3d8), 7th level (4d8), 9th level (5d8), 11th level (6d8), 13th level (7d8), 15th level (8d8), 17th level (9d8), and 19th level (10d8).</text>
-			</feature>				
+			</feature>
 			<feature optional="YES">
 				<name>Alchemical Formula: Smoke Stick</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a stick that produces a thick plume of smoke. You can hold on to the stick or throw it to a point up to 30 feet away as part of the action used to produce it. The area in a 10-foot radius around the stick is filled with thick smoke that blocks vision, including darkvision. The stick and smoke persist for 1 minute and then disappear. After using this formula, you can’t do so again for 1 minute.</text>
@@ -308,7 +308,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<name>Alchemical Formula 6 Healing Draught</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a vial of healing liquid. A creature can drink it as an action to regain 1d8 hit points. The vial then disappears. Once a creature regains hit points from this alchemical formula, the creature can’t do so again until it finishes a long rest. If not used, the vial and its contents disappear after 1 hour. While the vial exists, you can’t use this formula.</text>
 				<text>This formula’s healing increases by 1d8 when you reach certain levels in this class: 3rd level (2d8), 5th level (3d8), 7th level (4d8), 9th level (5d8), 11th level (6d8), 13th level (7d8), 15th level (8d8), 17th level (9d8), and 19th level (10d8).</text>
-			</feature>				
+			</feature>
 			<feature optional="YES">
 				<name>Alchemical Formula 6 Smoke Stick</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a stick that produces a thick plume of smoke. You can hold on to the stick or throw it to a point up to 30 feet away as part of the action used to produce it. The area in a 10-foot radius around the stick is filled with thick smoke that blocks vision, including darkvision. The stick and smoke persist for 1 minute and then disappear. After using this formula, you can’t do so again for 1 minute.</text>
@@ -363,7 +363,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<name>Alchemical Formula 7 Healing Draught</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a vial of healing liquid. A creature can drink it as an action to regain 1d8 hit points. The vial then disappears. Once a creature regains hit points from this alchemical formula, the creature can’t do so again until it finishes a long rest. If not used, the vial and its contents disappear after 1 hour. While the vial exists, you can’t use this formula.</text>
 				<text>This formula’s healing increases by 1d8 when you reach certain levels in this class: 3rd level (2d8), 5th level (3d8), 7th level (4d8), 9th level (5d8), 11th level (6d8), 13th level (7d8), 15th level (8d8), 17th level (9d8), and 19th level (10d8).</text>
-			</feature>				
+			</feature>
 			<feature optional="YES">
 				<name>Alchemical Formula 7 Smoke Stick</name>
 				<text>As an action, you can reach into your Alchemist’s Satchel and pull out a stick that produces a thick plume of smoke. You can hold on to the stick or throw it to a point up to 30 feet away as part of the action used to produce it. The area in a 10-foot radius around the stick is filled with thick smoke that blocks vision, including darkvision. The stick and smoke persist for 1 minute and then disappear. After using this formula, you can’t do so again for 1 minute.</text>
@@ -411,10 +411,10 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<name>Soul of Artifice</name>
 				<text>At 20th level, your understanding of magic items is unmatched, allowing you to mingle your soul with items linked to you. You can attune to up to six magic items at once. In addition, you gain a +1 bonus to all saving throws per magic item you are currently attuned to.</text>
 			</feature>
-		</autolevel>	
-		
-		
-		
+		</autolevel>
+
+
+
 	</class>
 
 	<class>
@@ -5415,7 +5415,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<text>When you reach 12th level you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.</text>
 				<text>    If your DM allows the use of feats, you may instead take a feat.</text>
 			</feature>
-		</autolevel>  
+		</autolevel>
 
 		<autolevel level="14">
 			<feature>
@@ -5480,7 +5480,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 				<text>At 20th level, you become an unparalleled hunter of your enemies. Once on each of your turns, you can add your Wisdom modifier to the attack roll or the damage roll of an attack you make against one of your favored enemies. You can choose to use this feature before or after the roll, but before any effects of the roll are applied.</text>
 			</feature>
 		</autolevel>
-< !--Unearthed Arcana-->
+<!--Unearthed Arcana-->
         <autolevel level="2">
             <feature optional="YES">
                 <name>Fighting Style: Close Quarters Shooter</name>
@@ -5940,7 +5940,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
                     <name>Primeval Guardian: Extra Attack</name>
                     <text>Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.</text>
                 </feature>
-            </autolevel>    
+            </autolevel>
             <autolevel level="6">
                 <feature>
                     <name>Greater Favored Enemy</name>
@@ -6525,7 +6525,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
                 <text>Starting at 13th level, you excel at leading ambushes. If any of your foes are surprised, you can use a bonus action on your turn in the first round of the combat to grant each ally who can see you a +5 bonus to initiative that lasts until the combat ends. If the initiative bonus would increase an ally’s initiative above yours, the ally’s initiative instead equals your initiative.</text>
                 <text>  Each of the allies also receives a 10 -foot increase to speed that lasts until the end of the ally’s next turn.</text>
             </feature>
-        </autolevel>    
+        </autolevel>
 
 		<autolevel level="17">
 			<feature optional="YES">


### PR DESCRIPTION
Lince 5483 is the only real change.
The xml comment opening tag in that line had a space between "<" and "!", which corrupted the xml preventing the Fight Club app to correctly parse it.

All other line changes are just trims.