### PR TITLE
Malformed xml

### DIFF
--- a/Items/Magic Items.xml
+++ b/Items/Magic Items.xml
@@ -14471,6 +14471,7 @@
     <name>Spell Gem (Obsidian)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Uncommon</text>
     <text>Attunement Optional</text>
     <text />
     <text>An obsidian spell gem can contain one cantrip from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14485,6 +14486,7 @@
     <name>Spell Gem (Lapis lazuli)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Uncommon</text>
     <text>Attunement Optional</text>
     <text />
     <text>A lapis lazuli spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14499,6 +14501,7 @@
     <name>Spell Gem (Quartz)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Rare</text>
     <text>Attunement Optional</text>
     <text />
     <text>A quartz spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14513,6 +14516,7 @@
     <name>Spell Gem (Bloodstone)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Rare</text>
     <text>Attunement Optional</text>
     <text />
     <text>A bloodstone spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14527,6 +14531,7 @@
     <name>Spell Gem (Amber)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Very Rare</text>
     <text>Attunement Optional</text>
     <text />
     <text>An amber spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14541,6 +14546,7 @@
     <name>Spell Gem (Jade)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Very Rare</text>
     <text>Attunement Optional</text>
     <text />
     <text>A jade spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14555,6 +14561,7 @@
     <name>Spell Gem (Topaz)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Very Rare</text>
     <text>Attunement Optional</text>
     <text />
     <text>A topaz spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14569,6 +14576,7 @@
     <name>Spell Gem (Star ruby)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Legendary</text>
     <text>Attunement Optional</text>
     <text />
     <text>A star ruby spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14583,6 +14591,7 @@
     <name>Spell Gem (Ruby)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Legendary</text>
     <text>Attunement Optional</text>
     <text />
     <text>A ruby spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>
@@ -14597,6 +14606,7 @@
     <name>Spell Gem (Diamond)</name>
     <type>W</type>
     <magic>1</magic>
+    <text>Rarity: Legendary</text>
     <text>Attunement Optional</text>
     <text />
     <text>A diamond spell gem can contain one spell from any class's spell list. You become aware of the spell when you learn the gem's properties. While holding the gem, you can cast the spell from it as an action if you know the spell or if the spell is on your class's spell list. Doing so doesn't require any components, and doesn't require attunement. The spell then disappears from the gem.</text>

--- a/Items/Magic Items.xml
+++ b/Items/Magic Items.xml
@@ -15575,7 +15575,7 @@ items to be within 5 feet of each other. At the end, the pennant is destroyed, a
 		<name>Waythe</name>
 		<type>M</type>
 		<magic>1</magic>
-        <rarity>legendary</rarity></rarit>
+        <rarity>legendary</rarity>
 		<detail>legendary (requires attunement)</detail>
 		<weight>6</weight>
 		<text>Waythe is a unique greatsword most recently in the possession of a high-ranking cloud giant ambassador. </text>

--- a/create_compendiums.py
+++ b/create_compendiums.py
@@ -20,8 +20,15 @@ class XMLCombiner(object):
 
     def __init__(self, filenames):
         assert len(filenames) > 0, 'No filenames!'
-        self.files = [et.parse(f) for f in filenames]
+        self.files = [self.informed_parse(f) for f in filenames]
         self.roots = [f.getroot() for f in self.files]
+
+    def informed_parse(self, filename):
+        try:
+            return et.parse(filename)
+        except:
+            print filename
+            raise
 
     def combine_pruned(self, output):
         """Combine the xml files and sort the items alphabetically


### PR DESCRIPTION
- extended the 'create_compendiums.py' script to echo the filename when a source file is malformed
- fixed `Items/Magic Items.xml` to remove malformed tag
- happened to have `Rarity: ...` text on Spell Gems, so included that

did not include the updated compendiums, wasn't clear to me whether those should be included in a pr