### PR TITLE
remove duplicate property on ancient black dragon

### DIFF
--- a/Bestiary/Monster Manual Bestiary.xml
+++ b/Bestiary/Monster Manual Bestiary.xml
@@ -1048,10 +1048,6 @@
 			<name>Legendary Resistance (3/Day)</name>
 			<text>If the dragon fails a saving throw, it can choose to succeed instead.</text>
 		</trait>
-		<trait>
-			<name>Legendary Resistance (3/Day)</name>
-			<text>If the dragon fails a saving throw, it can choose to succeed instead.</text>
-		</trait>
 		<action>
 			<name>Multiattack</name>
 			<text>The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.</text>


### PR DESCRIPTION
fixes #287

@ceryliae ancient black dragon had legendary resistance twice

