### PR TITLE
Fixed 'Psionic Inquisition' to 'Psychic Inquisition'

### DIFF
--- a/Character/Classes.xml
+++ b/Character/Classes.xml
@@ -5592,7 +5592,7 @@
         <roll>8d8</roll>
     </spell>
     <spell>
-        <name>Psionic Inquisition (Awakened)</name>
+        <name>Psychic Inquisition (Awakened)</name>
         <level>1</level>
         <time>Varies</time>
         <duration>Varies</duration>


### PR DESCRIPTION
I made a minor edit to the Classes.xml file to correct a typo among the Mystic (UA) disciplines.