### PR TITLE
fixed 'optional' typo, and elemental attunement components

### DIFF
--- a/Archive/Class.xml
+++ b/Archive/Class.xml
@@ -5401,7 +5401,6 @@
 		<school>EV</school>
 		<time>1 Action</time>
 		<range>Self (60-foot cone)</range>
-		<components>1 Action</components>
 		<duration>Instantaneous</duration>
 		<classes>Monk (Way of the Four Elements)</classes>
 		<text>You can use your action to briefly control elemental forces nearby, causing one of the following effects of your choice.</text>

--- a/Character/Classes.xml
+++ b/Character/Classes.xml
@@ -1749,7 +1749,7 @@
         </autolevel>
         
         <autolevel level="8">
-            <feature optionl="YES">
+            <feature optional="YES">
                 <name>Arcana Domain: Potent Spellcasting</name>
                 <text>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</text>
             </feature>
@@ -3802,7 +3802,6 @@
         <school>EV</school>
         <time>1 Action</time>
         <range>Self (60-foot cone)</range>
-        <components>1 Action</components>
         <duration>Instantaneous</duration>
         <classes>Monk (Way of the Four Elements)</classes>
         <text>You can use your action to briefly control elemental forces nearby, causing one of the following effects of your choice.</text>

--- a/Compendiums/Character Compendium.xml
+++ b/Compendiums/Character Compendium.xml
@@ -2158,7 +2158,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 		</autolevel>
 
 		<autolevel level="8">
-			<feature optionl="YES">
+			<feature optional="YES">
 				<name>Arcana Domain: Potent Spellcasting</name>
 				<text>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</text>
 			</feature>
@@ -3393,7 +3393,6 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 		<school>EV</school>
 		<time>1 Action</time>
 		<range>Self (60-foot cone)</range>
-		<components>1 Action</components>
 		<duration>Instantaneous</duration>
 		<classes>Monk (Way of the Four Elements)</classes>
 		<text>You can use your action to briefly control elemental forces nearby, causing one of the following effects of your choice.</text>

--- a/Compendiums/Full Compendium.xml
+++ b/Compendiums/Full Compendium.xml
@@ -21444,7 +21444,7 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 		</autolevel>
 
 		<autolevel level="8">
-			<feature optionl="YES">
+			<feature optional="YES">
 				<name>Arcana Domain: Potent Spellcasting</name>
 				<text>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</text>
 			</feature>
@@ -22679,7 +22679,6 @@ If an Alchemical Formula option requires a saving throw, the DC is 8 + your prof
 		<school>EV</school>
 		<time>1 Action</time>
 		<range>Self (60-foot cone)</range>
-		<components>1 Action</components>
 		<duration>Instantaneous</duration>
 		<classes>Monk (Way of the Four Elements)</classes>
 		<text>You can use your action to briefly control elemental forces nearby, causing one of the following effects of your choice.</text>


### PR DESCRIPTION
There was an 'optional' typo on one of the class features, and also Elemental Attunement listed '1 Action' as a spell component as well as a time. These have been fixed in this PR.